### PR TITLE
feat: 구글 소셜 로그인 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/user/domain/User.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/domain/User.java
@@ -60,7 +60,7 @@ public class User extends BaseTimeEntity implements UserDetails {
 
     private String bio;
 
-    @OneToOne(optional = false, cascade = CascadeType.PERSIST)
+    @OneToOne(cascade = CascadeType.PERSIST)
     @JoinColumn(name = "document_id")
     private Document profileImgId;
 

--- a/src/main/java/com/fithub/fithubbackend/domain/user/domain/User.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/domain/User.java
@@ -67,6 +67,10 @@ public class User extends BaseTimeEntity implements UserDetails {
     @ElementCollection
     private List<String> roles = new ArrayList<>();
 
+    // oauth2
+    private String provider;
+    private String providerId;
+
     @Builder
     public User(SignUpDto signUpDto, String encodedPassword, Document document) {
         this.password = encodedPassword;
@@ -81,7 +85,27 @@ public class User extends BaseTimeEntity implements UserDetails {
         this.bio = signUpDto.getBio();
         this.roles = Collections.singletonList("USER");
     }
-  
+    @Builder(builderMethodName = "oAuthBuilder", buildMethodName = "oAuthBuild")
+    public User (String nickname, String email, String provider, String providerId) {
+        this.name = nickname;
+        this.nickname = nickname;
+        this.email = email;
+        this.provider = provider;
+        this.providerId = providerId;
+        this.roles = Collections.singletonList("USER");
+        this.grade = Grade.NORMAL;
+        this.status = Status.NORMAL;
+        this.gender = Gender.UNDEFINED;
+        this.phone = "";
+    }
+
+    public User updateNicknameAndEmail(String nickname, String email) {
+        this.name = nickname;
+        this.nickname = nickname;
+        this.email = email;
+        return this;
+    }
+
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/com/fithub/fithubbackend/domain/user/enums/Gender.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/enums/Gender.java
@@ -1,5 +1,5 @@
 package com.fithub.fithubbackend.domain.user.enums;
 
 public enum Gender {
-    F, M
+    F, M, UNDEFINED
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/repository/UserRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByNickname(String nickname);
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByEmailAndProvider(String email, String provider);
 }

--- a/src/main/java/com/fithub/fithubbackend/global/auth/OAuthAttributes.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/OAuthAttributes.java
@@ -1,0 +1,31 @@
+package com.fithub.fithubbackend.global.auth;
+
+import com.fithub.fithubbackend.domain.user.domain.User;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+
+public enum OAuthAttributes {
+    GOOGLE("google", (attributes) -> {
+        return User.oAuthBuilder()
+                .nickname((String) attributes.get("name"))
+                .email((String) attributes.get("email"))
+                .provider("google")
+                .providerId("google_" + attributes.get("sub"))
+                .oAuthBuild();
+    });
+
+    private final String registrationId;
+    private final Function<Map<String, Object>, User> attributes;
+
+    OAuthAttributes(String registrationId, Function<Map<String, Object>, User> attributes) {
+        this.registrationId = registrationId;
+        this.attributes = attributes;
+    }
+
+    public static User extract(String registrationId, Map<String, Object> attributes) {
+        return Arrays.stream(values()).filter(provider -> registrationId.equals(provider.registrationId))
+                .findFirst().orElseThrow(IllegalArgumentException::new).attributes.apply(attributes);
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/global/auth/OAuthAttributes.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/OAuthAttributes.java
@@ -7,14 +7,12 @@ import java.util.Map;
 import java.util.function.Function;
 
 public enum OAuthAttributes {
-    GOOGLE("google", (attributes) -> {
-        return User.oAuthBuilder()
-                .nickname((String) attributes.get("name"))
-                .email((String) attributes.get("email"))
-                .provider("google")
-                .providerId("google_" + attributes.get("sub"))
-                .oAuthBuild();
-    });
+    GOOGLE("google", (attributes) -> User.oAuthBuilder()
+            .nickname((String) attributes.get("name"))
+            .email((String) attributes.get("email"))
+            .provider("google")
+            .providerId("google_" + attributes.get("sub"))
+            .oAuthBuild());
 
     private final String registrationId;
     private final Function<Map<String, Object>, User> attributes;

--- a/src/main/java/com/fithub/fithubbackend/global/auth/OAuthService.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/OAuthService.java
@@ -1,0 +1,68 @@
+package com.fithub.fithubbackend.global.auth;
+
+import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OAuthService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        // 로그인 진행중인 서비스 구분
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        User user = OAuthAttributes.extract(registrationId, attributes);
+        user = saveOrUpdate(user);
+
+        Map<String, Object> customAttribute = customAttribute(attributes, userNameAttributeName, user);
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority("USER")),
+                customAttribute,
+                userNameAttributeName
+        );
+    }
+
+    private Map<String, Object> customAttribute(Map<String, Object> attributes, String userNameAttributeName, User user) {
+        Map<String, Object> customAttribute = new LinkedHashMap<>();
+        customAttribute.put(userNameAttributeName, attributes.get(userNameAttributeName));
+        customAttribute.put("email", user.getEmail());
+        customAttribute.put("provider", user.getProvider());
+        customAttribute.put("nickname", user.getNickname());
+        return customAttribute;
+    }
+
+    private User saveOrUpdate(User user) {
+        User newUser = userRepository.findByEmailAndProvider(user.getEmail(), user.getProvider())
+                .map(m -> m.updateNicknameAndEmail(user.getNickname(), user.getEmail()))
+                .orElse(User.oAuthBuilder()
+                        .nickname(user.getNickname())
+                        .email(user.getEmail())
+                        .provider(user.getProvider())
+                        .providerId(user.getProviderId())
+                        .oAuthBuild());
+        return userRepository.save(newUser);
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/global/auth/OAuthSuccessHandler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/OAuthSuccessHandler.java
@@ -1,0 +1,39 @@
+package com.fithub.fithubbackend.global.auth;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    // TODO: redirect 주소 정해지면 수정 필요
+    @Value("${spring.security.registration.redirect}")
+    private String url;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+
+        TokenInfoDto token = jwtTokenProvider.createToken(authentication);
+        String targetUrl = UriComponentsBuilder.fromUriString(url)
+                .queryParam("accessToken", token.getAccessToken())
+                .queryParam("refreshToken", token.getRefreshToken())
+                .build().toString();
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+
+}

--- a/src/main/java/com/fithub/fithubbackend/global/auth/OAuthSuccessHandler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/OAuthSuccessHandler.java
@@ -26,7 +26,7 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
-        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+//        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
 
         TokenInfoDto token = jwtTokenProvider.createToken(authentication);
         String targetUrl = UriComponentsBuilder.fromUriString(url)


### PR DESCRIPTION
## PR 유형
- 기능 추가 (구글 로그인)

## 반영 브랜치
- auth -> main

## 변경 사항
- OAuthAttribute 추가 (현재는 구글만 있음)
- 소셜 로그인 처리하는 서비스, 핸들러 추가
- SecurityConfig에 oauth2 설정 추가
- User 프로필 이미지 null 허용으로 변경 (이미지가 지금 들어가지 않는 경우가 많은데 null 허용이 아니다 보니 복잡해져서 우선 허용해놨습니다)

## 테스트 결과
http://localhost:8080/oauth2/authorization/google    

진입 시
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/ada8231f-738b-47fa-8613-92561d80ed02)
구글 로그인 창으로 이동

계정 선택 시
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/26277133-d745-4569-afa2-7b79bfc0d908)

oAuthService 진입됨

유저 생성 or 업데이트 후
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/ca5eedb6-b4d0-4980-af25-7a519442776d)

성공 핸들러로 이동해서 토큰 발급 성공

## 추후 수정
프론트와 상의 후 소셜 로그인 성공 후, 회원 정보를 입력할 수 있는 페이지로 이동해야됨.
redirect 주소 수정 필요