### PR TITLE
feature/trainer: 트레이너 인증 요청 승인, 반려 기능 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/admin/api/AdminController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/admin/api/AdminController.java
@@ -1,0 +1,20 @@
+package com.fithub.fithubbackend.domain.admin.api;
+
+import com.fithub.fithubbackend.domain.admin.application.AdminService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @PutMapping("/trainer/certificate/accept")
+    private ResponseEntity<String> acceptTrainerCertificateRequest(@RequestParam Long requestId) {
+        adminService.acceptTrainerCertificateRequest(requestId);
+        return ResponseEntity.ok().body("완료");
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/admin/api/AdminController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/admin/api/AdminController.java
@@ -1,6 +1,9 @@
 package com.fithub.fithubbackend.domain.admin.api;
 
 import com.fithub.fithubbackend.domain.admin.application.AdminService;
+import com.fithub.fithubbackend.domain.admin.dto.CertRejectDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -12,9 +15,21 @@ public class AdminController {
 
     private final AdminService adminService;
 
+    @Operation(summary = "트레이너 인증 요청 승인", responses = {
+            @ApiResponse(responseCode = "200", description = "트레이너 인증 요청 승인 및 트레이너 생성 완료"),
+    })
     @PutMapping("/trainer/certificate/accept")
     private ResponseEntity<String> acceptTrainerCertificateRequest(@RequestParam Long requestId) {
         adminService.acceptTrainerCertificateRequest(requestId);
+        return ResponseEntity.ok().body("완료");
+    }
+
+    @Operation(summary = "트레이너 인증 요청 반려", responses = {
+            @ApiResponse(responseCode = "200", description = "트레이너 인증 요청 반려"),
+    })
+    @PutMapping("/trainer/certificate/reject")
+    private ResponseEntity<String> rejectTrainerCertificateRequest(@RequestParam Long requestId, @RequestBody CertRejectDto dto) {
+        adminService.rejectTrainerCertificateRequest(requestId, dto);
         return ResponseEntity.ok().body("완료");
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/admin/application/AdminService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/admin/application/AdminService.java
@@ -1,5 +1,8 @@
 package com.fithub.fithubbackend.domain.admin.application;
 
+import com.fithub.fithubbackend.domain.admin.dto.CertRejectDto;
+
 public interface AdminService {
     void acceptTrainerCertificateRequest(Long requestId);
+    void rejectTrainerCertificateRequest(Long requestId, CertRejectDto dto);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/admin/application/AdminService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/admin/application/AdminService.java
@@ -1,0 +1,5 @@
+package com.fithub.fithubbackend.domain.admin.application;
+
+public interface AdminService {
+    void acceptTrainerCertificateRequest(Long requestId);
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/admin/application/AdminServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/admin/application/AdminServiceImpl.java
@@ -1,0 +1,54 @@
+package com.fithub.fithubbackend.domain.admin.application;
+
+import com.fithub.fithubbackend.domain.trainer.domain.Trainer;
+import com.fithub.fithubbackend.domain.trainer.domain.TrainerCareer;
+import com.fithub.fithubbackend.domain.trainer.domain.TrainerCertificationRequest;
+import com.fithub.fithubbackend.domain.trainer.domain.TrainerLicenseImg;
+import com.fithub.fithubbackend.domain.trainer.repository.TrainerCertificationRequestRepository;
+import com.fithub.fithubbackend.domain.trainer.repository.TrainerRepository;
+import com.fithub.fithubbackend.global.exception.CustomException;
+import com.fithub.fithubbackend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminServiceImpl implements AdminService {
+    private final TrainerCertificationRequestRepository trainerCertificationRequestRepository;
+    private final TrainerRepository trainerRepository;
+
+    @Override
+    @Transactional
+    public void acceptTrainerCertificateRequest(Long requestId) {
+        TrainerCertificationRequest trainerCertificationRequest = trainerCertificationRequestRepository.findById(requestId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "트레이너 인증 요청을 찾을 수 없습니다."));
+        Trainer trainer = Trainer.builder()
+                .user(trainerCertificationRequest.getUser())
+                .build();
+
+        List<TrainerCareer> trainerCareerList = trainerCertificationRequest.getCareerTempList().stream().map(c -> TrainerCareer.builder()
+                        .trainer(trainer)
+                        .trainerCareerTemp(c)
+                        .build())
+                .toList();
+
+        List<TrainerLicenseImg> trainerLicenseImgList = trainerCertificationRequest.getLicenseTempImgList().stream().map(img -> TrainerLicenseImg.builder()
+                        .trainer(trainer)
+                        .document(img.getDocument())
+                        .build())
+                .toList();
+
+        trainer.updateCareerList(trainerCareerList);
+        trainer.updateTrainerLicenseImg(trainerLicenseImgList);
+
+        TrainerCareer career = trainerCareerList.stream().filter(TrainerCareer::isWorking).findFirst().orElseGet(null);
+        if (career != null) {
+            trainer.updateLocation(career.getCompany());
+        }
+
+        trainerRepository.save(trainer);
+        trainerCertificationRequestRepository.delete(trainerCertificationRequest);
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/admin/application/AdminServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/admin/application/AdminServiceImpl.java
@@ -1,5 +1,8 @@
 package com.fithub.fithubbackend.domain.admin.application;
 
+import com.fithub.fithubbackend.domain.admin.domain.TrainerCertificationRejectLog;
+import com.fithub.fithubbackend.domain.admin.dto.CertRejectDto;
+import com.fithub.fithubbackend.domain.admin.repository.TrainerCertificationRejectLogRepository;
 import com.fithub.fithubbackend.domain.trainer.domain.Trainer;
 import com.fithub.fithubbackend.domain.trainer.domain.TrainerCareer;
 import com.fithub.fithubbackend.domain.trainer.domain.TrainerCertificationRequest;
@@ -20,8 +23,11 @@ public class AdminServiceImpl implements AdminService {
     private final TrainerCertificationRequestRepository trainerCertificationRequestRepository;
     private final TrainerRepository trainerRepository;
 
+    private final TrainerCertificationRejectLogRepository rejectLogRepository;
+
     @Override
     @Transactional
+    // TODO: 승인됐다는 알림 보내기?
     public void acceptTrainerCertificateRequest(Long requestId) {
         TrainerCertificationRequest trainerCertificationRequest = trainerCertificationRequestRepository.findById(requestId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "트레이너 인증 요청을 찾을 수 없습니다."));
         Trainer trainer = Trainer.builder()
@@ -50,5 +56,19 @@ public class AdminServiceImpl implements AdminService {
 
         trainerRepository.save(trainer);
         trainerCertificationRequestRepository.delete(trainerCertificationRequest);
+    }
+
+    @Override
+    @Transactional
+    // TODO: 반려됐다는 알림 보내기?
+    public void rejectTrainerCertificateRequest(Long requestId, CertRejectDto dto) {
+        TrainerCertificationRequest trainerCertificationRequest = trainerCertificationRequestRepository.findById(requestId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "트레이너 인증 요청을 찾을 수 없습니다."));
+        trainerCertificationRequest.requestReject();
+
+        TrainerCertificationRejectLog rejectLog = TrainerCertificationRejectLog.builder()
+                .trainerCertificationRequest(trainerCertificationRequest)
+                .dto(dto)
+                .build();
+        rejectLogRepository.save(rejectLog);
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/admin/domain/TrainerCertificationRejectLog.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/admin/domain/TrainerCertificationRejectLog.java
@@ -1,0 +1,38 @@
+package com.fithub.fithubbackend.domain.admin.domain;
+
+import com.fithub.fithubbackend.domain.admin.dto.CertRejectDto;
+import com.fithub.fithubbackend.domain.admin.enums.RejectType;
+import com.fithub.fithubbackend.domain.trainer.domain.TrainerCertificationRequest;
+import com.fithub.fithubbackend.global.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrainerCertificationRejectLog extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(optional = false, cascade = CascadeType.REMOVE)
+    private TrainerCertificationRequest trainerCertificationRequest;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    private RejectType rejectType;
+
+    private String reason;
+
+    @Builder
+    public TrainerCertificationRejectLog(TrainerCertificationRequest trainerCertificationRequest, CertRejectDto dto) {
+        this.trainerCertificationRequest = trainerCertificationRequest;
+        this.rejectType = dto.getRejectType();
+        this.reason = dto.getReason() != null ? dto.getReason() : null;
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/admin/dto/CertRejectDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/admin/dto/CertRejectDto.java
@@ -1,0 +1,19 @@
+package com.fithub.fithubbackend.domain.admin.dto;
+
+import com.fithub.fithubbackend.domain.admin.enums.RejectType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Schema(description = "트레이너 인증 요청을 거절하는 이유")
+public class CertRejectDto {
+    @NotNull
+    @Schema(description = "거절 타입")
+    private RejectType rejectType;
+    
+    @Schema(description = "거절하는 상세한 설명이 필요하다면 작성")
+    private String reason;
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/admin/enums/RejectType.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/admin/enums/RejectType.java
@@ -1,0 +1,7 @@
+package com.fithub.fithubbackend.domain.admin.enums;
+
+public enum RejectType {
+    INVALID_CERTIFICATE,
+    UNPROVABLE_CAREER
+
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/admin/repository/TrainerCertificationRejectLogRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/admin/repository/TrainerCertificationRejectLogRepository.java
@@ -1,0 +1,7 @@
+package com.fithub.fithubbackend.domain.admin.repository;
+
+import com.fithub.fithubbackend.domain.admin.domain.TrainerCertificationRejectLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TrainerCertificationRejectLogRepository extends JpaRepository<TrainerCertificationRejectLog, Long> {
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerAuthServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerAuthServiceImpl.java
@@ -37,8 +37,8 @@ public class TrainerAuthServiceImpl implements TrainerAuthService {
             throw new CustomException(ErrorCode.DUPLICATE, "트레이너 인증이 완료된 회원입니다.");
         }
 
-        if (trainerCertificationRequestRepository.existsByUserId(user.getId())) {
-            throw new CustomException(ErrorCode.DUPLICATE, "완료되지 않은 트레이너 인증 요청이 존재하는 회원입니다.");
+        if (trainerCertificationRequestRepository.existsByRejectedFalseAndUserId(user.getId())) {
+            throw new CustomException(ErrorCode.DUPLICATE, "반려되지 않은 트레이너 인증 요청이 존재하는 회원입니다.");
         }
 
         TrainerCertificationRequest trainerCertificationRequest = TrainerCertificationRequest.builder()

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/Trainer.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/Trainer.java
@@ -10,6 +10,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import java.util.List;
 
 @Entity
 @Getter
@@ -27,13 +30,30 @@ public class Trainer extends BaseTimeEntity {
     @Size(min = 2)
     private String name;
 
-    @NotNull
+    @Comment("현재 일하는 장소")
     private String location;
 
+    @OneToMany(mappedBy = "trainer", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<TrainerCareer> trainerCareerList;
+
+    @OneToMany(mappedBy = "trainer", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<TrainerLicenseImg> trainerLicenseImgList;
+
     @Builder
-    public Trainer(User user, String location) {
+    public Trainer(User user) {
         this.user = user;
         this.name = user.getName();
+    }
+
+    public void updateLocation(String location) {
         this.location = location;
+    }
+    
+    public void updateCareerList(List<TrainerCareer> trainerCareerList) {
+        this.trainerCareerList = trainerCareerList;
+    }
+
+    public void updateTrainerLicenseImg(List<TrainerLicenseImg> trainerLicenseImgList) {
+        this.trainerLicenseImgList = trainerLicenseImgList;
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCareer.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCareer.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
@@ -36,4 +37,14 @@ public class TrainerCareer {
     @ColumnDefault("false")
     @NotNull
     private boolean working;
+
+    @Builder
+    public TrainerCareer(Trainer trainer, TrainerCareerTemp trainerCareerTemp) {
+        this.trainer = trainer;
+        this.company = trainerCareerTemp.getCompany();
+        this.work = trainerCareerTemp.getWork();
+        this.startDate = trainerCareerTemp.getStartDate();
+        this.endDate = trainerCareerTemp.getEndDate();
+        this.working = trainerCareerTemp.isWorking();
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCareer.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCareer.java
@@ -1,5 +1,6 @@
 package com.fithub.fithubbackend.domain.trainer.domain;
 
+import com.fithub.fithubbackend.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -14,7 +15,7 @@ import java.time.LocalDate;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class TrainerCareer {
+public class TrainerCareer extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCareerTemp.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCareerTemp.java
@@ -1,6 +1,7 @@
 package com.fithub.fithubbackend.domain.trainer.domain;
 
 import com.fithub.fithubbackend.domain.trainer.dto.TrainerCareerRequestDto;
+import com.fithub.fithubbackend.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -15,7 +16,7 @@ import java.time.LocalDate;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class TrainerCareerTemp {
+public class TrainerCareerTemp extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCertificationRequest.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCertificationRequest.java
@@ -1,6 +1,7 @@
 package com.fithub.fithubbackend.domain.trainer.domain;
 
 import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -8,6 +9,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,7 +17,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class TrainerCertificationRequest {
+public class TrainerCertificationRequest extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -33,11 +35,19 @@ public class TrainerCertificationRequest {
     @OneToMany(mappedBy = "trainerCertificationRequest", cascade = CascadeType.ALL)
     private List<TrainerCareerTemp> careerTempList;
 
+    @NotNull
+    @ColumnDefault("false")
+    private boolean rejected;
+
     @Builder
     public TrainerCertificationRequest(User user, String licenseNames) {
         this.user = user;
         this.licenseNames = licenseNames;
         this.licenseTempImgList = new ArrayList<>();
         this.careerTempList = new ArrayList<>();
+    }
+
+    public void requestReject() {
+        this.rejected = true;
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerLicenseImg.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerLicenseImg.java
@@ -1,5 +1,6 @@
 package com.fithub.fithubbackend.domain.trainer.domain;
 
+import com.fithub.fithubbackend.global.common.BaseTimeEntity;
 import com.fithub.fithubbackend.global.domain.Document;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -10,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class TrainerLicenseImg {
+public class TrainerLicenseImg extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerLicenseImg.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerLicenseImg.java
@@ -3,6 +3,7 @@ package com.fithub.fithubbackend.domain.trainer.domain;
 import com.fithub.fithubbackend.global.domain.Document;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,4 +21,10 @@ public class TrainerLicenseImg {
 
     @OneToOne(optional = false, cascade = CascadeType.ALL)
     private Document document;
+
+    @Builder
+    public TrainerLicenseImg(Trainer trainer, Document document) {
+        this.trainer = trainer;
+        this.document = document;
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerLicenseTempImg.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerLicenseTempImg.java
@@ -1,5 +1,6 @@
 package com.fithub.fithubbackend.domain.trainer.domain;
 
+import com.fithub.fithubbackend.global.common.BaseTimeEntity;
 import com.fithub.fithubbackend.global.domain.Document;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -10,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class TrainerLicenseTempImg {
+public class TrainerLicenseTempImg extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/repository/TrainerCertificationRequestRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/repository/TrainerCertificationRequestRepository.java
@@ -4,5 +4,5 @@ import com.fithub.fithubbackend.domain.trainer.domain.TrainerCertificationReques
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TrainerCertificationRequestRepository extends JpaRepository<TrainerCertificationRequest, Long> {
-    boolean existsByUserId(Long userId);
+    boolean existsByRejectedFalseAndUserId(Long userId);
 }


### PR DESCRIPTION
## pr 유형
- 기능 추가

## 반영 브랜치
- feature/trainer -> main

## 변경 사항
- 트레이너 엔티티에 경력, 자격증 사진 리스트 추가
- 트레이너 인증 요청 엔티티에 반려 여부 추가
- 트레이너 인증 요청 반려 기록 엔티티 추가
- 트레이너 인증 요청 승인, 반려 기능 추가
- 트레이너 인증 요청 시 인증 요청이 있는지 검사 -> 반려되지 않은 인증 요청이 있는지 검사로 변경 (반려된 인증 요청는 경우에는 신청 가능)

## 테스트 결과
1. 승인
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/49ece85d-c39f-43fb-81b9-ce5bd20a5535)
트레이너, 트레이너 자격증 사진, 트레이너 경력사항 엔티티에 추가 됨

2. 반려
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/b4f0b47a-82ab-42eb-86cc-1c2826265ca1)
트레이너 인증 요청 반려 기록에 추가
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/92b6b5bd-044d-462d-9143-15f624aadc1d)
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/651d9e6d-a8c5-4721-a0e3-c51fae022437)
rejected를 true로 설정

## 추후 필요한 작업
- 승인, 반려 시 회원에게 알림
- 반려된 내용을 어드민이 볼 수 있도록 (다른 작업 다 하고 나서 진행할듯)
