### PR TITLE
feat: 주변 헬스장 조회, fix: 인증번호 중복 발행 에러 수

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
 	// oauth2
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
+	// json parsing
+	implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/fithub/fithubbackend/FithubBackendApplication.java
+++ b/src/main/java/com/fithub/fithubbackend/FithubBackendApplication.java
@@ -2,7 +2,9 @@ package com.fithub.fithubbackend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.web.client.RestTemplate;
 
 @EnableJpaAuditing
 @SpringBootApplication
@@ -10,6 +12,10 @@ public class FithubBackendApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(FithubBackendApplication.class, args);
+	}
+	@Bean
+	public RestTemplate restTemplate(){
+		return new RestTemplate();
 	}
 
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/api/MapController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/api/MapController.java
@@ -3,6 +3,8 @@ package com.fithub.fithubbackend.domain.user.api;
 import com.fithub.fithubbackend.domain.user.application.MapService;
 import com.fithub.fithubbackend.domain.user.dto.constants.MapDocumentDto;
 import com.fithub.fithubbackend.domain.user.dto.constants.MapDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +18,11 @@ import java.util.List;
 @RequestMapping("/auth")
 public class MapController {
     private final MapService mapService;
+
+    @Operation(summary = "헬스장 조회", responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "409", description = "JSONParsing 에러")
+    })
     @GetMapping("/map")
     public ResponseEntity<MapDto> getFitness(@RequestParam(value = "page",defaultValue = "1") int page, @RequestParam double x, @RequestParam double y) {
         return ResponseEntity.ok(mapService.getLocationByFitness(page,x,y));

--- a/src/main/java/com/fithub/fithubbackend/domain/user/api/MapController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/api/MapController.java
@@ -1,0 +1,23 @@
+package com.fithub.fithubbackend.domain.user.api;
+
+import com.fithub.fithubbackend.domain.user.application.MapService;
+import com.fithub.fithubbackend.domain.user.dto.constants.MapDocumentDto;
+import com.fithub.fithubbackend.domain.user.dto.constants.MapDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class MapController {
+    private final MapService mapService;
+    @GetMapping("/map")
+    public ResponseEntity<MapDto> getFitness(@RequestParam(value = "page",defaultValue = "1") int page, @RequestParam double x, @RequestParam double y) {
+        return ResponseEntity.ok(mapService.getLocationByFitness(page,x,y));
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/EmailServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/EmailServiceImpl.java
@@ -40,6 +40,8 @@ public class EmailServiceImpl implements EmailService {
         mimeMessageHelper.setSubject(SUBJECT); // 메일 제목
         mimeMessageHelper.setText(emailDto.certificationNumberFormat(MESSAGE,certificationNumber), true); // 메일 본문 내용, HTML 여부
         javaMailSender.send(mimeMessage);
+        if(sentMail.containsKey(emailDto.getTo()))
+            sentMail.remove(emailDto.getTo());
         sentMail.put(emailDto.getTo(),certificationNumber);
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/MapService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/MapService.java
@@ -1,0 +1,9 @@
+package com.fithub.fithubbackend.domain.user.application;
+
+import com.fithub.fithubbackend.domain.user.dto.constants.MapDto;
+
+import java.util.List;
+
+public interface MapService {
+    MapDto getLocationByFitness(int page,double x, double y);
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/MapServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/MapServiceImpl.java
@@ -1,0 +1,56 @@
+package com.fithub.fithubbackend.domain.user.application;
+
+import com.fithub.fithubbackend.domain.user.dto.constants.MapDocumentDto;
+import com.fithub.fithubbackend.domain.user.dto.constants.MapDto;
+import com.fithub.fithubbackend.global.exception.CustomException;
+import com.fithub.fithubbackend.global.exception.ErrorCode;
+import com.fithub.fithubbackend.global.util.KakaoMapUtil;
+import lombok.RequiredArgsConstructor;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.springframework.stereotype.Service;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MapServiceImpl implements MapService{
+    private final KakaoMapUtil kakaoMapUtil;
+    @Override
+    public MapDto getLocationByFitness(int page, double x, double y) {
+        List<MapDocumentDto> documentList = new ArrayList<>();
+        boolean isEnd;
+        String fitness = kakaoMapUtil.getAddressByFitness(page,x,y);
+        try {
+            JSONParser jsonParser = new JSONParser();
+            JSONObject jsonObject = (JSONObject) jsonParser.parse(fitness);
+            JSONObject metaObject = (JSONObject) jsonObject.get("meta");
+            JSONArray documentsList = (JSONArray) jsonObject.get("documents");
+
+            isEnd = (boolean) metaObject.get("is_end");
+
+            for (Object documentsObject : documentsList) {
+                JSONObject documents = (JSONObject) documentsObject;
+                documentList.add(MapDocumentDto.builder()
+                        .addressName((String) documents.get("address_name"))
+                        .phone((String) documents.get("phone"))
+                        .placeName((String) documents.get("place_name"))
+                        .placeUrl((String) documents.get("place_url"))
+                        .roadAddressName((String) documents.get("road_address_name"))
+                        .x((String) documents.get("x"))
+                        .y((String) documents.get("y"))
+                        .build());
+                }
+
+        }catch(ParseException e){
+            throw new CustomException(ErrorCode.PARSING_ERROR,ErrorCode.PARSING_ERROR.getMessage());
+        }
+        MapDto result = MapDto.builder()
+                .mapDocumentDto(documentList)
+                .isEnd(isEnd)
+                .build();
+        return result;
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/user/dto/constants/MapDocumentDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/dto/constants/MapDocumentDto.java
@@ -1,0 +1,16 @@
+package com.fithub.fithubbackend.domain.user.dto.constants;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class MapDocumentDto {
+    private String addressName; // 전체 지번 주소
+    private String phone; // 전화번호
+    private String placeName; // 건물 이름
+    private String placeUrl; // 장소 url
+    private String roadAddressName; // 전체 도로명 주소
+    private String x; // x좌표
+    private String y; // y좌표
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/user/dto/constants/MapDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/dto/constants/MapDto.java
@@ -1,0 +1,13 @@
+package com.fithub.fithubbackend.domain.user.dto.constants;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class MapDto {
+    private List<MapDocumentDto> mapDocumentDto;
+    private boolean isEnd; // 마지막 페이지 여부
+}

--- a/src/main/java/com/fithub/fithubbackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/fithub/fithubbackend/global/exception/ErrorCode.java
@@ -25,7 +25,8 @@ public enum ErrorCode {
 
     FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
 
-    AUTHENTICATION_ERROR(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다.");
+    AUTHENTICATION_ERROR(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다."),
+    PARSING_ERROR(HttpStatus.BAD_GATEWAY,"파싱에 실패하였습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fithub/fithubbackend/global/util/KakaoMapUtil.java
+++ b/src/main/java/com/fithub/fithubbackend/global/util/KakaoMapUtil.java
@@ -1,0 +1,45 @@
+package com.fithub.fithubbackend.global.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoMapUtil {
+    private final RestTemplate restTemplate;
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String key;
+
+    public String getAddressByFitness(int page,double x, double y) {
+        URI uri = UriComponentsBuilder
+                .newInstance()
+                .scheme("https")
+                .host("dapi.kakao.com")
+                .path("/v2/local/search/keyword.json")
+                .queryParam("query", "헬스클럽")
+                .queryParam("page",page)
+                .queryParam("x",x)
+                .queryParam("y",y)
+                .encode()
+                .build()
+                .toUri();
+
+        RequestEntity requestEntity = RequestEntity
+                .get(uri)
+                .header("Authorization","KakaoAK " + key)
+                .build();
+        ResponseEntity<String> result = restTemplate.exchange(requestEntity, String.class);
+        return result.getBody();
+    }
+}


### PR DESCRIPTION
## pr 유형
- 기능 추가, 수정

## 반영 브랜치
- feature/map-> main

## 변경 사항
1. 인증번호 중복 발행 시 이전에 있던 인증번호 삭제
2. 위치를 입력받고 위치에 따른 주변 헬스장 조회

## 테스트 결과
![image](https://github.com/team-Fithub/fithub-backend/assets/66781422/d88d8f1f-7a9a-4b79-b7ce-555d53659719)

## 질문사항
- 카카오 Map을 사용했는데 카카오에서 조회시 최대 개수를 45개로 정해놔서 검색 결과 개수가 45개를 넘어가도 45개까지만 나옵니다. 좀 더 많은 결과를 보여주는 openApi가 있다면 바꾸는게 좋을까요?