### PR TITLE
update: 로그인 완성

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/user/api/AuthController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/api/AuthController.java
@@ -59,8 +59,8 @@ public class AuthController {
     @DeleteMapping("/sign-out")
     public ResponseEntity signOut(@CookieValue(name = "accessToken") String cookieAccessToken,
                                   @AuthenticationPrincipal UserDetails userDetails, HttpServletResponse response, HttpServletRequest request){
-        SignOutDto signOutDto = SignOutDto.builder().accessToken(cookieAccessToken).build();
-        authService.signOut(signOutDto, userDetails, response, request);
+        SignOutDto signOutDto = SignOutDto.builder().accessToken(cookieAccessToken).email(userDetails.getUsername()).build();
+        authService.signOut(signOutDto, response, request);
         return new ResponseEntity<>("로그아웃 성공", HttpStatus.OK);
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthService.java
@@ -16,7 +16,7 @@ public interface AuthService {
     
     TokenInfoDto signIn(SignInDto signInDto, HttpServletResponse response);
 
-    void signOut(SignOutDto signOutDto, UserDetails userDetails, HttpServletResponse response, HttpServletRequest request);
+    void signOut(SignOutDto signOutDto, HttpServletResponse response, HttpServletRequest request);
 
     TokenInfoDto reissue(String cookieRefreshToken, HttpServletRequest request, HttpServletResponse response);
 

--- a/src/main/java/com/fithub/fithubbackend/domain/user/dto/SignOutDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/dto/SignOutDto.java
@@ -16,7 +16,8 @@ public class SignOutDto {
     private String refreshToken;
 
     @Builder
-    public SignOutDto (String accessToken) {
+    public SignOutDto (String accessToken, String email) {
         this.accessToken = accessToken;
+        this.email = email;
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.fithub.fithubbackend.global.auth;
 
 import com.fithub.fithubbackend.global.exception.ErrorCode;
+import com.fithub.fithubbackend.global.util.HeaderUtil;
 import com.fithub.fithubbackend.global.util.RedisUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -20,21 +21,22 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.util.Arrays;
 
+import static com.fithub.fithubbackend.global.exception.ErrorCode.EXPIRED_REFRESH_TOKEN;
+
 @Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-
-    public static final String ACCESS_TOKEN_COOKIE = "accessToken";
-    public static final String REFRESH_TOKEN_COOKIE = "refreshToken";
 
     private final JwtTokenProvider jwtTokenProvider;
 
     private final RedisUtil redisUtil;
 
+    private final HeaderUtil headerUtil;
+
 
     private static final String[] SHOULD_NOT_FILTER_URI_ALL_LIST = new String[]{
             "/auth/sign-in", "/auth/sign-up", "/auth/oauth/regist", "exception",
-            "/auth/reissue", "/admin/sign-in", "**exception**"
+            "/admin/sign-in", "**exception**"
     };
 
     @Override
@@ -46,72 +48,57 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-        String accessToken = resolveAccessToken(request);
-        String refreshToken = resolveRefreshToken(request);
+        // 1. 쿠키에서 token 추출
+        String accessToken = headerUtil.resolveAccessToken(request);
+        String refreshToken = headerUtil.resolveRefreshToken(request);
 
-        if (accessToken != null && jwtTokenProvider.validateToken(accessToken)) {
+        if (accessToken != null && jwtTokenProvider.validateToken(accessToken)) {   // 2. access Token 유효 시
             String isLogout = redisUtil.getData(accessToken);
             if (ObjectUtils.isEmpty(isLogout)) {
                 Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
-        } else if (accessToken == null && refreshToken != null) {
-            if (jwtTokenProvider.validateToken(refreshToken)) {     // 리프레시 토큰이 유효할 경우 액세스 토큰 재발급
-                createAccessToken(refreshToken, response);
+        } else if (accessToken == null && refreshToken != null) {   // 3. access Token 존재 X / refresh 유효 시
+            if (jwtTokenProvider.validateToken(refreshToken)) {
+                Authentication authentication = jwtTokenProvider.getAuthentication(refreshToken);
+
+                if (jwtTokenProvider.existsRefreshToken(authentication.getName()))
+                    createAccessToken(authentication, response);
+                else
+                    notExistRefreshToken(response);
                 return;
             }
         }
         filterChain.doFilter(request, response);
     }
 
-    private String resolveAccessToken(HttpServletRequest request) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies != null) {
-            for (Cookie cookie : cookies) {
-                if (ACCESS_TOKEN_COOKIE.equals(cookie.getName())) {
-                    return cookie.getValue();
-                }
-            }
-        }
-        return null;
-    }
-
-    private String resolveRefreshToken(HttpServletRequest request) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies != null) {
-            for (Cookie cookie : cookies) {
-                if (REFRESH_TOKEN_COOKIE.equals(cookie.getName())) {
-                    return cookie.getValue();
-                }
-            }
-        }
-        return null;
-    }
-
-    public void createAccessToken(String refreshToken, HttpServletResponse response) throws IOException {
-        Authentication authentication = jwtTokenProvider.getAuthentication(refreshToken);
-
+    public void createAccessToken(Authentication authentication, HttpServletResponse response) throws IOException {
         response.setContentType("application/json;charset=UTF-8");
         JSONObject responseJson = new JSONObject();
 
-        if (jwtTokenProvider.existsRefreshToken(authentication.getName())) {
-            String newAccessToken = jwtTokenProvider.createAccessToken(authentication);
+        String newAccessToken = jwtTokenProvider.createAccessToken(authentication);
 
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
-            response.setStatus(HttpStatus.CREATED.value());     // 201 성공적으로 access Token 재발급
-            responseJson.put("message", "30분 유효 기간 지나 access Token 재발급 성공");
-            responseJson.put("accessToken", newAccessToken);
-            response.getWriter().print(responseJson);
+        response.setStatus(HttpStatus.CREATED.value());     // 201 성공적으로 access Token 재발급
 
-            log.info("액세스 토큰 재발급 성공");
-        }
-        else {
-            response.setStatus(ErrorCode.EXPIRED_REFRESH_TOKEN.getHttpStatus().value());
-            responseJson.put("message", ErrorCode.EXPIRED_REFRESH_TOKEN.getMessage());
-            responseJson.put("httpStatus", ErrorCode.EXPIRED_REFRESH_TOKEN.getHttpStatus());
-            response.getWriter().print(responseJson);
-        }
-    };
+        responseJson.put("httpStatus", HttpStatus.CREATED);
+        responseJson.put("code", HttpStatus.CREATED.value());
+        responseJson.put("message", "30분 유효 기간 지나 access Token 재발급 성공");
+        responseJson.put("accessToken", newAccessToken);
+
+        response.getWriter().print(responseJson);
+        log.info("액세스 토큰 재발급 성공");
+    }
+
+    public void notExistRefreshToken(HttpServletResponse response) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        JSONObject responseJson = new JSONObject();
+
+        response.setStatus(HttpStatus.METHOD_NOT_ALLOWED.value());
+        responseJson.put("httpStatus", ErrorCode.EXPIRED_TOKEN.getHttpStatus().value());
+        responseJson.put("code", ErrorCode.EXPIRED_TOKEN.getHttpStatus());
+        responseJson.put("message", "redis에 Token 존재 하지 않음");
+        response.getWriter().print(responseJson);
+    }
 }
-

--- a/src/main/java/com/fithub/fithubbackend/global/auth/JwtExceptionFilter.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/JwtExceptionFilter.java
@@ -60,7 +60,7 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
                     } else {
                         setResponse(response, ErrorCode.EXPIRED_REFRESH_TOKEN);
                     }
-                } catch (ExpiredJwtException expiredJwtException) {     // Refresh Token 만료 시
+                } catch (JwtException jwtException) {     // Refresh Token 만료 시
                     setResponse(response, ErrorCode.EXPIRED_REFRESH_TOKEN);
                 }
             } else if (errorMsg.equals(ErrorCode.WRONG_TYPE_TOKEN.getMessage())) {
@@ -89,6 +89,6 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
         JSONObject responseJson = new JSONObject();
         responseJson.put("message", "30분 유효 기간 지나 access Token 재발급 성공");
         responseJson.put("accessToken", accessToken);
-        response.getWriter().print(responseJson.toString());
+        response.getWriter().print(responseJson);
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/global/auth/JwtExceptionFilter.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/JwtExceptionFilter.java
@@ -76,6 +76,7 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
         response.setStatus(code.getHttpStatus().value());
 
         JSONObject responseJson = new JSONObject();
+        responseJson.put("code", code.getHttpStatus().value());
         responseJson.put("message", code.getMessage());
         responseJson.put("httpStatus", code.getHttpStatus());
 
@@ -87,6 +88,8 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
         response.setStatus(HttpStatus.CREATED.value());     // 201 성공적으로 access Token 재발급
 
         JSONObject responseJson = new JSONObject();
+        responseJson.put("httpStatus", HttpStatus.CREATED);
+        responseJson.put("code", HttpStatus.CREATED.value());
         responseJson.put("message", "30분 유효 기간 지나 access Token 재발급 성공");
         responseJson.put("accessToken", accessToken);
         response.getWriter().print(responseJson);

--- a/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
@@ -56,7 +56,7 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
 
                 // jwtFilter 추가
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, redisUtil), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, redisUtil, headerUtil), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new JwtExceptionFilter(jwtTokenProvider, headerUtil, cookieUtil), JwtAuthenticationFilter.class)
 
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))


### PR DESCRIPTION
## PR 유형
- 기능 추가

## 반영 브랜치
- feature/auth -> main

## 변경 사항
- SignOutDto 빌더 수정
- 로그아웃 파라미터 수정
-  jwt 예외 관련 response json 형식 수정
- 로그아웃, 토큰 재발급 시 예외 처리하는 try-catch 추가
- SHOULD_NOT_FILTER_URI_ALL_LIST 에 토큰 재발급 api 삭제
- 유효한 refresh Token만 쿠키에 있을 경우, access Token 재발급

## 테스트 결과

### 쿠키에 access Token 존재 O / refresh Token 존재 O

> 1. access Token 유효 X / refresh Token 유효 X

`{
    "code": 405,
    "httpStatus": "405 METHOD_NOT_ALLOWED",
    "message": "재로그인 필요"
}`

> 2. access Token 유효 X /  refresh Token 유효 O

`{
    "code": 201,
    "httpStatus": "201 CREATED",
    "message": "30분 유효 기간 지나 access Token 재발급 성공",
    "accessToken": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmaW5hbEBmaW5hbC5jb20iLCJhdXRoIjoiR1VFU1QiLCJleHAiOjE3MDI2MTQ1NzV9.IB2iLGk6bPjF1Dxp8gSBoYY8CBo5hY86PRWQgXybC_g"
}`

### 쿠키에 access Token 존재 X / refresh Token 존재 O

> 1. redis에 refresh Token 존재 X 및 refresh Token 유효 X

`{
    "code": 405,
    "httpStatus": "405 METHOD_NOT_ALLOWED",
    "message": "재로그인 필요"
}`

> 2. refresh Token이 redis에 존재 O, 유효 O

`{
    "code": 201,
    "httpStatus": "201 CREATED",
    "message": "30분 유효 기간 지나 access Token 재발급 성공",
    "accessToken": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmaW5hbEBmaW5hbC5jb20iLCJhdXRoIjoiR1VFU1QiLCJleHAiOjE3MDI2MTQ1NzV9.IB2iLGk6bPjF1Dxp8gSBoYY8CBo5hY86PRWQgXybC_g"
}`

