### PR TITLE
feat: SpringSecurity, Jwt, Redis 이용한 로그인/로그아웃/토큰 재발급 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,9 +37,11 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	implementation 'javax.xml.bind:jaxb-api:2.3.1'
 
-
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// json
+	implementation 'org.json:json:20160810'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,14 @@ dependencies {
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+	implementation 'javax.xml.bind:jaxb-api:2.3.1'
+
+
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/fithub/fithubbackend/domain/user/api/UserController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/api/UserController.java
@@ -1,18 +1,18 @@
 package com.fithub.fithubbackend.domain.user.api;
 
 import com.fithub.fithubbackend.domain.user.application.UserService;
-import com.fithub.fithubbackend.domain.user.dto.UserDto;
+import com.fithub.fithubbackend.domain.user.dto.SignInDto;
+import com.fithub.fithubbackend.domain.user.dto.SignOutDto;
 import com.fithub.fithubbackend.global.auth.TokenInfoDto;
-import com.fithub.fithubbackend.global.exception.ErrorResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -25,22 +25,45 @@ public class UserController {
     @Operation(summary = "로그인", responses = {
             @ApiResponse(responseCode = "200", description = "로그인 성공"),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 회원"),
-            @ApiResponse(responseCode = "403", description = "로그인 실패")
+            @ApiResponse(responseCode = "403", description = "로그인 실패 - 비밀번호 불일치")
     })
     @PostMapping("/auth/sign-in")
-    public ResponseEntity<TokenInfoDto> signIn(@RequestBody UserDto.SignInDto signInDto) {
-        return ResponseEntity.ok(userService.signIn(signInDto));
+    public ResponseEntity<TokenInfoDto> signIn(@RequestBody SignInDto signInDto, HttpServletResponse response) {
+        return ResponseEntity.ok(userService.signIn(signInDto, response));
     }
 
-    @Operation(summary = "로그아웃 ( accessToken과 email(아이디)는 필수 값 / refreshToken은 \"\"(null)으로 설정 )", responses = {
+    @Operation(summary = "로그아웃", responses = {
             @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
             @ApiResponse(responseCode = "401", description = "검증되지 않는 토큰이거나 만료된 토큰"),
             @ApiResponse(responseCode = "403", description = "로그아웃 실패")
     })
-    @PostMapping("/auth/sign-out")
-    public ResponseEntity signOut(@RequestBody UserDto.SignOutDto signOutDto){
-        userService.signOut(signOutDto);
+    @DeleteMapping("/auth/sign-out")
+    public ResponseEntity signOut(@CookieValue(name = "refreshToken") String cookieRefreshToken,
+                                  @CookieValue(name = "accessToken") String cookieAccessToken,
+                                  @AuthenticationPrincipal UserDetails userDetails, HttpServletResponse response, HttpServletRequest request){
+        SignOutDto signOutDto = SignOutDto.builder()
+                .accessToken(cookieAccessToken)
+                .refreshToken(cookieRefreshToken).build();
+        userService.signOut(signOutDto, userDetails, response, request);
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @Operation(summary = "로그인 테스트 용")
+    @GetMapping("/auth/test")
+    public String test(@AuthenticationPrincipal UserDetails user) {
+        return "인증 후 진입 가능";
+    }
+
+    @Operation(summary = "토큰 재발급", responses = {
+            @ApiResponse(responseCode = "200", description = "토큰 재발급 성공"),
+            @ApiResponse(responseCode = "400", description = "검증되지 않는 토큰"),
+            @ApiResponse(responseCode = "403", description = "토큰 재발급 실패")
+    })
+    @PatchMapping("/auth/reissue")
+    public  ResponseEntity<TokenInfoDto> reissue(@CookieValue(name = "refreshToken") String cookieRefreshToken,
+                                                      @AuthenticationPrincipal UserDetails userDetails,
+                                                      HttpServletRequest request,HttpServletResponse response) {
+        return ResponseEntity.ok(userService.reissue(cookieRefreshToken, request, response));
     }
 
 

--- a/src/main/java/com/fithub/fithubbackend/domain/user/api/UserController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/api/UserController.java
@@ -1,0 +1,47 @@
+package com.fithub.fithubbackend.domain.user.api;
+
+import com.fithub.fithubbackend.domain.user.application.UserService;
+import com.fithub.fithubbackend.domain.user.dto.UserDto;
+import com.fithub.fithubbackend.global.auth.TokenInfoDto;
+import com.fithub.fithubbackend.global.exception.ErrorResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "로그인", responses = {
+            @ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 회원"),
+            @ApiResponse(responseCode = "403", description = "로그인 실패")
+    })
+    @PostMapping("/auth/sign-in")
+    public ResponseEntity<TokenInfoDto> signIn(@RequestBody UserDto.SignInDto signInDto) {
+        return ResponseEntity.ok(userService.signIn(signInDto));
+    }
+
+    @Operation(summary = "로그아웃 ( accessToken과 email(아이디)는 필수 값 / refreshToken은 \"\"(null)으로 설정 )", responses = {
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+            @ApiResponse(responseCode = "401", description = "검증되지 않는 토큰이거나 만료된 토큰"),
+            @ApiResponse(responseCode = "403", description = "로그아웃 실패")
+    })
+    @PostMapping("/auth/sign-out")
+    public ResponseEntity signOut(@RequestBody UserDto.SignOutDto signOutDto){
+        userService.signOut(signOutDto);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/UserDetailsServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/UserDetailsServiceImpl.java
@@ -1,0 +1,29 @@
+package com.fithub.fithubbackend.domain.user.application;
+
+import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return userRepository.findByEmail(email)
+                .map(this::createUserDetails)
+                .orElseThrow(() -> new UsernameNotFoundException("해당하는 유저가 없습니다."));
+    }
+
+    private UserDetails createUserDetails(User user) {
+        return new org.springframework.security.core.userdetails.User(user.getEmail(), user.getPassword(), user.getAuthorities());
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/UserService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/UserService.java
@@ -1,0 +1,12 @@
+package com.fithub.fithubbackend.domain.user.application;
+
+import com.fithub.fithubbackend.domain.user.dto.UserDto;
+import com.fithub.fithubbackend.global.auth.TokenInfoDto;
+import org.springframework.security.core.Authentication;
+
+public interface UserService {
+
+    TokenInfoDto signIn(UserDto.SignInDto signInDto);
+
+    void signOut(UserDto.SignOutDto signOutDto);
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/UserService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/UserService.java
@@ -1,12 +1,17 @@
 package com.fithub.fithubbackend.domain.user.application;
 
-import com.fithub.fithubbackend.domain.user.dto.UserDto;
+import com.fithub.fithubbackend.domain.user.dto.SignInDto;
+import com.fithub.fithubbackend.domain.user.dto.SignOutDto;
 import com.fithub.fithubbackend.global.auth.TokenInfoDto;
-import org.springframework.security.core.Authentication;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.userdetails.UserDetails;
 
 public interface UserService {
 
-    TokenInfoDto signIn(UserDto.SignInDto signInDto);
+    TokenInfoDto signIn(SignInDto signInDto, HttpServletResponse response);
 
-    void signOut(UserDto.SignOutDto signOutDto);
+    void signOut(SignOutDto signOutDto, UserDetails userDetails, HttpServletResponse response, HttpServletRequest request);
+
+    TokenInfoDto reissue(String cookieRefreshToken, HttpServletRequest request, HttpServletResponse response);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/UserServiceImpl.java
@@ -1,0 +1,101 @@
+package com.fithub.fithubbackend.domain.user.application;
+
+import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.domain.user.dto.UserDto;
+import com.fithub.fithubbackend.domain.user.repository.UserRepository;
+import com.fithub.fithubbackend.global.auth.JwtTokenProvider;
+import com.fithub.fithubbackend.global.auth.TokenInfoDto;
+import com.fithub.fithubbackend.global.exception.CustomException;
+import com.fithub.fithubbackend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService, UserDetailsService {
+
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+    private final RedisTemplate redisTemplate;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return userRepository.findByEmail(email)
+                .map(this::createUserDetails)
+                .orElseThrow(() -> new UsernameNotFoundException("해당하는 유저가 없습니다."));
+    }
+
+    private UserDetails createUserDetails(User user) {
+        return new org.springframework.security.core.userdetails.User(user.getEmail(), user.getPassword(), user.getAuthorities());
+    }
+
+    @Transactional
+    @Override
+    public TokenInfoDto signIn(UserDto.SignInDto signInDto) {
+
+        if (userRepository.findByEmail(signInDto.getEmail()).isEmpty())
+            throw new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 회원");
+
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(signInDto.getEmail(), signInDto.getPassword());
+
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+
+        TokenInfoDto tokenInfoDto = jwtTokenProvider.createToken(authentication);
+
+        // Redis에 Key(이메일):Value(refreshToken) 저장
+        redisTemplate.opsForValue()
+                .set(authentication.getName(), tokenInfoDto.getRefreshToken(),
+                        tokenInfoDto.getRefreshTokenExpirationTime(), TimeUnit.MILLISECONDS);
+
+        return tokenInfoDto;
+    }
+
+    @Transactional
+    @Override
+    public void signOut(UserDto.SignOutDto signOutDto) {
+
+        String refreshToken = (String) redisTemplate.opsForValue().get(signOutDto.getEmail());
+        signOutDto.setRefreshToken(refreshToken);
+
+        boolean validateToken = false;
+
+        try {
+            validateToken = jwtTokenProvider.validateToken(signOutDto.getAccessToken());
+            if (!validateToken) {
+                redisTemplate.delete(signOutDto.getEmail());
+                throw new CustomException(ErrorCode.FAIL_AUTHENTICATION);
+            }
+        } catch (Exception e) {
+            redisTemplate.delete(signOutDto.getEmail());
+            throw new CustomException(ErrorCode.TOKEN_EXPIRED);
+        }
+
+        Authentication authentication = jwtTokenProvider.getAuthentication(signOutDto.getAccessToken());
+
+        if (redisTemplate.opsForValue().get(authentication.getName()) != null) {
+            redisTemplate.delete(authentication.getName());
+        }
+
+        if (validateToken) {
+            Long expiration = jwtTokenProvider.getExpiration(signOutDto.getAccessToken());
+            redisTemplate.opsForValue()
+                    .set(signOutDto.getAccessToken(), "logout", expiration, TimeUnit.MILLISECONDS);
+        }
+
+    }
+
+
+}
+

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/UserServiceImpl.java
@@ -71,10 +71,10 @@ public class UserServiceImpl implements UserService {
         try {
             validateToken = jwtTokenProvider.validateToken(signOutDto.getAccessToken());
             if (!validateToken) {
-                throw new CustomException(ErrorCode.FAIL_AUTHENTICATION);
+                throw new CustomException(ErrorCode.INVALID_TOKEN);
             }
         } catch (Exception e) {
-            throw new CustomException(ErrorCode.TOKEN_EXPIRED);
+            throw new CustomException(ErrorCode.EXPIRED_TOKEN);
         }
 
         Authentication authentication = jwtTokenProvider.getAuthentication(signOutDto.getAccessToken());
@@ -111,7 +111,7 @@ public class UserServiceImpl implements UserService {
         String refreshToken = redisUtil.getData(authentication.getName());
 
         if(ObjectUtils.isEmpty(refreshToken)) {
-            throw new CustomException(ErrorCode.TOKEN_NULL);
+            throw new CustomException(ErrorCode.UNKNOWN_ERROR);
         }
 
         if(!refreshToken.equals(cookieRefreshToken)) {

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/UserServiceImpl.java
@@ -1,49 +1,40 @@
 package com.fithub.fithubbackend.domain.user.application;
 
-import com.fithub.fithubbackend.domain.user.domain.User;
-import com.fithub.fithubbackend.domain.user.dto.UserDto;
+import com.fithub.fithubbackend.domain.user.dto.SignInDto;
+import com.fithub.fithubbackend.domain.user.dto.SignOutDto;
 import com.fithub.fithubbackend.domain.user.repository.UserRepository;
 import com.fithub.fithubbackend.global.auth.JwtTokenProvider;
 import com.fithub.fithubbackend.global.auth.TokenInfoDto;
 import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
+import com.fithub.fithubbackend.global.util.CookieUtil;
+import com.fithub.fithubbackend.global.util.HeaderUtil;
+import com.fithub.fithubbackend.global.util.RedisUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.concurrent.TimeUnit;
+import org.springframework.util.ObjectUtils;
 
 @Service
 @RequiredArgsConstructor
-public class UserServiceImpl implements UserService, UserDetailsService {
+public class UserServiceImpl implements UserService {
 
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
-    private final RedisTemplate redisTemplate;
-
-    @Override
-    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        return userRepository.findByEmail(email)
-                .map(this::createUserDetails)
-                .orElseThrow(() -> new UsernameNotFoundException("해당하는 유저가 없습니다."));
-    }
-
-    private UserDetails createUserDetails(User user) {
-        return new org.springframework.security.core.userdetails.User(user.getEmail(), user.getPassword(), user.getAuthorities());
-    }
+    private final RedisUtil redisUtil;
+    private final CookieUtil cookieUtil;
+    private final HeaderUtil headerUtil;
 
     @Transactional
     @Override
-    public TokenInfoDto signIn(UserDto.SignInDto signInDto) {
+    public TokenInfoDto signIn(SignInDto signInDto, HttpServletResponse response) {
 
         if (userRepository.findByEmail(signInDto.getEmail()).isEmpty())
             throw new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 회원");
@@ -54,19 +45,23 @@ public class UserServiceImpl implements UserService, UserDetailsService {
 
         TokenInfoDto tokenInfoDto = jwtTokenProvider.createToken(authentication);
 
+        // refreshToken, accessToken 쿠키에 저장
+        cookieUtil.addRefreshTokenCookie(response, tokenInfoDto);
+        cookieUtil.addAccessTokenCookie(response, tokenInfoDto);
+
         // Redis에 Key(이메일):Value(refreshToken) 저장
-        redisTemplate.opsForValue()
-                .set(authentication.getName(), tokenInfoDto.getRefreshToken(),
-                        tokenInfoDto.getRefreshTokenExpirationTime(), TimeUnit.MILLISECONDS);
+        redisUtil.setData(authentication.getName(), tokenInfoDto.getRefreshToken(), tokenInfoDto.getRefreshTokenExpirationTime());
 
         return tokenInfoDto;
     }
 
     @Transactional
     @Override
-    public void signOut(UserDto.SignOutDto signOutDto) {
+    public void signOut(SignOutDto signOutDto, UserDetails userDetails,
+                        HttpServletResponse response, HttpServletRequest request) {
 
-        String refreshToken = (String) redisTemplate.opsForValue().get(signOutDto.getEmail());
+        signOutDto.setEmail(userDetails.getUsername());
+        String refreshToken = redisUtil.getData(signOutDto.getEmail());
         signOutDto.setRefreshToken(refreshToken);
 
         boolean validateToken = false;
@@ -74,28 +69,65 @@ public class UserServiceImpl implements UserService, UserDetailsService {
         try {
             validateToken = jwtTokenProvider.validateToken(signOutDto.getAccessToken());
             if (!validateToken) {
-                redisTemplate.delete(signOutDto.getEmail());
                 throw new CustomException(ErrorCode.FAIL_AUTHENTICATION);
             }
         } catch (Exception e) {
-            redisTemplate.delete(signOutDto.getEmail());
             throw new CustomException(ErrorCode.TOKEN_EXPIRED);
         }
 
         Authentication authentication = jwtTokenProvider.getAuthentication(signOutDto.getAccessToken());
 
-        if (redisTemplate.opsForValue().get(authentication.getName()) != null) {
-            redisTemplate.delete(authentication.getName());
+        if (redisUtil.getData(authentication.getName()) != null) {
+            redisUtil.deleteData(signOutDto.getEmail());
         }
 
         if (validateToken) {
             Long expiration = jwtTokenProvider.getExpiration(signOutDto.getAccessToken());
-            redisTemplate.opsForValue()
-                    .set(signOutDto.getAccessToken(), "logout", expiration, TimeUnit.MILLISECONDS);
+            redisUtil.setData(signOutDto.getAccessToken(), "logout", expiration);
         }
+
+        cookieUtil.deleteRefreshTokenCookie(request, response);
+        cookieUtil.deleteAccessTokenCookie(request, response);
 
     }
 
+    @Transactional
+    @Override
+    public TokenInfoDto reissue(String cookieRefreshToken, HttpServletRequest request, HttpServletResponse response) {
+
+        // 1. Request Header 에서 Access Token 추출
+        String accessToken = headerUtil.resolveToken(request);
+
+        // 2. Refresh Token 검증
+        if (!jwtTokenProvider.validateToken(cookieRefreshToken)) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN, "Refresh Token 정보가 유효하지 않습니다.");
+        }
+
+        // 3. Access Token 에서 User email 추출
+        Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+
+        // 4. Redis 에서 User email 을 기반으로 저장된 Refresh Token 추출
+        String refreshToken = redisUtil.getData(authentication.getName());
+
+        if(ObjectUtils.isEmpty(refreshToken)) {
+            throw new CustomException(ErrorCode.TOKEN_NULL);
+        }
+
+        if(!refreshToken.equals(cookieRefreshToken)) {
+            throw  new CustomException(ErrorCode.TOKEN_NOT_EQUALS);
+        }
+
+        // 5. 새로운 토큰 생성
+        TokenInfoDto tokenInfoDto = jwtTokenProvider.createToken(authentication);
+
+        // 6. RefreshToken Redis 업데이트
+        redisUtil.setData(authentication.getName(), tokenInfoDto.getRefreshToken(), tokenInfoDto.getRefreshTokenExpirationTime());
+
+        // 7. Cookie 업데이트
+        cookieUtil.updateCookie(request, response, tokenInfoDto);
+
+        return tokenInfoDto;
+    };
 
 }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/user/domain/User.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/domain/User.java
@@ -1,19 +1,27 @@
 package com.fithub.fithubbackend.domain.user.domain;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fithub.fithubbackend.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User extends BaseTimeEntity {
+public class User extends BaseTimeEntity implements UserDetails {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,6 +29,8 @@ public class User extends BaseTimeEntity {
 
     @Column(unique = true)
     private String userId;
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private String password;
 
     @NotNull
@@ -55,4 +65,41 @@ public class User extends BaseTimeEntity {
 
     @ElementCollection
     private List<String> roles = new ArrayList<>();
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return this.roles.stream()
+                .map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+    }
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @Override
+    public String getUsername() {
+        return this.email;
+    }
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/dto/SignInDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/dto/SignInDto.java
@@ -1,0 +1,17 @@
+package com.fithub.fithubbackend.domain.user.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Data
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class SignInDto {
+
+    @NotNull
+    private String email;
+
+    @NotNull
+    private String password;
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/user/dto/SignOutDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/dto/SignOutDto.java
@@ -1,0 +1,23 @@
+package com.fithub.fithubbackend.domain.user.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class SignOutDto {
+
+    @NotNull
+    private String accessToken;
+
+    private String email;
+
+    private String refreshToken;
+
+    @Builder
+    public SignOutDto (String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/user/dto/UserDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/dto/UserDto.java
@@ -1,4 +1,31 @@
 package com.fithub.fithubbackend.domain.user.dto;
 
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
 public class UserDto {
+
+    @Data
+    public static class SignInDto {
+
+        @NotNull
+        private String email;
+
+        @NotNull
+        private String password;
+    }
+
+    @Data
+    public static class SignOutDto {
+
+        @NotNull
+        private String accessToken;
+
+        private String email;
+
+        private String refreshToken;
+    }
+
+
+
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/dto/UserDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/dto/UserDto.java
@@ -1,31 +1,11 @@
 package com.fithub.fithubbackend.domain.user.dto;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 public class UserDto {
-
-    @Data
-    public static class SignInDto {
-
-        @NotNull
-        private String email;
-
-        @NotNull
-        private String password;
-    }
-
-    @Data
-    public static class SignOutDto {
-
-        @NotNull
-        private String accessToken;
-
-        private String email;
-
-        private String refreshToken;
-    }
-
-
 
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.fithub.fithubbackend.domain.user.repository;
+
+import com.fithub.fithubbackend.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,54 @@
+package com.fithub.fithubbackend.global.auth;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends GenericFilterBean {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_TYPE = "Bearer";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    private RedisTemplate redisTemplate;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+
+        String token = resolveToken((HttpServletRequest) request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+
+            String isLogout = (String)redisTemplate.opsForValue().get(token);
+            if (ObjectUtils.isEmpty(isLogout)) {
+                Authentication authentication = jwtTokenProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_TYPE)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}
+

--- a/src/main/java/com/fithub/fithubbackend/global/auth/JwtExceptionFilter.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/JwtExceptionFilter.java
@@ -1,0 +1,77 @@
+package com.fithub.fithubbackend.global.auth;
+
+import com.fithub.fithubbackend.global.exception.ErrorCode;
+import com.fithub.fithubbackend.global.util.CookieUtil;
+import com.fithub.fithubbackend.global.util.HeaderUtil;
+import io.jsonwebtoken.*;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final HeaderUtil headerUtil;
+    private final CookieUtil cookieUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        response.setCharacterEncoding("utf-8");
+
+        try {
+            filterChain.doFilter(request, response);    // JwtAuthenticationFilter로 이동
+        } catch (JwtException e) {
+            String errorMsg = e.getMessage();
+
+            if (errorMsg.equals(ErrorCode.UNKNOWN_ERROR.getMessage())) {
+                setResponse(response, ErrorCode.UNKNOWN_ERROR);
+            } else if (errorMsg.equals(ErrorCode.EXPIRED_TOKEN.getMessage())) {     // 토큰 만료 시
+                try {
+                    String refreshToken = headerUtil.resolveRefreshToken(request);
+
+                    if (refreshToken != null && jwtTokenProvider.validateToken(refreshToken) && jwtTokenProvider.existsRefreshToken(refreshToken)) {
+                        Authentication authentication = jwtTokenProvider.getAuthentication(refreshToken);
+                        String accessToken = jwtTokenProvider.createAccessToken(authentication);
+
+                        SecurityContextHolder.getContext().setAuthentication(authentication);
+                        cookieUtil.addAccessTokenCookie(response, accessToken);
+                        log.info("액세스 토큰 재발급 성공");
+                    } else {
+                        setResponse(response, ErrorCode.EXPIRED_REFRESH_TOKEN);
+                    }
+                } catch (ExpiredJwtException expiredJwtException) {     // Refresh Token 만료 시
+                    setResponse(response, ErrorCode.EXPIRED_REFRESH_TOKEN);
+                }
+            } else if (errorMsg.equals(ErrorCode.WRONG_TYPE_TOKEN.getMessage())) {
+                setResponse(response, ErrorCode.WRONG_TYPE_TOKEN);
+            } else if (errorMsg.equals(ErrorCode.UNSUPPORTED_TOKEN.getMessage())) {
+                setResponse(response, ErrorCode.UNSUPPORTED_TOKEN);
+            }
+        }
+    }
+
+    private void setResponse(HttpServletResponse response, ErrorCode code) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(code.getHttpStatus().value());
+
+        JSONObject responseJson = new JSONObject();
+        responseJson.put("message", code.getMessage());
+        responseJson.put("httpStatus", code.getHttpStatus());
+
+        response.getWriter().print(responseJson);
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/global/auth/JwtTokenProvider.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/JwtTokenProvider.java
@@ -1,0 +1,123 @@
+package com.fithub.fithubbackend.global.auth;
+
+import com.fithub.fithubbackend.global.exception.CustomException;
+import com.fithub.fithubbackend.global.exception.ErrorCode;
+import io.jsonwebtoken.*;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Component
+@Slf4j
+public class JwtTokenProvider {
+
+
+    @Value("${jwt.secret-key}")
+    private String secretKey;
+
+    private static final String AUTHORITIES_KEY = "auth";
+    private static final String BEARER_TYPE = "Bearer";
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 30 * 60 * 1000L;              // 30분
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 7 * 24 * 60 * 60 * 1000L;    // 7일
+
+
+    @PostConstruct
+    protected void init(){
+        secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
+    }
+
+    public TokenInfoDto createToken(Authentication authentication) {
+
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        Date now = new Date();
+
+        Date accessTokenExpiresIn = new Date(now.getTime() + ACCESS_TOKEN_EXPIRE_TIME);
+        String accessToken = Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim(AUTHORITIES_KEY, authorities)
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+
+
+        String refreshToken = Jwts.builder()
+                .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_EXPIRE_TIME))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+
+        return TokenInfoDto.builder()
+                .grantType(BEARER_TYPE)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .refreshTokenExpirationTime(REFRESH_TOKEN_EXPIRE_TIME)
+                .build();
+    }
+
+    public Authentication getAuthentication(String accessToken) {
+
+        Claims claims = parseClaims(accessToken);
+
+        if (claims.get(AUTHORITIES_KEY) == null) {
+            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+        }
+
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    public boolean validateToken(String token) throws JwtException {
+        try {
+            Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {     // 유효하지 않는 구성의 JWT 토큰
+            log.info("Invalid JWT Token", e);
+        } catch (ExpiredJwtException e) {   // 만료된 JWT 토큰
+            log.info("Expired JWT Token", e);
+            throw new JwtException("만료된 토큰");
+        } catch (UnsupportedJwtException e) {   // 지원되지 않는 형식이거나 구성의 JWT 토큰
+            log.info("Unsupported JWT Token", e);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims string is empty.", e);
+        }
+        return false;
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(accessToken).getBody();
+        } catch (ExpiredJwtException e) {   // accessToken 만료된 경우
+            return e.getClaims();
+        } catch (JwtException e) {      // accessToken 변조된 경우
+             return null;      // TODO 변조된 경우 반환 타입 변환
+        }
+    }
+
+    public Long getExpiration(String accessToken) {
+        Date expiration = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(accessToken).getBody().getExpiration();
+        Long now = new Date().getTime();
+        System.out.printf(String.valueOf(expiration.getTime() - now));
+        return (expiration.getTime() - now);
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/global/auth/TokenInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/TokenInfoDto.java
@@ -1,0 +1,26 @@
+package com.fithub.fithubbackend.global.auth;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TokenInfoDto {
+
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+    private Long refreshTokenExpirationTime;
+
+    @Builder
+    public TokenInfoDto(String grantType, String accessToken, String refreshToken, Long refreshTokenExpirationTime){
+        this.grantType = grantType;
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.refreshTokenExpirationTime = refreshTokenExpirationTime;
+    }
+
+
+}

--- a/src/main/java/com/fithub/fithubbackend/global/config/RedisConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/RedisConfig.java
@@ -1,0 +1,34 @@
+package com.fithub.fithubbackend.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+
+}

--- a/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.fithub.fithubbackend.global.config;
 
 import com.fithub.fithubbackend.global.auth.JwtAuthenticationFilter;
 import com.fithub.fithubbackend.global.auth.JwtTokenProvider;
+import com.fithub.fithubbackend.global.util.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -28,6 +29,7 @@ public class SecurityConfig {
 
     // 토큰 프로바이더 추가
     private final JwtTokenProvider jwtTokenProvider;
+    private final RedisUtil redisUtil;
 
     // TODO: 로그인, 회원가입 패턴으로 수정
     private static final String[] PERMIT_ALL_PATTERNS = new String[] {
@@ -45,7 +47,7 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
 
                 // jwtFilter 추가
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, redisUtil), UsernamePasswordAuthenticationFilter.class)
 
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(requests -> requests

--- a/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
@@ -1,13 +1,15 @@
 package com.fithub.fithubbackend.global.config;
 
 import com.fithub.fithubbackend.global.auth.JwtAuthenticationFilter;
+import com.fithub.fithubbackend.global.auth.JwtExceptionFilter;
 import com.fithub.fithubbackend.global.auth.JwtTokenProvider;
+import com.fithub.fithubbackend.global.util.CookieUtil;
+import com.fithub.fithubbackend.global.util.HeaderUtil;
 import com.fithub.fithubbackend.global.util.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -30,6 +32,8 @@ public class SecurityConfig {
     // 토큰 프로바이더 추가
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisUtil redisUtil;
+    private final HeaderUtil headerUtil;
+    private final CookieUtil cookieUtil;
 
     // TODO: 로그인, 회원가입 패턴으로 수정
     private static final String[] PERMIT_ALL_PATTERNS = new String[] {
@@ -48,6 +52,7 @@ public class SecurityConfig {
 
                 // jwtFilter 추가
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, redisUtil), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtExceptionFilter(jwtTokenProvider, headerUtil, cookieUtil),JwtAuthenticationFilter.class)
 
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(requests -> requests

--- a/src/main/java/com/fithub/fithubbackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/fithub/fithubbackend/global/exception/ErrorCode.java
@@ -11,9 +11,7 @@ public enum ErrorCode {
     NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 데이터입니다."),
     INVALID_DATE(HttpStatus.CONFLICT, "유효하지 않은 날짜입니다."),
     UNCORRECTABLE_DATA(HttpStatus.CONFLICT, "현재 수정할 수 없는 데이터입니다."),
-    FAIL_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "검증되지 않는 토큰입니다."),
-    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
-    TOKEN_NULL(HttpStatus.BAD_REQUEST, "NULL인 토큰입니다."),
+
     TOKEN_NOT_EQUALS(HttpStatus.BAD_REQUEST, "토큰이 일치하지 않습니다."),
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "검증되지 않는 토큰입니다."),
 

--- a/src/main/java/com/fithub/fithubbackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/fithub/fithubbackend/global/exception/ErrorCode.java
@@ -15,7 +15,14 @@ public enum ErrorCode {
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     TOKEN_NULL(HttpStatus.BAD_REQUEST, "NULL인 토큰입니다."),
     TOKEN_NOT_EQUALS(HttpStatus.BAD_REQUEST, "토큰이 일치하지 않습니다."),
-    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "검증되지 않는 토큰입니다.");
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "검증되지 않는 토큰입니다."),
+
+    // TODO JWT 토큰 관련 ERROR CODE 수정 필요
+    UNKNOWN_ERROR(HttpStatus.valueOf(400), "토큰이 존재하지 않습니다."),
+    WRONG_TYPE_TOKEN(HttpStatus.valueOf(401), "잘못된 타입의 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.valueOf(402), "만료된 토큰입니다."),
+    UNSUPPORTED_TOKEN(HttpStatus.valueOf(403), "지원되지 않는 토큰입니다."),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.valueOf(405), "재로그인 필요");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fithub/fithubbackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/fithub/fithubbackend/global/exception/ErrorCode.java
@@ -10,7 +10,9 @@ public enum ErrorCode {
 
     NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 데이터입니다."),
     INVALID_DATE(HttpStatus.CONFLICT, "유효하지 않은 날짜입니다."),
-    UNCORRECTABLE_DATA(HttpStatus.CONFLICT, "현재 수정할 수 없는 데이터입니다.");
+    UNCORRECTABLE_DATA(HttpStatus.CONFLICT, "현재 수정할 수 없는 데이터입니다."),
+    FAIL_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "검증되지 않는 토큰입니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fithub/fithubbackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/fithub/fithubbackend/global/exception/ErrorCode.java
@@ -12,7 +12,10 @@ public enum ErrorCode {
     INVALID_DATE(HttpStatus.CONFLICT, "유효하지 않은 날짜입니다."),
     UNCORRECTABLE_DATA(HttpStatus.CONFLICT, "현재 수정할 수 없는 데이터입니다."),
     FAIL_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "검증되지 않는 토큰입니다."),
-    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다.");
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+    TOKEN_NULL(HttpStatus.BAD_REQUEST, "NULL인 토큰입니다."),
+    TOKEN_NOT_EQUALS(HttpStatus.BAD_REQUEST, "토큰이 일치하지 않습니다."),
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "검증되지 않는 토큰입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fithub/fithubbackend/global/util/CookieUtil.java
+++ b/src/main/java/com/fithub/fithubbackend/global/util/CookieUtil.java
@@ -1,0 +1,139 @@
+package com.fithub.fithubbackend.global.util;
+
+import com.fithub.fithubbackend.global.auth.TokenInfoDto;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NoArgsConstructor;
+import org.springframework.context.annotation.Description;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+@Service
+@NoArgsConstructor
+public class CookieUtil {
+
+    private Cookie[] cookies;
+    private Cookie cookie;
+
+    public CookieUtil(HttpServletRequest request) {
+        this.cookies = request.getCookies();
+    }
+
+    public String getValue(String name) {
+
+        for(int i = 0; i < this.cookies.length; i++) {
+            if(cookies[i].getName().equals(name)) {
+                return cookies[i].getValue();
+            }
+        }
+        return null;
+    }
+
+    @Description("refresh Token 쿠키 생성")
+    public HttpServletResponse addRefreshTokenCookie(HttpServletResponse response, TokenInfoDto tokenInfoDto) {
+
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", tokenInfoDto.getRefreshToken())
+                .maxAge(tokenInfoDto.getRefreshTokenExpirationTime())
+                .path("/")
+                .sameSite("None")
+                .httpOnly(true)
+//                .secure(true)  //    HTTPS 프로토콜에서만 쿠키 전송 가능
+                .build();
+        response.addHeader("Set-Cookie", cookie.toString());
+        return response;
+    }
+
+    @Description("access Token 쿠키 생성")
+    public HttpServletResponse addAccessTokenCookie(HttpServletResponse response, TokenInfoDto tokenInfoDto) {
+
+
+        ResponseCookie cookie = ResponseCookie.from("accessToken", tokenInfoDto.getAccessToken())
+                .maxAge(1800)
+                .path("/")
+                .sameSite("None")
+                .httpOnly(true)
+//                .secure(true)  //    HTTPS 프로토콜에서만 쿠키 전송 가능
+                .build();
+        response.addHeader("Set-Cookie", cookie.toString());
+        return response;
+    }
+
+    @Description("refresh token 쿠키 삭제")
+    public void deleteRefreshTokenCookie(HttpServletRequest request, HttpServletResponse response) {
+        Optional<Cookie> refreshTokenCookie = Arrays
+                .stream(request.getCookies())
+                .filter(cookie -> cookie.getName().equals("refreshToken")).findFirst();
+
+        if (refreshTokenCookie.isPresent()) {
+            refreshTokenCookie.get().setMaxAge(0);
+            refreshTokenCookie.get().setValue("");
+            response.addCookie(refreshTokenCookie.get());
+        }
+
+    }
+
+    @Description("access token 쿠키 삭제")
+    public void deleteAccessTokenCookie(HttpServletRequest request, HttpServletResponse response) {
+        Optional<Cookie> refreshTokenCookie = Arrays
+                .stream(request.getCookies())
+                .filter(cookie -> cookie.getName().equals("accessToken")).findFirst();
+
+        if (refreshTokenCookie.isPresent()) {
+            refreshTokenCookie.get().setMaxAge(0);
+            refreshTokenCookie.get().setValue("");
+            response.addCookie(refreshTokenCookie.get());
+        }
+
+    }
+
+    @Description("쿠키 업데이트")
+    public void updateCookie(HttpServletRequest request, HttpServletResponse response, TokenInfoDto tokenInfoDto) {
+        Optional<Cookie> refreshTokenCookie = Arrays
+                .stream(request.getCookies())
+                .filter(cookie -> cookie.getName().equals("refreshToken")).findFirst();
+
+        Optional<Cookie> accessTokenCookie = Arrays
+                .stream(request.getCookies())
+                .filter(cookie -> cookie.getName().equals("accessToken")).findFirst();
+
+        if (refreshTokenCookie.isPresent()) {
+            refreshTokenCookie.get().setMaxAge(Math.toIntExact(tokenInfoDto.getRefreshTokenExpirationTime()));
+            refreshTokenCookie.get().setValue(tokenInfoDto.getRefreshToken());
+            refreshTokenCookie.get().setPath("/");
+            refreshTokenCookie.get().setHttpOnly(true);
+            response.addCookie(refreshTokenCookie.get());
+        }
+
+        if (accessTokenCookie.isPresent()) {
+            accessTokenCookie.get().setMaxAge(1800);
+            accessTokenCookie.get().setValue(tokenInfoDto.getAccessToken());
+            accessTokenCookie.get().setPath("/");
+            accessTokenCookie.get().setHttpOnly(true);
+            response.addCookie(accessTokenCookie.get());
+        }
+
+    }
+
+    public CookieUtil addCookie(String key, String value) {
+        this.cookie = new Cookie(key, value);
+        return this;
+    }
+
+    public CookieUtil setExpire(int period) {
+        this.cookie.setMaxAge(period);
+        return this;
+    }
+
+    public CookieUtil setHttpOnly(boolean setHttpOnly) {
+        this.cookie.setHttpOnly(setHttpOnly);
+        return this;
+    }
+
+    public Cookie build() {
+        return this.cookie;
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/global/util/CookieUtil.java
+++ b/src/main/java/com/fithub/fithubbackend/global/util/CookieUtil.java
@@ -48,11 +48,10 @@ public class CookieUtil {
     }
 
     @Description("access Token 쿠키 생성")
-    public HttpServletResponse addAccessTokenCookie(HttpServletResponse response, TokenInfoDto tokenInfoDto) {
+    public HttpServletResponse addAccessTokenCookie(HttpServletResponse response, String accessToken) {
 
-
-        ResponseCookie cookie = ResponseCookie.from("accessToken", tokenInfoDto.getAccessToken())
-                .maxAge(1800)
+        ResponseCookie cookie = ResponseCookie.from("accessToken", accessToken)
+//                .maxAge(1800)
                 .path("/")
                 .sameSite("None")
                 .httpOnly(true)
@@ -70,10 +69,8 @@ public class CookieUtil {
 
         if (refreshTokenCookie.isPresent()) {
             refreshTokenCookie.get().setMaxAge(0);
-            refreshTokenCookie.get().setValue("");
             response.addCookie(refreshTokenCookie.get());
         }
-
     }
 
     @Description("access token 쿠키 삭제")
@@ -109,7 +106,7 @@ public class CookieUtil {
         }
 
         if (accessTokenCookie.isPresent()) {
-            accessTokenCookie.get().setMaxAge(1800);
+//            accessTokenCookie.get().setMaxAge(1800);
             accessTokenCookie.get().setValue(tokenInfoDto.getAccessToken());
             accessTokenCookie.get().setPath("/");
             accessTokenCookie.get().setHttpOnly(true);

--- a/src/main/java/com/fithub/fithubbackend/global/util/HeaderUtil.java
+++ b/src/main/java/com/fithub/fithubbackend/global/util/HeaderUtil.java
@@ -2,20 +2,33 @@ package com.fithub.fithubbackend.global.util;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 
 @Service
 public class HeaderUtil {
 
     public static final String ACCESS_TOKEN_COOKIE = "accessToken";
-    public String resolveToken(HttpServletRequest request) {
+
+    public static final String REFRESH_TOKEN_COOKIE = "refreshToken";
+
+
+    public String resolveAccessToken(HttpServletRequest request) {
 
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
             for (Cookie cookie : cookies)
                 if (ACCESS_TOKEN_COOKIE.equals(cookie.getName()))
+                    return cookie.getValue();
+        }
+        return null;
+    }
+
+    public String resolveRefreshToken(HttpServletRequest request) {
+
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies)
+                if (REFRESH_TOKEN_COOKIE.equals(cookie.getName()))
                     return cookie.getValue();
         }
         return null;

--- a/src/main/java/com/fithub/fithubbackend/global/util/HeaderUtil.java
+++ b/src/main/java/com/fithub/fithubbackend/global/util/HeaderUtil.java
@@ -1,0 +1,24 @@
+package com.fithub.fithubbackend.global.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+public class HeaderUtil {
+
+    public static final String ACCESS_TOKEN_COOKIE = "accessToken";
+    public String resolveToken(HttpServletRequest request) {
+
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies)
+                if (ACCESS_TOKEN_COOKIE.equals(cookie.getName()))
+                    return cookie.getValue();
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/fithub/fithubbackend/global/util/RedisUtil.java
+++ b/src/main/java/com/fithub/fithubbackend/global/util/RedisUtil.java
@@ -1,0 +1,26 @@
+package com.fithub.fithubbackend.global.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class RedisUtil {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void setData(String key, String value, Long expiredTime){
+        redisTemplate.opsForValue().set(key, value, expiredTime, TimeUnit.MILLISECONDS);
+    }
+
+    public String getData(String key){
+        return (String) redisTemplate.opsForValue().get(key);
+    }
+
+    public void deleteData(String key){
+        redisTemplate.delete(key);
+    }
+}


### PR DESCRIPTION
## PR 유형
- 기능 추가

## 반영 브랜치
- feature/auth -> main

## 변경 사항
- Spring Security, Jwt, Redis 이용한 로그인/로그아웃/토큰 재발급 기능 추가

## 테스트 결과

### 로그인 

> POST /user/auth/sign-in

1. RequestBody로 이메일, 비밀번호를 전달 받음.
`{
    "email": "test@test.com",
    "password": "testtest"
}`

2. 로그인 성공 시, TokenInfoDto 전달 및 쿠키에 저장 **(HTTP Status Code : 200)**
   - accessToken 유효 기간 : 30분 / refreshToken 유효 기간 : 7일
![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/f649144d-97d6-444b-a7a1-e909b4f42ccc)

3. 로그인 실패 시
   - 아이디가 DB에 없을 경우 **(HTTP Status Code : 404)**
   - 비밀번호가 틀린 경우 **(HTTP Status Code : 403)**

3. Redis에 키(email), 값(refreshToken)으로 저장.
![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/b0bd8817-1460-4ce1-8fcd-e086058c61dd)

<hr>

### 로그아웃 
> DELETE /user/auth/sign-out
1. 로그아웃 성공 시 **(HTTP Status Code : 200)** 
2. 실패 시  **(HTTP Status Code : 403)** 

<hr>

### 토큰 재발급
> PATCH /user/auth/reissue
1. 재발급 성공 시 TokenInfoDto 전달 **(HTTP Status Code : 200)** 
2. 실패 시  **(HTTP Status Code : 403)** 

<hr>

### accessToken 유효 기간 만료 O & refreshToken 유효 기간 만료 X 인 경우
- refreshToken 유효 기간 동안 자동 로그인 실행

## 추가 변경 사항
- application.yml에 redis, jwt 관련 환경 변수 추가 ( Notion 백엔드 -> 파일에 업로드 )