### PR TITLE
update: 소셜 회원가입 권한 수정, 회원가입/로그인에 따라 성공 로직 수정

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/user/domain/User.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/domain/User.java
@@ -92,7 +92,7 @@ public class User extends BaseTimeEntity implements UserDetails {
         this.email = email;
         this.provider = provider;
         this.providerId = providerId;
-        this.roles = Collections.singletonList("USER");
+        this.roles = Collections.singletonList("GUEST");
         this.grade = Grade.NORMAL;
         this.status = Status.NORMAL;
         this.gender = Gender.UNDEFINED;

--- a/src/main/java/com/fithub/fithubbackend/global/auth/OAuthSuccessHandler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/OAuthSuccessHandler.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -21,26 +23,35 @@ import java.io.IOException;
 public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private final JwtTokenProvider jwtTokenProvider;
 
-    // TODO: redirect 주소 정해지면 수정 필요
     @Value("${spring.security.registration.redirect}")
     private String url;
+
+    @Value("${spring.security.registration.first.redirect}")
+    private String firstRedirect;
 
     private final RedisUtil redisUtil;
     private final CookieUtil cookieUtil;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
-//        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
 
-        TokenInfoDto tokenInfoDto = jwtTokenProvider.createToken(authentication);
-        cookieUtil.addRefreshTokenCookie(response, tokenInfoDto);
-        cookieUtil.addAccessTokenCookie(response, tokenInfoDto.getAccessToken());
-        redisUtil.setData(authentication.getName(), tokenInfoDto.getRefreshToken(), tokenInfoDto.getRefreshTokenExpirationTime());
+        String targetUrl = "";
+        if (oAuth2User.getAuthorities().contains(new SimpleGrantedAuthority("GUEST"))) {
+            targetUrl = UriComponentsBuilder.fromUriString(firstRedirect)
+                    .build().toString();
+        } else {
+            TokenInfoDto tokenInfoDto = jwtTokenProvider.createToken(authentication);
+            cookieUtil.addRefreshTokenCookie(response, tokenInfoDto);
+            cookieUtil.addAccessTokenCookie(response, tokenInfoDto.getAccessToken());
+            redisUtil.setData(authentication.getName(), tokenInfoDto.getRefreshToken(), tokenInfoDto.getRefreshTokenExpirationTime());
 
-        String targetUrl = UriComponentsBuilder.fromUriString(url)
-                .queryParam("accessToken", tokenInfoDto.getAccessToken())
-                .queryParam("refreshToken", tokenInfoDto.getRefreshToken())
-                .build().toString();
+            targetUrl = UriComponentsBuilder.fromUriString(url)
+                    .queryParam("accessToken", tokenInfoDto.getAccessToken())
+                    .queryParam("refreshToken", tokenInfoDto.getRefreshToken())
+                    .build().toString();
+        }
+
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 

--- a/src/main/java/com/fithub/fithubbackend/global/auth/OAuthSuccessHandler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/OAuthSuccessHandler.java
@@ -44,7 +44,7 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
             TokenInfoDto tokenInfoDto = jwtTokenProvider.createToken(authentication);
             cookieUtil.addRefreshTokenCookie(response, tokenInfoDto);
             cookieUtil.addAccessTokenCookie(response, tokenInfoDto.getAccessToken());
-            redisUtil.setData(authentication.getName(), tokenInfoDto.getRefreshToken(), tokenInfoDto.getRefreshTokenExpirationTime());
+            redisUtil.setData((String) oAuth2User.getAttribute("email"), tokenInfoDto.getRefreshToken(), tokenInfoDto.getRefreshTokenExpirationTime());
 
             targetUrl = UriComponentsBuilder.fromUriString(url)
                     .queryParam("accessToken", tokenInfoDto.getAccessToken())


### PR DESCRIPTION
## PR 유형
- 기능 수정

## 반영 브랜치
- auth -> main

## 변경 사항
1. 소셜 로그인 시 saveOrUpdate에서 .orElse로 상황에 상관없이 접근해서 .orElseGet으로 변경
2. 소셜 회원가입 시에는 role을 GUEST로 줘서 회원가입이 완료된 회원인지 아닌지 확인할 수 있는 방법 추가
3. 소셜 작업 성공 시 role에 GUEST가 있으면 추가 정보 입력이 필요한 회원으로 판별해 정보 입력을 하는 url로 이동하도록 추가

## 추가 변경 사항
- 노션 application.yml에 redirect 주소 추가

## 추후 수정
프론트에서 배포 링크 주면 그걸로 application.yml에 redirect 주소 수정 후 서버 배포 필요