### PR TITLE
update: 소셜 로그인 성공 시 액세스 토큰을 리다이렉트 URI의 쿼리로 전달

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainerInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainerInfoDto.java
@@ -15,7 +15,7 @@ public class TrainerInfoDto {
     private String location;
 
     public static TrainerInfoDto toDto(Trainer trainer) {
-        String profile = (trainer.getUser().getProfileImgId() != null ? trainer.getUser().getProfileImgId().getUrl() : null);
+        String profile = (trainer.getUser().getProfileImg() != null ? trainer.getUser().getProfileImg().getUrl() : null);
 
         return TrainerInfoDto.builder()
                 .trainerId(trainer.getId())

--- a/src/main/java/com/fithub/fithubbackend/global/auth/OAuthService.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/OAuthService.java
@@ -56,6 +56,7 @@ public class OAuthService implements OAuth2UserService<OAuth2UserRequest, OAuth2
         customAttribute.put("id", user.getId());
         customAttribute.put("provider", user.getProvider());
         customAttribute.put("name", user.getName());
+        customAttribute.put("email", user.getEmail());
 //        customAttribute.put("profileImg", user.getProfileImg());
         customAttribute.put("phone", user.getPhone());
         customAttribute.put("gender", user.getGender().toString());


### PR DESCRIPTION
## PR 유형
- 에러 수정

## 반영 브랜치
- main -> main

## 변경 사항
- TrainerInfoDto profileImg 변수명 변경
- customAttribute에 email 값 추가
- user의 role이 guest가 아닌 경우 uri의 파라미터로 액세스 토큰 전달

## 테스트 결과

- user의 role이 guest가 아닌 경우 redirect-uri 퀴리로 액세스 토큰 전달 
   > http://localhost:3000/?accessToken=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ7aWQ9UzE2d1p2NWJHWE1YN3o5d2xRMUhSQkpocTR3dF9YaUE2Zk4ycDd0NC1fQSwgbmlja25hbWU9azI2OTksIGVtYWlsPWtqcjI2OTlAbmF2ZXIuY29tfSIsImF1dGgiOiJVU0VSIiwiZXhwIjoxNzAyMTA2MDI5fQ.R2ExllDiUVAOeDO62A6JXGRRapmrrmmqXz-_N36FzBI
