### PR TITLE
update: 게시글 관련 entity 양방향 연관 관계로 수정, 해시태그 업데이트 기능 수정

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/BookmarkServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/BookmarkServiceImpl.java
@@ -29,13 +29,16 @@ public class BookmarkServiceImpl implements BookmarkService {
         if (bookmark.isPresent())
             throw new CustomException(ErrorCode.DUPLICATE, "이미 북마크한 게시글입니다.");
 
-        bookmarkRepository.save(new Bookmark(user, post));
+        post.addBookmark(new Bookmark(user, post));
     }
 
     @Override
     @Transactional
     public void deleteBookmark(User user, Post post) {
-        bookmarkRepository.deleteByUserAndPost(user, post);
+        Optional<Bookmark> bookmark = bookmarkRepository.findByUserAndPost(user, post);
+
+        if (bookmark.isPresent())
+            post.getBookmarks().remove(bookmark.get());
     }
 
 

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/LikesServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/LikesServiceImpl.java
@@ -26,13 +26,15 @@ public class LikesServiceImpl implements LikesService {
         if (likes.isPresent())
             throw new CustomException(ErrorCode.DUPLICATE, "이미 좋아요한 게시글입니다.");
 
-        likesRepository.save(new Likes(user, post));
+        post.addLikes(new Likes(user, post));
     }
 
     @Override
     @Transactional
     public void deleteLikes(User user, Post post) {
-        likesRepository.deleteByUserAndPost(user, post);
+        Optional<Likes> likes = likesRepository.findByUserAndPost(user, post);
+        if (likes.isPresent())
+            post.getLikes().remove(likes.get());
     }
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostDocumentServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostDocumentServiceImpl.java
@@ -15,11 +15,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -41,7 +38,7 @@ public class PostDocumentServiceImpl implements PostDocumentService {
                 .post(post)
                 .size(image.getSize()).build();
 
-        postDocumentRepository.save(postDocument);
+        post.addPostDocument(postDocument);
     }
 
     @Override
@@ -59,8 +56,9 @@ public class PostDocumentServiceImpl implements PostDocumentService {
 
         if (needToDelete != null && !needToDelete.isEmpty()) {
             needToDelete.forEach(imageUrl -> {
-                awsS3Uploader.deleteS3(postDocumentRepository.findByUrl(imageUrl).getPath());
-                postDocumentRepository.deleteByUrl(imageUrl);
+                PostDocument postDocument = postDocumentRepository.findByUrl(imageUrl);
+                awsS3Uploader.deleteS3(postDocument.getPath());
+                post.getPostDocuments().remove(postDocument);
             });
         }
 
@@ -74,7 +72,6 @@ public class PostDocumentServiceImpl implements PostDocumentService {
         extractMultipartFile.forEach(
                 image -> {
                     try {
-                        System.out.println(image.getOriginalFilename());
                         createDocument(image, post);
                     } catch (IOException e) {
                         throw new CustomException(ErrorCode.FILE_UPLOAD_ERROR);

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostHashtagServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostHashtagServiceImpl.java
@@ -2,6 +2,7 @@ package com.fithub.fithubbackend.domain.board.application;
 
 import com.fithub.fithubbackend.domain.board.post.domain.Post;
 import com.fithub.fithubbackend.domain.board.post.domain.PostHashtag;
+import com.fithub.fithubbackend.domain.board.repository.HashtagRepository;
 import com.fithub.fithubbackend.domain.board.repository.PostHashtagRepository;
 import com.fithub.fithubbackend.global.domain.Hashtag;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ public class PostHashtagServiceImpl implements PostHashtagService {
 
     private final PostHashtagRepository postHashtagRepository;
     private final HashtagService hashtagService;
+    private final HashtagRepository hashtagRepository;
 
     @Override
     @Transactional
@@ -35,15 +37,75 @@ public class PostHashtagServiceImpl implements PostHashtagService {
     @Transactional
     public void updateHashtag(String hashTagContentStr, Post post) {
 
+        /* 해시태그 업데이트
+        * 1. DB에 저장된 postHashtag 삭제 후 업데이트된 해시태그 저장
+        * */
+//        List<String> oldHashTags = postHashtagRepository.findHashtagByPostId(post.getId());
+//
+//        List<String> newHashTags = extractHashTags(hashTagContentStr);
+//
+//        if (oldHashTags.equals(newHashTags))
+//            return;
+//
+//        post.getPostHashtags().clear();
+//        newHashTags.forEach(hashTagContent -> savePostHashtag(hashTagContent, post));
+
+        /* 해시태그 업데이트
+         * 2. 기존 해시태그 리스트의 hashtag fk 업데이트
+         * */
+
+        // DB에 저장된 PostHashtags 리스트
+        List<PostHashtag> dbPostHashtags = postHashtagRepository.findByPostFetch(post.getId());
+
+        // 문자열 형태의 기존 DB에 저장된 해시태그 리스트
         List<String> oldHashTags = postHashtagRepository.findHashtagByPostId(post.getId());
 
-        List<String> newHashTags = extractHashTags(hashTagContentStr);
+        // 문자열 형태의 새로운 해시태그 리스트
+        List<String> newHashtags = extractHashTags(hashTagContentStr);
 
-        if (oldHashTags.equals(newHashTags))
+        if (oldHashTags.equals(newHashtags))
             return;
 
-        post.getPostHashtags().clear();
-        newHashTags.forEach(hashTagContent -> savePostHashtag(hashTagContent, post));
+        int i, j;
+        for (i = 0; i < newHashtags.size(); i++ ) {
+
+            String newHashtagContent = newHashtags.get(i);
+            Optional<Hashtag> hashtag = hashtagRepository.findByContent(newHashtagContent);
+
+            if (i < oldHashTags.size()) {
+                if (!newHashtagContent.equals(oldHashTags.get(i))) {
+                    PostHashtag dbPostHashtag = dbPostHashtags.get(i);
+
+                    hashtag.ifPresentOrElse(
+                            h -> dbPostHashtag.setHashtag(h),
+                            () -> {
+                                Hashtag newHashtag = new Hashtag(newHashtagContent);
+                                hashtagRepository.save(newHashtag);
+                                dbPostHashtag.setHashtag(newHashtag);
+                            }
+                    );
+                }
+            }
+            else {
+                String addHashtagContent = newHashtags.get(i);
+
+                hashtag.ifPresentOrElse(
+                        h -> post.addPostHashtag(new PostHashtag(post, hashtag.get())),
+                        () -> {
+                            Hashtag addHashtag = new Hashtag(addHashtagContent);
+                            hashtagRepository.save(addHashtag);
+                            post.addPostHashtag(new PostHashtag(post, addHashtag));
+                        }
+                );
+            }
+        }
+
+        if (newHashtags.size() < oldHashTags.size()) {
+            for (j = i; j < oldHashTags.size(); j++) {
+                post.getPostHashtags().remove(dbPostHashtags.get(j));
+            }
+        }
+
     }
 
     public List<String> extractHashTags(String hashTagContentStr) {

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostHashtagServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostHashtagServiceImpl.java
@@ -37,23 +37,6 @@ public class PostHashtagServiceImpl implements PostHashtagService {
     @Transactional
     public void updateHashtag(String hashTagContentStr, Post post) {
 
-        /* 해시태그 업데이트
-        * 1. DB에 저장된 postHashtag 삭제 후 업데이트된 해시태그 저장
-        * */
-//        List<String> oldHashTags = postHashtagRepository.findHashtagByPostId(post.getId());
-//
-//        List<String> newHashTags = extractHashTags(hashTagContentStr);
-//
-//        if (oldHashTags.equals(newHashTags))
-//            return;
-//
-//        post.getPostHashtags().clear();
-//        newHashTags.forEach(hashTagContent -> savePostHashtag(hashTagContent, post));
-
-        /* 해시태그 업데이트
-         * 2. 기존 해시태그 리스트의 hashtag fk 업데이트
-         * */
-
         // DB에 저장된 PostHashtags 리스트
         List<PostHashtag> dbPostHashtags = postHashtagRepository.findByPostFetch(post.getId());
 

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostService.java
@@ -4,7 +4,6 @@ import com.fithub.fithubbackend.domain.board.dto.PostCreateDto;
 import com.fithub.fithubbackend.domain.board.dto.PostUpdateDto;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import java.io.IOException;
 
 public interface PostService {
     void createPost(PostCreateDto postCreateDto, UserDetails userDetails);

--- a/src/main/java/com/fithub/fithubbackend/domain/board/post/domain/Bookmark.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/post/domain/Bookmark.java
@@ -1,5 +1,6 @@
 package com.fithub.fithubbackend.domain.board.post.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
@@ -7,8 +8,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -25,12 +24,16 @@ public class Bookmark extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "post_id")
-    @OnDelete(action= OnDeleteAction.CASCADE)
+    @JsonIgnore
     private Post post;
 
     @Builder
     public Bookmark (User user, Post post) {
         this.user = user;
+        this.post = post;
+    }
+
+    public void setPost(Post post) {
         this.post = post;
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/board/post/domain/Likes.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/post/domain/Likes.java
@@ -1,5 +1,6 @@
 package com.fithub.fithubbackend.domain.board.post.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
@@ -7,8 +8,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -25,12 +24,16 @@ public class Likes extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "post_id")
-    @OnDelete(action= OnDeleteAction.CASCADE)
+    @JsonIgnore
     private Post post;
 
     @Builder
     public Likes(User user, Post post) {
         this.user = user;
+        this.post = post;
+    }
+
+    public void setPost(Post post) {
         this.post = post;
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/board/post/domain/Post.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/post/domain/Post.java
@@ -1,5 +1,6 @@
 package com.fithub.fithubbackend.domain.board.post.domain;
 
+import com.fithub.fithubbackend.domain.board.comment.domain.Comment;
 import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
@@ -9,7 +10,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.BatchSize;
+
+import java.util.*;
 
 @Entity
 @Getter
@@ -25,9 +28,27 @@ public class Post extends BaseTimeEntity {
     @NotNull
     private Integer views;
 
-    @Comment("게시글 작성자")
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     private User user;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
+
+    @BatchSize(size = 100)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    private List<Bookmark> bookmarks = new ArrayList<>();
+
+    @BatchSize(size = 100)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    private List<Likes> likes = new ArrayList<>();
+
+    @BatchSize(size = 100)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    private List<PostHashtag> postHashtags = new ArrayList<>();
+
+    @BatchSize(size = 100)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    private List<PostDocument> postDocuments = new ArrayList<>();
 
     public void setUser(User user) {
         this.user = user;
@@ -43,5 +64,34 @@ public class Post extends BaseTimeEntity {
     public void updatePost(String content) {
         this.content = content;
     }
+
+    public void addPostHashtag(PostHashtag postHashtag) {
+        this.postHashtags.add(postHashtag);
+
+        if (postHashtag.getPost() != this)
+            postHashtag.setPost(this);
+    }
+
+    public void addPostDocument(PostDocument postDocument) {
+        this.postDocuments.add(postDocument);
+
+        if (postDocument.getPost() != this)
+            postDocument.setPost(this);
+    }
+
+    public void addBookmark(Bookmark bookmark) {
+        this.bookmarks.add(bookmark);
+
+        if (bookmark.getPost() != this)
+            bookmark.setPost(this);
+    }
+
+    public void addLikes(Likes likes) {
+        this.likes.add(likes);
+
+        if (likes.getPost() != this)
+            likes.setPost(this);
+    }
+
 
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/post/domain/PostDocument.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/post/domain/PostDocument.java
@@ -7,8 +7,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -34,7 +32,6 @@ public class PostDocument {
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "post_id")
-    @OnDelete(action= OnDeleteAction.CASCADE)
     private Post post;
 
     @Builder
@@ -44,5 +41,9 @@ public class PostDocument {
         this.path = path;
         this.post = post;
         this.size = size;
+    }
+
+    public void setPost(Post post) {
+        this.post = post;
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/post/domain/PostHashtag.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/post/domain/PostHashtag.java
@@ -7,8 +7,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -21,7 +19,6 @@ public class PostHashtag {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @OnDelete(action= OnDeleteAction.CASCADE)
     private Post post;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
@@ -31,5 +28,9 @@ public class PostHashtag {
     public PostHashtag(Post post, Hashtag hashtag){
         this.post = post;
         this.hashtag = hashtag;
+    }
+
+    public void setPost(Post post) {
+        this.post = post;
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/post/domain/PostHashtag.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/post/domain/PostHashtag.java
@@ -33,4 +33,8 @@ public class PostHashtag {
     public void setPost(Post post) {
         this.post = post;
     }
+
+    public void setHashtag(Hashtag hashtag) {
+        this.hashtag = hashtag;
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/repository/PostHashtagRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/repository/PostHashtagRepository.java
@@ -1,5 +1,6 @@
 package com.fithub.fithubbackend.domain.board.repository;
 
+import com.fithub.fithubbackend.domain.board.post.domain.Post;
 import com.fithub.fithubbackend.domain.board.post.domain.PostHashtag;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,4 +12,8 @@ public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long> 
 
     @Query(value = "SELECT h.content FROM PostHashtag p JOIN Hashtag h ON p.hashtag = h WHERE p.post.id = :postId order by p.id")
     List<String> findHashtagByPostId(@Param("postId") Long postId);
+
+    @Query(value = "SELECT ph FROM PostHashtag ph LEFT JOIN FETCH ph.hashtag WHERE ph.post.id = :postId")
+    List<PostHashtag> findByPostFetch(@Param("postId") Long postId);
+
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/repository/PostHashtagRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/repository/PostHashtagRepository.java
@@ -1,8 +1,6 @@
 package com.fithub.fithubbackend.domain.board.repository;
 
-import com.fithub.fithubbackend.domain.board.post.domain.Post;
 import com.fithub.fithubbackend.domain.board.post.domain.PostHashtag;
-import com.fithub.fithubbackend.global.domain.Hashtag;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,10 +9,6 @@ import java.util.*;
 
 public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long> {
 
-    List<PostHashtag> findByPost(Post post);
-
-    Optional<PostHashtag> findByPostAndHashtag(Post post, Hashtag hashtag);
-
-    @Query(value = "SELECT h.content FROM PostHashtag p JOIN Hashtag h ON p.hashtag = h WHERE p.post.id = :postId")
+    @Query(value = "SELECT h.content FROM PostHashtag p JOIN Hashtag h ON p.hashtag = h WHERE p.post.id = :postId order by p.id")
     List<String> findHashtagByPostId(@Param("postId") Long postId);
 }


### PR DESCRIPTION
## PR 유형
- 기능 수정

## 반영 브랜치
- feature/post-> main

## 변경 사항
- 게시글 조회 위해 관련 entity(이미지, 해시태그, 북마크, 좋아요) 양방향 연관 관계로 수정 
- 해시태그  업데이트 기능 수정

## 이슈
- 기존 코드에서 게시글 해시태그 수정한 후, 게시글 정보를 불러올 때 유저가 수정한 순서대로 불러오지 않는 문제 발생
   - 기존 해시태그와 수정된 해시태그를 비교하고, 다르다면 기존 해시태그들을 삭제 후 새로 생성하도록 수정 
   -> **변경 사항이 거의 없을 경우 비효율적이라 사용 X**
   - post의 content에 내용과 해시태그 같이 저장 
   -> **해시태그 테이블을 쓰는 의미가 없어 사용 X**
   - 기존 포스트 해시태그의 해시태그 fk 수정 및 추가하는 방식으로 수정

## 테스트 결과

> 해시태그 수정 전

![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/eece1fb2-a0d3-437a-8adf-c35345ce5a48)

> 해시태그 수정 후

![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/0aa59a23-2f52-48b2-b5b8-b679df94ea10)


   