### PR TITLE
feat/trainer: 트레이너 인증 요청 추가, fix:role prefix 수정

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerAuthController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerAuthController.java
@@ -1,0 +1,45 @@
+package com.fithub.fithubbackend.domain.trainer.api;
+
+import com.fithub.fithubbackend.domain.trainer.application.TrainerAuthService;
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerCertificationRequestDto;
+import com.fithub.fithubbackend.global.exception.ErrorResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth/trainer/certificate")
+public class TrainerAuthController {
+
+    private final TrainerAuthService trainerAuthService;
+
+    @Operation(summary = "트레이너 인증 요청, swagger에서는 careerList를 application/json으로 못 보내서 사용 X, postman에서는 Body->form-data로 요청 가능",
+            description = "postman 요청 시 이미지는 licenseFileList로 보내도 되지만 careerList는 careerList[0].company 이런 식으로 보내야됨",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "트레이너 인증 요청 완료"),
+                    @ApiResponse(responseCode = "409", description = "이미 트레이너인 회원의 요청 / 완료되지 않은 요청이 있음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+                    @ApiResponse(responseCode = "500", description = "s3에 파일 업로드 실패")
+            }, parameters = {
+            @Parameter(name="requestDto", description = "트레이너 인증 요청 dto(자격증 이미지 파일 리스트, 자격증 이름, 경력사항 리스트)")
+    })
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> certificationRequest(@Valid TrainerCertificationRequestDto requestDto, @AuthenticationPrincipal UserDetails userDetails) {
+        if (userDetails == null) {
+            return ResponseEntity.badRequest().body("로그인한 사용자만 가능합니다.");
+        }
+        trainerAuthService.saveTrainerCertificateRequest(requestDto, userDetails.getUsername());
+        return ResponseEntity.ok().body("완료");
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerAuthController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerAuthController.java
@@ -26,11 +26,11 @@ public class TrainerAuthController {
     private final TrainerAuthService trainerAuthService;
 
     @Operation(summary = "트레이너 인증 요청, swagger에서는 careerList를 application/json으로 못 보내서 사용 X, postman에서는 Body->form-data로 요청 가능",
-            description = "postman 요청 시 이미지는 licenseFileList로 보내도 되지만 careerList는 careerList[0].company 이런 식으로 보내야됨",
+            description = "postman 요청 시 licenseFileList[0], careerList[0].company 이런 식으로 보내야됨",
             responses = {
                     @ApiResponse(responseCode = "200", description = "트레이너 인증 요청 완료"),
                     @ApiResponse(responseCode = "409", description = "이미 트레이너인 회원의 요청 / 완료되지 않은 요청이 있음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
-                    @ApiResponse(responseCode = "500", description = "s3에 파일 업로드 실패")
+                    @ApiResponse(responseCode = "500", description = "s3에 파일 업로드 실패", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
             }, parameters = {
             @Parameter(name="requestDto", description = "트레이너 인증 요청 dto(자격증 이미지 파일 리스트, 자격증 이름, 경력사항 리스트)")
     })

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerAuthService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerAuthService.java
@@ -1,0 +1,7 @@
+package com.fithub.fithubbackend.domain.trainer.application;
+
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerCertificationRequestDto;
+
+public interface TrainerAuthService {
+    void saveTrainerCertificateRequest(TrainerCertificationRequestDto request, String email);
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerAuthServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerAuthServiceImpl.java
@@ -1,0 +1,71 @@
+package com.fithub.fithubbackend.domain.trainer.application;
+
+import com.fithub.fithubbackend.domain.trainer.domain.TrainerCareerTemp;
+import com.fithub.fithubbackend.domain.trainer.domain.TrainerCertificationRequest;
+import com.fithub.fithubbackend.domain.trainer.domain.TrainerLicenseTempImg;
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerCareerRequestDto;
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerCertificationRequestDto;
+import com.fithub.fithubbackend.domain.trainer.repository.TrainerCertificationRequestRepository;
+import com.fithub.fithubbackend.domain.trainer.repository.TrainerRepository;
+import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.domain.user.repository.UserRepository;
+import com.fithub.fithubbackend.global.config.s3.AwsS3Uploader;
+import com.fithub.fithubbackend.global.domain.Document;
+import com.fithub.fithubbackend.global.exception.CustomException;
+import com.fithub.fithubbackend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TrainerAuthServiceImpl implements TrainerAuthService {
+    private final TrainerRepository trainerRepository;
+    private final TrainerCertificationRequestRepository trainerCertificationRequestRepository;
+
+    private final UserRepository userRepository;
+
+    private final AwsS3Uploader s3Uploader;
+
+    @Override
+    public void saveTrainerCertificateRequest(TrainerCertificationRequestDto requestDto, String email) {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 회원입니다."));
+
+        if (trainerRepository.existsByUserId(user.getId())) {
+            throw new CustomException(ErrorCode.DUPLICATE, "트레이너 인증이 완료된 회원입니다.");
+        }
+
+        if (trainerCertificationRequestRepository.existsByUserId(user.getId())) {
+            throw new CustomException(ErrorCode.DUPLICATE, "완료되지 않은 트레이너 인증 요청이 존재하는 회원입니다.");
+        }
+
+        TrainerCertificationRequest trainerCertificationRequest = TrainerCertificationRequest.builder()
+                .user(user).licenseNames(requestDto.getLicenseNames()).build();
+
+        List<MultipartFile> licenseFileList = requestDto.getLicenseFileList();
+        if (licenseFileList != null && !licenseFileList.isEmpty()) {
+            for (MultipartFile file : licenseFileList) {
+                String path = s3Uploader.imgPath("trainer_license_temp");
+                Document document = Document.builder()
+                        .inputName(file.getOriginalFilename())
+                        .url(s3Uploader.putS3(file, path))
+                        .path(path)
+                        .build();
+                TrainerLicenseTempImg trainerLicenseTempImg = TrainerLicenseTempImg.builder()
+                        .document(document).build();
+                trainerLicenseTempImg.updateRequest(trainerCertificationRequest);
+            }
+        }
+
+        List<TrainerCareerRequestDto> careerList = requestDto.getCareerList();
+        for (TrainerCareerRequestDto dto : careerList) {
+            TrainerCareerTemp trainerCareerTemp = TrainerCareerTemp.builder()
+                    .dto(dto).build();
+            trainerCareerTemp.updateRequest(trainerCertificationRequest);
+        }
+
+        trainerCertificationRequestRepository.save(trainerCertificationRequest);
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/Trainer.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/Trainer.java
@@ -5,6 +5,7 @@ import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,11 +24,16 @@ public class Trainer extends BaseTimeEntity {
     private User user;
 
     @NotNull
+    @Size(min = 2)
+    private String name;
+
+    @NotNull
     private String location;
 
     @Builder
     public Trainer(User user, String location) {
         this.user = user;
+        this.name = user.getName();
         this.location = location;
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCareer.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCareer.java
@@ -1,0 +1,39 @@
+package com.fithub.fithubbackend.domain.trainer.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrainerCareer {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    private Trainer trainer;
+
+    @NotNull
+    @Size(min = 2)
+    private String company;
+    @NotNull
+    @Size(min = 2)
+    private String work;
+
+    @NotNull
+    private LocalDate startDate;
+    @NotNull
+    private LocalDate endDate;
+
+    @ColumnDefault("false")
+    @NotNull
+    private boolean working;
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCareerTemp.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCareerTemp.java
@@ -1,0 +1,56 @@
+package com.fithub.fithubbackend.domain.trainer.domain;
+
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerCareerRequestDto;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrainerCareerTemp {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    private TrainerCertificationRequest trainerCertificationRequest;
+
+    @NotNull
+    @Size(min = 2)
+    private String company;
+    @NotNull
+    @Size(min = 2)
+    private String work;
+
+    @NotNull
+    private LocalDate startDate;
+    @NotNull
+    private LocalDate endDate;
+
+    @ColumnDefault("false")
+    @NotNull
+    private boolean working;
+
+    @Builder
+    public TrainerCareerTemp (TrainerCareerRequestDto dto) {
+        this.company = dto.getCompany();
+        this.work = dto.getWork();
+        this.startDate = dto.getStartDate();
+        this.endDate = dto.getEndDate();
+        this.working = dto.isWorking();
+    }
+
+    public void updateRequest(TrainerCertificationRequest request) {
+        this.trainerCertificationRequest = request;
+        request.getCareerTempList().add(this);
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCertificationRequest.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCertificationRequest.java
@@ -1,0 +1,43 @@
+package com.fithub.fithubbackend.domain.trainer.domain;
+
+import com.fithub.fithubbackend.domain.user.domain.User;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrainerCertificationRequest {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    private User user;
+
+    @OneToMany(mappedBy = "trainerCertificationRequest", cascade = CascadeType.ALL)
+    private List<TrainerLicenseTempImg> licenseTempImgList;
+
+    @NotNull
+    @Size(min = 2)
+    private String licenseNames;
+
+    @OneToMany(mappedBy = "trainerCertificationRequest", cascade = CascadeType.ALL)
+    private List<TrainerCareerTemp> careerTempList;
+
+    @Builder
+    public TrainerCertificationRequest(User user, String licenseNames) {
+        this.user = user;
+        this.licenseNames = licenseNames;
+        this.licenseTempImgList = new ArrayList<>();
+        this.careerTempList = new ArrayList<>();
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerLicenseImg.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerLicenseImg.java
@@ -1,0 +1,23 @@
+package com.fithub.fithubbackend.domain.trainer.domain;
+
+import com.fithub.fithubbackend.global.domain.Document;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrainerLicenseImg {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    private Trainer trainer;
+
+    @OneToOne(optional = false, cascade = CascadeType.ALL)
+    private Document document;
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerLicenseTempImg.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerLicenseTempImg.java
@@ -19,7 +19,7 @@ public class TrainerLicenseTempImg {
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     private TrainerCertificationRequest trainerCertificationRequest;
 
-    @OneToOne(optional = false, cascade = CascadeType.ALL)
+    @OneToOne(optional = false)
     private Document document;
 
     @Builder

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerLicenseTempImg.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerLicenseTempImg.java
@@ -1,0 +1,34 @@
+package com.fithub.fithubbackend.domain.trainer.domain;
+
+import com.fithub.fithubbackend.global.domain.Document;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrainerLicenseTempImg {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    private TrainerCertificationRequest trainerCertificationRequest;
+
+    @OneToOne(optional = false, cascade = CascadeType.ALL)
+    private Document document;
+
+    @Builder
+    public TrainerLicenseTempImg(Document document) {
+        this.document = document;
+    }
+
+    public void updateRequest(TrainerCertificationRequest request) {
+        this.trainerCertificationRequest = request;
+        request.getLicenseTempImgList().add(this);
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerLicenseTempImg.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerLicenseTempImg.java
@@ -19,7 +19,7 @@ public class TrainerLicenseTempImg {
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     private TrainerCertificationRequest trainerCertificationRequest;
 
-    @OneToOne(optional = false)
+    @OneToOne(optional = false, cascade = CascadeType.PERSIST)
     private Document document;
 
     @Builder

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerCareerRequestDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerCareerRequestDto.java
@@ -1,0 +1,37 @@
+package com.fithub.fithubbackend.domain.trainer.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Schema(description = "트레이너 인증 요청 시 작성하는 경력 사항")
+public class TrainerCareerRequestDto {
+    @NotBlank
+    @Schema(description = "근무지")
+    private String company;
+
+    @NotBlank
+    @Schema(description = "담당 업무")
+    private String work;
+
+    @NotNull
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @Schema(description = "입사년월")
+    private LocalDate startDate;
+
+    @NotNull
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @Schema(description = "퇴사년월")
+    private LocalDate endDate;
+
+    @NotNull
+    @Schema(description = "현 근무지 재직 여부")
+    private boolean working;
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerCertificationRequestDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerCertificationRequestDto.java
@@ -1,0 +1,31 @@
+package com.fithub.fithubbackend.domain.trainer.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@Schema(description = "트레이너 인증 요청 dto")
+public class TrainerCertificationRequestDto {
+    @Valid
+    @NotNull(message = "자격증은 1개 이상 등록되어야 합니다.")
+    @Schema(description = "트레이너 인증 요청 시 첨부한 자격증 파일 리스트")
+    private List<MultipartFile> licenseFileList = new ArrayList<>();
+
+    @NotBlank
+    @Schema(description = "트레이너 인증 요청 시 입력한 자격증 리스트", example = "2급 생활스포츠지도사,NSCA")
+    private String licenseNames;
+
+    @Valid
+    @NotNull(message = "경력사항은 1개 이상 등록되어야 합니다.")
+    @Schema(description = "트레이너 인증 요청 시 작성한 경력사항")
+    private List<TrainerCareerRequestDto> careerList = new ArrayList<>();
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/repository/TrainerCertificationRequestRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/repository/TrainerCertificationRequestRepository.java
@@ -1,0 +1,8 @@
+package com.fithub.fithubbackend.domain.trainer.repository;
+
+import com.fithub.fithubbackend.domain.trainer.domain.TrainerCertificationRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TrainerCertificationRequestRepository extends JpaRepository<TrainerCertificationRequest, Long> {
+    boolean existsByUserId(Long userId);
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/repository/TrainerRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/repository/TrainerRepository.java
@@ -4,4 +4,5 @@ import com.fithub.fithubbackend.domain.trainer.domain.Trainer;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TrainerRepository extends JpaRepository<Trainer, Long> {
+    boolean existsByUserId(Long userId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthServiceImpl.java
@@ -61,9 +61,9 @@ public class AuthServiceImpl implements AuthService {
         duplicateNickname(signUpDto.getNickname()); // 닉네임 중복 확인
 
         String profileImgInputName = "default";
-        String profileImgPath = "default";
+        String profileImgPath = "profiles/default";
 
-        if(!profileImg.isEmpty()){
+        if(profileImg != null && !profileImg.isEmpty()){
             profileImgPath = awsS3Uploader.imgPath("profiles");
             profileImgUrl = awsS3Uploader.putS3(profileImg,profileImgPath);
             profileImgInputName = profileImg.getOriginalFilename();

--- a/src/main/java/com/fithub/fithubbackend/domain/user/domain/User.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/domain/User.java
@@ -84,7 +84,7 @@ public class User extends BaseTimeEntity implements UserDetails {
         this.status = Status.NORMAL;
         this.profileImg = document;
         this.bio = signUpDto.getBio();
-        this.roles = Collections.singletonList("USER");
+        this.roles = Collections.singletonList("ROLE_USER");
     }
     @Builder(builderMethodName = "oAuthBuilder", buildMethodName = "oAuthBuild")
     public User (String nickname, String email, String provider, String providerId) {
@@ -93,7 +93,7 @@ public class User extends BaseTimeEntity implements UserDetails {
         this.email = email;
         this.provider = provider;
         this.providerId = providerId;
-        this.roles = Collections.singletonList("GUEST");
+        this.roles = Collections.singletonList("ROLE_GUEST");
         this.grade = Grade.NORMAL;
         this.status = Status.NORMAL;
         this.gender = Gender.UNDEFINED;
@@ -106,7 +106,7 @@ public class User extends BaseTimeEntity implements UserDetails {
         this.email = "";
         this.provider = provider;
         this.providerId = providerId;
-        this.roles = Collections.singletonList("GUEST");
+        this.roles = Collections.singletonList("ROLE_GUEST");
         this.profileImg = profileImg;
         this.grade = Grade.NORMAL;
         this.status = Status.NORMAL;
@@ -121,7 +121,7 @@ public class User extends BaseTimeEntity implements UserDetails {
         this.email = email;
         this.provider = provider;
         this.providerId = providerId;
-        this.roles = Collections.singletonList("GUEST");
+        this.roles = Collections.singletonList("ROLE_GUEST");
         this.grade = Grade.NORMAL;
         this.status = Status.NORMAL;
         this.gender = gender;
@@ -142,7 +142,7 @@ public class User extends BaseTimeEntity implements UserDetails {
     }
 
     public void updateGuestToUser() {
-        this.roles.set(this.roles.indexOf("GUEST"), "USER");
+        this.roles.set(this.roles.indexOf("ROLE_GUEST"), "ROLE_USER");
     }
 
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)

--- a/src/main/java/com/fithub/fithubbackend/global/auth/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,33 @@
+package com.fithub.fithubbackend.global.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fithub.fithubbackend.global.exception.ErrorCode;
+import com.fithub.fithubbackend.global.exception.ErrorResponseDto;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@Slf4j
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+        log.info("인증 실패: " + authException.getMessage());
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        ErrorResponseDto errorResponseDto = ErrorResponseDto.toResponseEntity(ErrorCode.AUTHENTICATION_ERROR, "인증 실패").getBody();
+
+        response.setStatus(401);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("utf-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponseDto));
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
@@ -67,6 +67,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 HttpMethod.GET, PERMIT_ALL_GET_PATTERNS).permitAll()
                         .requestMatchers("/**").hasRole("USER")
+                        .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(e -> e.authenticationEntryPoint(new CustomAuthenticationEntryPoint()))

--- a/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
@@ -66,7 +66,7 @@ public class SecurityConfig {
                         ).permitAll()
                         .requestMatchers(
                                 HttpMethod.GET, PERMIT_ALL_GET_PATTERNS).permitAll()
-                        .requestMatchers("/**").hasRole("USER")
+//                        .requestMatchers("/**").hasRole("USER")
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
@@ -69,6 +69,7 @@ public class SecurityConfig {
                         .requestMatchers("/**").hasRole("USER")
                         .anyRequest().authenticated()
                 )
+                .exceptionHandling(e -> e.authenticationEntryPoint(new CustomAuthenticationEntryPoint()))
                 .oauth2Login(oauth2Login -> {
                     oauth2Login.userInfoEndpoint(userInfoEndPoint -> userInfoEndPoint.userService(oAuthService));
                     oauth2Login.successHandler(oAuthSuccessHandler);

--- a/src/main/java/com/fithub/fithubbackend/global/config/s3/AwsS3Uploader.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/s3/AwsS3Uploader.java
@@ -1,9 +1,7 @@
 package com.fithub.fithubbackend.global.config.s3;
 
 import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -13,10 +11,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.util.Optional;
 import java.util.UUID;
 
 @Slf4j
@@ -34,12 +29,15 @@ public class AwsS3Uploader {
         return dirName + "/" + UUID.randomUUID(); // 파일 경로 반환
     }
 
-    public String putS3(MultipartFile multipartFile, String fileName) throws IOException {
+    public String putS3(MultipartFile multipartFile, String fileName) {
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentType(multipartFile.getContentType());
         metadata.setContentLength(multipartFile.getSize());
-
-        amazonS3Client.putObject(bucket, fileName, multipartFile.getInputStream(), metadata);
+        try {
+            amazonS3Client.putObject(bucket, fileName, multipartFile.getInputStream(), metadata);
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.FILE_UPLOAD_ERROR);
+        }
         return amazonS3Client.getUrl(bucket, fileName).toString(); // 업로드된 파일의 S3 URL 주소 반환
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/fithub/fithubbackend/global/exception/ErrorCode.java
@@ -21,7 +21,11 @@ public enum ErrorCode {
     EXPIRED_TOKEN(HttpStatus.valueOf(402), "만료된 토큰입니다."),
     UNSUPPORTED_TOKEN(HttpStatus.valueOf(403), "지원되지 않는 토큰입니다."),
     EXPIRED_REFRESH_TOKEN(HttpStatus.valueOf(405), "재로그인 필요"),
-    INVALID_PWD(HttpStatus.FORBIDDEN, "이메일이나 비밀번호가 틀렸습니다");
+    INVALID_PWD(HttpStatus.FORBIDDEN, "이메일이나 비밀번호가 틀렸습니다"),
+
+    FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
+
+    AUTHENTICATION_ERROR(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## pr 유형
- 기능 추가, 수정

## 반영 브랜치
- feature/trainer-> main

## 변경 사항
1. s3에서 에러 던지는 걸 try-catch로 수정
2. 사용자 프로필 기본 imgPath에 폴더명 추가
3. 인증 실패 시 response가 현재 security login 창으로 이동인데 이걸 인증 실패 response 반환으로 수정
4. 트레이너 인증요청,자격증, 임시 자격증,경력사항, 임시 경력사항 엔티티 추가
5. 트레이너 인증 요청 기능 추가
6. role관련 ROLE_ prefix 추가

## 테스트 결과
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/452364cd-489e-4f1a-a5cf-e82cc0ee435c)

![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/b8b6260f-9f6f-4030-8d4e-64e384cc5023)

요청 후 s3에 파일 업로드,  db 저장 완료