### PR TITLE
feat/auth: 소셜 회원가입 후 토큰 발급

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/user/api/AuthController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/api/AuthController.java
@@ -75,12 +75,11 @@ public class AuthController {
 
 
     @Operation(summary = "소셜 회원가입 추가 정보 저장", responses = {
-            @ApiResponse(responseCode = "200", description = "소셜 회원가입 완료. 로그인으로 이동 필요"),
+            @ApiResponse(responseCode = "200", description = "accessToken 반환. 세션 쿠키로 설정 필요"),
             @ApiResponse(responseCode = "500", description = "소셜 회원가입이 제대로 성공하지 못 해 db에 user 정보가 저장된게 없음. 다시 회원가입부터 진행 필요")
     })
     @PostMapping("/oauth/regist")
     public ResponseEntity<String> oAuthSignUp(@RequestBody OAuthSignUpDto oAuthSignUpDto, @RequestParam String email, HttpServletResponse response) {
-        authService.oAuthSignUp(oAuthSignUpDto, email, response);
-        return ResponseEntity.ok().body("완료");
+        return ResponseEntity.ok(authService.oAuthSignUp(oAuthSignUpDto, email, response));
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/api/AuthController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/api/AuthController.java
@@ -79,8 +79,8 @@ public class AuthController {
             @ApiResponse(responseCode = "500", description = "소셜 회원가입이 제대로 성공하지 못 해 db에 user 정보가 저장된게 없음. 다시 회원가입부터 진행 필요")
     })
     @PostMapping("/oauth/regist")
-    public ResponseEntity<String> oAuthSignUp(@RequestBody OAuthSignUpDto oAuthSignUpDto, Long userId) {
-        authService.oAuthSignUp(oAuthSignUpDto, userId);
+    public ResponseEntity<String> oAuthSignUp(@RequestBody OAuthSignUpDto oAuthSignUpDto, @RequestParam String email, HttpServletResponse response) {
+        authService.oAuthSignUp(oAuthSignUpDto, email, response);
         return ResponseEntity.ok().body("완료");
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthService.java
@@ -20,5 +20,5 @@ public interface AuthService {
 
     TokenInfoDto reissue(String cookieRefreshToken, HttpServletRequest request, HttpServletResponse response);
 
-    void oAuthSignUp(OAuthSignUpDto oAuthSignUpDto, String email, HttpServletResponse response);
+    String oAuthSignUp(OAuthSignUpDto oAuthSignUpDto, String email, HttpServletResponse response);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthService.java
@@ -20,5 +20,5 @@ public interface AuthService {
 
     TokenInfoDto reissue(String cookieRefreshToken, HttpServletRequest request, HttpServletResponse response);
 
-    void oAuthSignUp(OAuthSignUpDto oAuthSignUpDto, Long userId);
+    void oAuthSignUp(OAuthSignUpDto oAuthSignUpDto, String email, HttpServletResponse response);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthServiceImpl.java
@@ -174,10 +174,18 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     @Transactional
-    public void oAuthSignUp(OAuthSignUpDto oAuthSignUpDto, Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new UsernameNotFoundException("소셜 회원가입을 다시 진행해주십시오."));
+    public void oAuthSignUp(OAuthSignUpDto oAuthSignUpDto, String email, HttpServletResponse response) {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new UsernameNotFoundException("소셜 회원가입을 다시 진행해주십시오."));
         user.updateNameAndPhoneAndBioAndGender(oAuthSignUpDto);
         user.updateGuestToUser();
+
+        TokenInfoDto tokenInfoDto = jwtTokenProvider.createToken(email);
+
+        // refreshToken 쿠키에 저장
+        cookieUtil.addRefreshTokenCookie(response, tokenInfoDto);
+        cookieUtil.addAccessTokenCookie(response, tokenInfoDto.getAccessToken());
+        // Redis에 Key(이메일):Value(refreshToken) 저장
+        redisUtil.setData(email, tokenInfoDto.getRefreshToken(), tokenInfoDto.getRefreshTokenExpirationTime());
     }
 
     private void duplicateNickname(String nickname){

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthServiceImpl.java
@@ -174,7 +174,7 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     @Transactional
-    public void oAuthSignUp(OAuthSignUpDto oAuthSignUpDto, String email, HttpServletResponse response) {
+    public String oAuthSignUp(OAuthSignUpDto oAuthSignUpDto, String email, HttpServletResponse response) {
         User user = userRepository.findByEmail(email).orElseThrow(() -> new UsernameNotFoundException("소셜 회원가입을 다시 진행해주십시오."));
         user.updateNameAndPhoneAndBioAndGender(oAuthSignUpDto);
         user.updateGuestToUser();
@@ -183,9 +183,9 @@ public class AuthServiceImpl implements AuthService {
 
         // refreshToken 쿠키에 저장
         cookieUtil.addRefreshTokenCookie(response, tokenInfoDto);
-        cookieUtil.addAccessTokenCookie(response, tokenInfoDto.getAccessToken());
         // Redis에 Key(이메일):Value(refreshToken) 저장
         redisUtil.setData(email, tokenInfoDto.getRefreshToken(), tokenInfoDto.getRefreshTokenExpirationTime());
+        return tokenInfoDto.getAccessToken();
     }
 
     private void duplicateNickname(String nickname){

--- a/src/main/java/com/fithub/fithubbackend/global/auth/JwtTokenProvider.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/JwtTokenProvider.java
@@ -96,6 +96,33 @@ public class JwtTokenProvider {
                 .build();
     }
 
+    public TokenInfoDto createToken(String email) {
+        Claims claims = Jwts.claims().setSubject(email);
+
+        Date now = new Date();
+
+        String accessToken = Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + ACCESS_TOKEN_EXPIRE_TIME))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+
+
+        String refreshToken = Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_EXPIRE_TIME))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+
+        return TokenInfoDto.builder()
+                .grantType(BEARER_TYPE)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .refreshTokenExpirationTime(REFRESH_TOKEN_EXPIRE_TIME)
+                .build();
+    }
 
     public Authentication getAuthentication(String accessToken) {
 


### PR DESCRIPTION
## pr 유형
- 기능 추가

## 반영 브랜치
- auth ->main

## 변경 사항
- 소셜 회원가입 시 토큰 발급을 위해 createToken 메소드 오버로딩 (소셜 회원가입시에는 authentication 대신 email로)
- 소셜 회원가입 후에 추가 정보 입력 -> 성공하면 토큰 발급