### PR TITLE
refactor: 전화번호 정규식 수정

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/user/dto/constants/SignUpDtoConstants.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/dto/constants/SignUpDtoConstants.java
@@ -2,7 +2,7 @@ package com.fithub.fithubbackend.domain.user.dto.constants;
 
 public class SignUpDtoConstants {
     public static final String PASSWORD_REGEXP = "^(?=.*[@$!%*#?&])[A-Za-z@$!%*#?&\\d]{8,}$";
-    public static final String PHONE_NUMBER_REGEXP = "^\\d{3}-\\d{3,4}-\\d{4}$";
+    public static final String PHONE_NUMBER_REGEXP = "^\\d{3}\\d{3,4}\\d{4}$";
     public static final String EMAIL_REGEXP = "^[a-zA-Z0-9+-\\_.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$";
     public static final String NAME_REGEXP = "^[a-zA-Z가-힣]*$";
     public static final String FORM_DATA_ERROR_REGEXP = "[Optional\\[\\]]";


### PR DESCRIPTION
## PR 유형
- 전화번호 형식 변경

## 반영 브랜치
- refactor/dataform -> main

## 변경 사항
- 전화번호 정규표현식 수정 ('-' 제거)

## 요청사항
@mohyerolo 프론트분께서 한글로 데이터를 넘기면 에러가 발생하신다고 하셔서 찾아봤는데 oracle이 테이블을 만들 때 charset을 utf-8로 만들어 주지 않아 생기는 오류라고 합니다 ㅠ
![image](https://github.com/team-Fithub/fithub-backend/assets/66781422/9b491330-ea75-49e9-b007-59297bdd1ed8)
`charset이 없네요 ㅠ`

찾아보니 jpa ddl-auto로는 안되고, rds에 파라미터 그룹에서 charset 설정을 해줘야 한다고 하더라구요 .
https://catloaf.tistory.com/m/68
https://designdevelop.tistory.com/68
이 두 블로그 참고해 보시면 좋을 것 같고, 2번째꺼는 mysql 이긴 하지만 파라미터 그룹 생성하는건 똑같을 것 같아서 올려두었습니다!