### PR TITLE
update: 로그인 시 비밀번호 틀린 경우에 대한 예외 처리 추가, 토큰 관련 응답 결과 수정

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/user/api/AuthController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/api/AuthController.java
@@ -47,8 +47,8 @@ public class AuthController {
 
     @Operation(summary = "로그인", responses = {
             @ApiResponse(responseCode = "200", description = "로그인 성공"),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 회원"),
-            @ApiResponse(responseCode = "403", description = "로그인 실패 - 비밀번호 불일치")
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 회원", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "403", description = "로그인 실패 - 비밀번호 불일치", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
     })
     @PostMapping("/sign-in")
     public ResponseEntity<TokenInfoDto> signIn(@RequestBody SignInDto signInDto, HttpServletResponse response) {
@@ -57,26 +57,22 @@ public class AuthController {
 
     @Operation(summary = "로그아웃", responses = {
             @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
-            @ApiResponse(responseCode = "401", description = "검증되지 않는 토큰이거나 만료된 access Token"),
-            @ApiResponse(responseCode = "403", description = "로그아웃 실패")
+            @ApiResponse(responseCode = "405", description = "만료되거나 redis에 저장되지 않는 refresh Token", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
     @DeleteMapping("/sign-out")
     public ResponseEntity signOut(@CookieValue(name = "accessToken") String cookieAccessToken,
                                   @AuthenticationPrincipal UserDetails userDetails, HttpServletResponse response, HttpServletRequest request){
         SignOutDto signOutDto = SignOutDto.builder().accessToken(cookieAccessToken).build();
         authService.signOut(signOutDto, userDetails, response, request);
-        return new ResponseEntity<>(HttpStatus.OK);
+        return new ResponseEntity<>("로그아웃 성공", HttpStatus.OK);
     }
 
     @Operation(summary = "토큰 재발급", responses = {
             @ApiResponse(responseCode = "200", description = "토큰 재발급 성공"),
-            @ApiResponse(responseCode = "400", description = "검증되지 않는 토큰"),
-            @ApiResponse(responseCode = "403", description = "토큰 재발급 실패")
+            @ApiResponse(responseCode = "405", description = "만료되거나 redis에 저장되지 않는 refresh Token", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
     @PatchMapping("/reissue")
-    public  ResponseEntity<TokenInfoDto> reissue(@CookieValue(name = "refreshToken") String cookieRefreshToken,
-                                                 @AuthenticationPrincipal UserDetails userDetails,
-                                                 HttpServletRequest request,HttpServletResponse response) {
+    public  ResponseEntity<TokenInfoDto> reissue(@CookieValue(name = "refreshToken") String cookieRefreshToken, HttpServletRequest request,HttpServletResponse response) {
         return ResponseEntity.ok(authService.reissue(cookieRefreshToken, request, response));
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthServiceImpl.java
@@ -21,6 +21,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.transaction.annotation.Transactional;
@@ -91,20 +92,24 @@ public class AuthServiceImpl implements AuthService {
     @Transactional
     public TokenInfoDto signIn(SignInDto signInDto, HttpServletResponse response) {
 
-        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(signInDto.getEmail(), signInDto.getPassword());
+        try {
+            UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(signInDto.getEmail(), signInDto.getPassword());
 
-        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+            Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
 
-        TokenInfoDto tokenInfoDto = jwtTokenProvider.createToken(authentication);
+            TokenInfoDto tokenInfoDto = jwtTokenProvider.createToken(authentication);
 
-        // refreshToken, accessToken 쿠키에 저장
-        cookieUtil.addRefreshTokenCookie(response, tokenInfoDto);
-        cookieUtil.addAccessTokenCookie(response, tokenInfoDto.getAccessToken());
+            // refreshToken 쿠키에 저장
+            cookieUtil.addRefreshTokenCookie(response, tokenInfoDto);
 
-        // Redis에 Key(이메일):Value(refreshToken) 저장
-        redisUtil.setData(authentication.getName(), tokenInfoDto.getRefreshToken(), tokenInfoDto.getRefreshTokenExpirationTime());
+            // Redis에 Key(이메일):Value(refreshToken) 저장
+            redisUtil.setData(authentication.getName(), tokenInfoDto.getRefreshToken(), tokenInfoDto.getRefreshTokenExpirationTime());
 
-        return tokenInfoDto;
+            return tokenInfoDto;
+        } catch (BadCredentialsException e) {
+            throw new CustomException(ErrorCode.INVALID_PWD);
+        }
+
     }
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/global/auth/OAuthSuccessHandler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/OAuthSuccessHandler.java
@@ -43,7 +43,6 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
         } else {
             TokenInfoDto tokenInfoDto = jwtTokenProvider.createToken(authentication);
             cookieUtil.addRefreshTokenCookie(response, tokenInfoDto);
-            cookieUtil.addAccessTokenCookie(response, tokenInfoDto.getAccessToken());
             redisUtil.setData((String) oAuth2User.getAttribute("email"), tokenInfoDto.getRefreshToken(), tokenInfoDto.getRefreshTokenExpirationTime());
 
             targetUrl = UriComponentsBuilder.fromUriString(url)

--- a/src/main/java/com/fithub/fithubbackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/fithub/fithubbackend/global/exception/ErrorCode.java
@@ -20,7 +20,9 @@ public enum ErrorCode {
     WRONG_TYPE_TOKEN(HttpStatus.valueOf(401), "잘못된 타입의 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.valueOf(402), "만료된 토큰입니다."),
     UNSUPPORTED_TOKEN(HttpStatus.valueOf(403), "지원되지 않는 토큰입니다."),
-    EXPIRED_REFRESH_TOKEN(HttpStatus.valueOf(405), "재로그인 필요");
+    EXPIRED_REFRESH_TOKEN(HttpStatus.valueOf(405), "재로그인 필요"),
+    INVALID_PWD(HttpStatus.FORBIDDEN, "이메일이나 비밀번호가 틀렸습니다");
+
     private final HttpStatus httpStatus;
     private final String message;
 }

--- a/src/main/java/com/fithub/fithubbackend/global/util/CookieUtil.java
+++ b/src/main/java/com/fithub/fithubbackend/global/util/CookieUtil.java
@@ -41,7 +41,7 @@ public class CookieUtil {
                 .path("/")
                 .sameSite("None")
                 .httpOnly(true)
-//                .secure(true)  //    HTTPS 프로토콜에서만 쿠키 전송 가능
+                .secure(true)  //    HTTPS 프로토콜에서만 쿠키 전송 가능
                 .build();
         response.addHeader("Set-Cookie", cookie.toString());
         return response;
@@ -55,7 +55,7 @@ public class CookieUtil {
                 .path("/")
                 .sameSite("None")
                 .httpOnly(true)
-//                .secure(true)  //    HTTPS 프로토콜에서만 쿠키 전송 가능
+                .secure(true)  //    HTTPS 프로토콜에서만 쿠키 전송 가능
                 .build();
         response.addHeader("Set-Cookie", cookie.toString());
         return response;
@@ -93,26 +93,14 @@ public class CookieUtil {
                 .stream(request.getCookies())
                 .filter(cookie -> cookie.getName().equals("refreshToken")).findFirst();
 
-        Optional<Cookie> accessTokenCookie = Arrays
-                .stream(request.getCookies())
-                .filter(cookie -> cookie.getName().equals("accessToken")).findFirst();
-
         if (refreshTokenCookie.isPresent()) {
             refreshTokenCookie.get().setMaxAge(Math.toIntExact(tokenInfoDto.getRefreshTokenExpirationTime()));
             refreshTokenCookie.get().setValue(tokenInfoDto.getRefreshToken());
             refreshTokenCookie.get().setPath("/");
             refreshTokenCookie.get().setHttpOnly(true);
+            refreshTokenCookie.get().setSecure(true);
             response.addCookie(refreshTokenCookie.get());
         }
-
-        if (accessTokenCookie.isPresent()) {
-//            accessTokenCookie.get().setMaxAge(1800);
-            accessTokenCookie.get().setValue(tokenInfoDto.getAccessToken());
-            accessTokenCookie.get().setPath("/");
-            accessTokenCookie.get().setHttpOnly(true);
-            response.addCookie(accessTokenCookie.get());
-        }
-
     }
 
     public CookieUtil addCookie(String key, String value) {


### PR DESCRIPTION
## PR 유형
- 에러 수정, 기능 수정

## 반영 브랜치
- main -> main

## 변경 사항
- 로그인 시, 비밀 번호 틀린 경우 403 에러 발생하도록 수정 
- 로그인, 로그아웃, 토큰 재발급 error 관련 api-response 수정
- access Token은 cookie 대신 response body로 전달하도록 수정
- refresh Token 쿠키 생성 시, secure 옵션 True로 설정
- access Token 유효 기간 만료 및 refresh Token 유효한 경우, access Token을 새로 발급하여 response body에 토큰과 201 코드 전달

## 테스트 결과

- 로그인
  - 수정 전 
   > 비밀번호가 틀려도 HTTP 상태 코드 200 전달
     ![비밀번호가 틀렸을 경우, 200 코드가 뜸](https://github.com/team-Fithub/fithub-backend/assets/106025529/c2e296de-75bf-4d11-854e-9c7b1af0c77c)

  - 수정 후 
   > 비밀번호가 틀릴 경우 BadCredentialsException 에러 발생 시켜 HTTP 상태 코드 403 코드 전달
     ![수정 완료](https://github.com/team-Fithub/fithub-backend/assets/106025529/ae33d2fa-bdef-4d9c-8f0f-a4e006607de4)

- 토큰 재발급
   - access Token 유효 기간 만료 및 refresh Token 유효한 경우, access Token을 새로 발급하여 response body에 토큰과 201 코드 전달
     ![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/9be44720-edb8-4586-8e91-a8222a005431)

