### PR TITLE
feat/training: 회원-트레이닝 찜 여부 조회, 찜 설정 / 해제 기능 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/UserTrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/UserTrainingController.java
@@ -3,6 +3,8 @@ package com.fithub.fithubbackend.domain.Training.api;
 import com.fithub.fithubbackend.domain.Training.application.UserTrainingService;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingOutlineDto;
+import com.fithub.fithubbackend.global.exception.CustomException;
+import com.fithub.fithubbackend.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
@@ -11,10 +13,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/users/training")
@@ -35,5 +36,28 @@ public class UserTrainingController {
     @GetMapping
     public ResponseEntity<TrainingInfoDto> searchById(@RequestParam Long trainingId) {
         return ResponseEntity.ok(userTrainingService.searchById(trainingId));
+    }
+
+    @Operation(summary = "트레이닝 찜 여부 조회", parameters = {
+            @Parameter(name = "trainingId", description = "조회할 트레이닝의 primary key(id)")
+    })
+    @GetMapping("/check/likes")
+    public ResponseEntity<Boolean> isLikesTraining(@RequestParam Long trainingId, @AuthenticationPrincipal UserDetails userDetails) {
+        if (userDetails == null) {
+            throw new CustomException(ErrorCode.UNKNOWN_ERROR, "로그인한 사용자만 가능합니다.");
+        }
+        return ResponseEntity.ok(userTrainingService.isLikesTraining(trainingId, userDetails.getUsername()));
+    }
+
+    @Operation(summary = "트레이닝 찜 설정 및 해제", parameters = {
+            @Parameter(name = "trainingId", description = "조회할 트레이닝의 primary key(id)")
+    })
+    @PostMapping("/likes")
+    public ResponseEntity<String> likes(@RequestParam Long trainingId, boolean likes, @AuthenticationPrincipal UserDetails userDetails) {
+        if (userDetails == null) {
+            return ResponseEntity.badRequest().body("로그인한 사용자만 가능합니다.");
+        }
+        userTrainingService.likesTraining(trainingId, likes, userDetails.getUsername());
+        return ResponseEntity.ok().body("완료");
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingService.java
@@ -8,4 +8,8 @@ import org.springframework.data.domain.Pageable;
 public interface UserTrainingService {
     Page<TrainingOutlineDto> searchAll(Pageable pageable);
     TrainingInfoDto searchById(Long id);
+
+    boolean isLikesTraining(Long trainingId, String email);
+
+    void likesTraining(Long trainingId, boolean likes, String email);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingServiceImpl.java
@@ -54,6 +54,9 @@ public class UserTrainingServiceImpl implements UserTrainingService {
         checkClosed(training.isClosed());
 
         User user = userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 회원입니다."));
+        if (user.getId().equals(training.getTrainer().getUser().getId())) {
+            throw new CustomException(ErrorCode.UNKNOWN_ERROR, "트레이너는 자신의 트레이닝을 찜할 수 없습니다.");
+        }
         if (likes) {
             TrainingLikes trainingLikes = TrainingLikes.builder().training(training).user(user).build();
             trainingLikesRepository.save(trainingLikes);

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingServiceImpl.java
@@ -1,9 +1,13 @@
 package com.fithub.fithubbackend.domain.Training.application;
 
 import com.fithub.fithubbackend.domain.Training.domain.Training;
+import com.fithub.fithubbackend.domain.Training.domain.TrainingLikes;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingOutlineDto;
+import com.fithub.fithubbackend.domain.Training.repository.TrainingLikesRepository;
 import com.fithub.fithubbackend.domain.Training.repository.TrainingRepository;
+import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.domain.user.repository.UserRepository;
 import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserTrainingServiceImpl implements UserTrainingService {
 
     private final TrainingRepository trainingRepository;
+    private final TrainingLikesRepository trainingLikesRepository;
+    private final UserRepository userRepository;
 
     @Override
     @Transactional(readOnly = true)
@@ -32,4 +38,34 @@ public class UserTrainingServiceImpl implements UserTrainingService {
         return TrainingInfoDto.toDto(training);
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public boolean isLikesTraining(Long trainingId, String email) {
+        Training training = trainingRepository.findById(trainingId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 트레이닝입니다."));
+        checkClosed(training.isClosed());
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 회원입니다."));
+        return trainingLikesRepository.existsByTrainingIdAndUserId(trainingId, user.getId());
+    }
+
+    @Override
+    @Transactional
+    public void likesTraining(Long trainingId, boolean likes, String email) {
+        Training training = trainingRepository.findById(trainingId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 트레이닝입니다."));
+        checkClosed(training.isClosed());
+
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 회원입니다."));
+        if (likes) {
+            TrainingLikes trainingLikes = TrainingLikes.builder().training(training).user(user).build();
+            trainingLikesRepository.save(trainingLikes);
+        } else {
+            TrainingLikes trainingLikes = trainingLikesRepository.findByTrainingIdAndUserId(trainingId, user.getId()).orElseThrow(() -> new CustomException(ErrorCode.UNCORRECTABLE_DATA, "트레이닝을 찜하지 않았습니다."));
+            trainingLikesRepository.delete(trainingLikes);
+        }
+    }
+
+    private void checkClosed(boolean closed) {
+        if (closed) {
+            throw new CustomException(ErrorCode.UNCORRECTABLE_DATA, "마감된 트레이닝은 찜할 수 없습니다.");
+        }
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
@@ -28,7 +28,7 @@ public class Training extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(optional = false, cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    @ManyToOne(optional = false, cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private Trainer trainer;
 
     @NotNull
@@ -66,7 +66,7 @@ public class Training extends BaseTimeEntity {
     @NotNull
     private LocalTime endHour;
 
-    @OneToMany(mappedBy = "training", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "training", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @JsonIgnoreProperties({"training"})
     private List<AvailableDate> availableDates;
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/TrainingLikes.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/TrainingLikes.java
@@ -1,0 +1,31 @@
+package com.fithub.fithubbackend.domain.Training.domain;
+
+import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.global.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrainingLikes extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    private Training training;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    private User user;
+
+    @Builder
+    public TrainingLikes(Training training, User user) {
+        this.training = training;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingLikesRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingLikesRepository.java
@@ -1,0 +1,11 @@
+package com.fithub.fithubbackend.domain.Training.repository;
+
+import com.fithub.fithubbackend.domain.Training.domain.TrainingLikes;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TrainingLikesRepository extends JpaRepository<TrainingLikes, Long> {
+    Optional<TrainingLikes> findByTrainingIdAndUserId(Long trainingId, Long userId);
+    boolean existsByTrainingIdAndUserId(Long trainingId, Long userId);
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/Trainer.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/Trainer.java
@@ -6,6 +6,7 @@ import com.fithub.fithubbackend.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,4 +24,10 @@ public class Trainer extends BaseTimeEntity {
 
     @NotNull
     private String location;
+
+    @Builder
+    public Trainer(User user, String location) {
+        this.user = user;
+        this.location = location;
+    }
 }


### PR DESCRIPTION
## pr 유형
- 기능 추가

## 반영 브랜치
- feature/training -> main

## 변경 사항
1. Trainer 빌더 추가
2. Training 엔티티에서 Trainer fetchtype LAZY로 수정
3. 트레이닝 찜 엔티티 추가
4. 찜 여부 조회, 찜 설정/해제 기능 추가

## 테스트 결과
1. 찜 여부 조회
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/416706e3-d954-4aa6-889c-7edd435df691)

2. 찜 설정/해제 기능
- 설정
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/63cb567f-36e3-417c-ac23-141194602d58)
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/594ecf71-f268-40c5-80b3-d5388a273d4d)

- 해제
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/f2e63afe-b859-46f6-9159-0b1702999c0c)

## 논의
회원에 대한 정보를 가져올 때 AuthenticationPrincipal을 사용해서 UserDetails를 가져오는데 이러면 메소드 안에서 회원을 사용해야 할 때 다시 인증할 때처럼 userRepository에 접근하는 비용 발생. (ex. db에 저장할 일이 필요하면 대부분 사용자 id (primary key)가 필요한데 userDetails로는 얻을 수 없음)

userRepo -> documentRepo -> roleRepo 접근해서 인증 후에 또 메소드에서 userRepo -> documentRepo로 접근하는 상황이 발생하는데 이때 loadByUsername을 User로 가져오게 하고 Authentication에 user를 저장하는 것과 그냥 지금처럼 userDetails를 사용하는거 중에서 어떤게 더 안전하고 효율적인 선택지인지 고민
