### PR TITLE
Feat/training: 예약(결제) 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven { url 'https://jitpack.io' }
 }
 
 dependencies {
@@ -35,7 +36,7 @@ dependencies {
 
 	// email
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
-  
+
 	// jwt
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	implementation 'javax.xml.bind:jaxb-api:2.3.1'
@@ -54,6 +55,9 @@ dependencies {
 
 	// json parsing
 	implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
+
+	// portone (결제 api)
+	implementation 'com.github.iamport:iamport-rest-client-java:0.2.23'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/PaymentController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/PaymentController.java
@@ -1,0 +1,46 @@
+package com.fithub.fithubbackend.domain.Training.api;
+
+import com.fithub.fithubbackend.domain.Training.application.PaymentService;
+import com.fithub.fithubbackend.domain.Training.dto.CancelReqDto;
+import com.fithub.fithubbackend.domain.Training.dto.PaymentReqDto;
+import com.fithub.fithubbackend.domain.Training.dto.PaymentResDto;
+import com.fithub.fithubbackend.domain.Training.dto.ReserveReqDto;
+import com.siot.IamportRestClient.exception.IamportResponseException;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/payment")
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    @PostMapping("/validation")
+    public ResponseEntity<PaymentResDto> validate(@RequestBody @Valid PaymentReqDto dto) throws IamportResponseException, IOException {
+        return ResponseEntity.ok(paymentService.validate(dto));
+    }
+
+    @PostMapping("/order")
+    //TODO: 예약 완료 후 찜에 있는 트레이닝이면 삭제할거냐고 물어보는게 좋을수도
+    public ResponseEntity<String> reserveComplete(@RequestBody @Valid ReserveReqDto dto, @AuthenticationPrincipal UserDetails userDetails) {
+        paymentService.reserveComplete(dto, userDetails.getUsername());
+        return ResponseEntity.ok().body("완료");
+    }
+
+    @PostMapping("/cancel")
+    public ResponseEntity<String> cancelPayment(@RequestBody @Valid CancelReqDto dto, @AuthenticationPrincipal UserDetails userDetails) throws IamportResponseException, IOException {
+        paymentService.cancelPayment(dto, userDetails.getUsername());
+        return ResponseEntity.ok().body("완료");
+    }
+
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/PaymentService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/PaymentService.java
@@ -1,5 +1,6 @@
 package com.fithub.fithubbackend.domain.Training.application;
 
+import com.fithub.fithubbackend.domain.Training.dto.CancelReqDto;
 import com.fithub.fithubbackend.domain.Training.dto.PaymentReqDto;
 import com.fithub.fithubbackend.domain.Training.dto.PaymentResDto;
 import com.fithub.fithubbackend.domain.Training.dto.ReserveReqDto;
@@ -10,4 +11,5 @@ import java.io.IOException;
 public interface PaymentService {
     PaymentResDto validate(PaymentReqDto dto) throws IamportResponseException, IOException;
     void reserveComplete(ReserveReqDto dto, String email);
+    void cancelPayment(CancelReqDto dto, String email) throws IamportResponseException, IOException;
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/PaymentService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/PaymentService.java
@@ -1,0 +1,13 @@
+package com.fithub.fithubbackend.domain.Training.application;
+
+import com.fithub.fithubbackend.domain.Training.dto.PaymentReqDto;
+import com.fithub.fithubbackend.domain.Training.dto.PaymentResDto;
+import com.fithub.fithubbackend.domain.Training.dto.ReserveReqDto;
+import com.siot.IamportRestClient.exception.IamportResponseException;
+
+import java.io.IOException;
+
+public interface PaymentService {
+    PaymentResDto validate(PaymentReqDto dto) throws IamportResponseException, IOException;
+    void reserveComplete(ReserveReqDto dto, String email);
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/PaymentServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/PaymentServiceImpl.java
@@ -1,0 +1,93 @@
+package com.fithub.fithubbackend.domain.Training.application;
+
+import com.fithub.fithubbackend.domain.Training.domain.ReserveInfo;
+import com.fithub.fithubbackend.domain.Training.domain.Training;
+import com.fithub.fithubbackend.domain.Training.dto.PaymentReqDto;
+import com.fithub.fithubbackend.domain.Training.dto.PaymentResDto;
+import com.fithub.fithubbackend.domain.Training.dto.ReserveReqDto;
+import com.fithub.fithubbackend.domain.Training.repository.ReserveInfoRepository;
+import com.fithub.fithubbackend.domain.Training.repository.TrainingRepository;
+import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.domain.user.repository.UserRepository;
+import com.fithub.fithubbackend.global.exception.CustomException;
+import com.fithub.fithubbackend.global.exception.ErrorCode;
+import com.siot.IamportRestClient.IamportClient;
+import com.siot.IamportRestClient.exception.IamportResponseException;
+import com.siot.IamportRestClient.request.CancelData;
+import com.siot.IamportRestClient.response.Payment;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentServiceImpl implements PaymentService {
+    private IamportClient iamportClient;
+
+    private final TrainingRepository trainingRepository;
+    private final UserRepository userRepository;
+    private final ReserveInfoRepository reserveInfoRepository;
+
+    @Value("${imp.api.key}")
+    private String apiKey;
+
+    @Value("${imp.api.secretkey}")
+    private String secretKey;
+
+    @PostConstruct
+    public void init() {
+        this.iamportClient = new IamportClient(apiKey, secretKey);
+    }
+
+
+    @Override
+    @Transactional(readOnly = true)
+    public PaymentResDto validate(PaymentReqDto dto) throws IamportResponseException, IOException {
+        Training training = trainingRepository.findById(dto.getTrainingId()).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 트레이닝입니다."));
+
+        Payment response = iamportClient.paymentByImpUid(dto.getImpUid()).getResponse();
+        int paidAmount = response.getAmount().intValue();
+
+        // 결제한 금액과 트레이닝 가격이 다르다면 결제 취소
+        if (training.getPrice() != paidAmount) {
+            log.error("결제 금액 상이: 결제 금액 - {}, 트레이닝 금액 - {}", paidAmount, training.getPrice());
+            iamportClient.cancelPaymentByImpUid(createCancelData(response));
+            throw new CustomException(ErrorCode.IAMPORT_PRICE_ERROR);
+        }
+
+        log.info("결제 내역 - 구매 번호: {}", response.getMerchantUid());
+        return PaymentResDto.builder()
+                .impUid(response.getImpUid())
+                .merchantUid(response.getMerchantUid())
+                .payMethod(response.getPayMethod())
+                .amount(response.getAmount().intValue())
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public void reserveComplete(ReserveReqDto dto, String email) {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 회원입니다."));
+        Training training = trainingRepository.findById(dto.getTrainingId()).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 트레이닝입니다."));
+
+        ReserveInfo reserveInfo = ReserveInfo.builder().dto(dto).user(user).training(training).build();
+
+        if (!training.removeAvailableDateTime(dto.getReserveDateTime())) {
+            log.error("예약 완료 실패 - 예약 가능한 시간대가 없음: {}", dto.getReserveDateTime());
+            throw new CustomException(ErrorCode.RESERVE_DATE_OR_TIME_ERROR);
+        }
+
+        reserveInfoRepository.save(reserveInfo);
+    }
+
+    private CancelData createCancelData(Payment response) {
+        log.info("결제 취소 - 포트원 고유 번호: {}, 구매 번호: {}", response.getImpUid(), response.getMerchantUid());
+        return new CancelData(response.getImpUid(), true);
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/AvailableDate.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/AvailableDate.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 @Entity
@@ -49,5 +50,35 @@ public class AvailableDate {
     public void addTraining(Training training) {
         this.training = training;
         training.getAvailableDates().add(this);
+    }
+
+    public boolean removeTime(LocalTime time) {
+        for (AvailableTime availableTime : this.getAvailableTimes()) {
+            if (availableTime.getTime().equals(time)) {
+                if (!availableTime.isEnabled()) return false;
+                availableTime.closeTime();
+                long enabledCnt = this.getAvailableTimes().stream().filter(AvailableTime::isEnabled).count();
+                if (enabledCnt == 0) closeDate();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void addTime(LocalTime time) {
+        for (AvailableTime availableTime : this.getAvailableTimes()) {
+            if (availableTime.getTime().equals(time)) {
+                availableTime.openTime();
+                return;
+            }
+        }
+    }
+
+    public void closeDate() {
+        this.enabled = false;
+    }
+
+    public void openDate() {
+        this.enabled = true;
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/AvailableTime.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/AvailableTime.java
@@ -35,4 +35,12 @@ public class AvailableTime {
         this.availableDate = date;
         this.enabled = enabled;
     }
+
+    public void closeTime() {
+        this.enabled = false;
+    }
+
+    public void openTime() {
+        this.enabled = true;
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/ReserveInfo.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/ReserveInfo.java
@@ -1,0 +1,74 @@
+package com.fithub.fithubbackend.domain.Training.domain;
+
+import com.fithub.fithubbackend.domain.Training.dto.ReserveReqDto;
+import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
+import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.global.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Comment;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReserveInfo extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Training training;
+
+    @NotNull
+    private LocalDateTime reserveDateTime;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private ReserveStatus status;
+
+    @NotNull
+    @Comment("결제 방법")
+    @Column(length = 100)
+    private String payMethod;
+
+    @NotNull
+    @Comment("주문 번호")
+    @Column(length = 100)
+    private String impUid;
+
+    @NotNull
+    @Comment("구매 번호")
+    @Column(length = 100)
+    private  String merchantUid;
+
+    @NotNull
+    @ColumnDefault("0")
+    private int price;
+
+    @Builder
+    public ReserveInfo(User user, Training training, ReserveReqDto dto) {
+        this.user = user;
+        this.training = training;
+        this.reserveDateTime = dto.getReserveDateTime();
+        this.status = ReserveStatus.BEFORE;
+        this.impUid = dto.getImpUid();
+        this.merchantUid = dto.getMerchantUid();
+        this.payMethod = dto.getPayMethod();
+        this.price = dto.getAmount();
+    }
+
+    public void updateStatus(ReserveStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
@@ -15,6 +15,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -100,5 +101,29 @@ public class Training extends BaseTimeEntity {
 
     public void updateClosed(boolean closed) {
         this.closed = closed;
+    }
+
+    public boolean removeAvailableDateTime(LocalDateTime dateTime) {
+        LocalDate reserveDate = dateTime.toLocalDate();
+        LocalTime reserveTime = dateTime.toLocalTime();
+        for (AvailableDate availableDate : this.getAvailableDates()) {
+            if (availableDate.getDate().equals(reserveDate)) {
+                if (!availableDate.isEnabled()) return false;
+                return availableDate.removeTime(reserveTime);
+            }
+        }
+        return false;
+    }
+
+    public void addAvailableDateTime(LocalDateTime dateTime) {
+        LocalDate reserveDate = dateTime.toLocalDate();
+        LocalTime reserveTime = dateTime.toLocalTime();
+        for (AvailableDate availableDate : this.getAvailableDates()) {
+            if (availableDate.getDate().equals(reserveDate)) {
+                availableDate.addTime(reserveTime);
+                if (!availableDate.isEnabled()) availableDate.openDate();
+                return;
+            }
+        }
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/CancelReqDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/CancelReqDto.java
@@ -1,0 +1,27 @@
+package com.fithub.fithubbackend.domain.Training.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Schema(description = "결제 취소 dto")
+public class CancelReqDto {
+    @NotNull
+    @Schema(description = "결제했던 트레이닝 id")
+    private Long trainingId;
+
+    @NotNull
+    @Schema(description = "결제 내역 id")
+    private Long reservationId;
+
+    @NotNull
+    @Schema(description = "포트원 거래고유번호")
+    private String impUid;
+
+    @NotNull
+    @Schema(description = "결제했던 금액(환불 금액)")
+    private String amount;
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/PaymentReqDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/PaymentReqDto.java
@@ -1,0 +1,32 @@
+package com.fithub.fithubbackend.domain.Training.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Schema(description = "트레이닝 예약 결제 검증을 위한 dto")
+public class PaymentReqDto {
+    @NotNull
+    @Schema(description = "결제하는 트레이닝 id")
+    private Long trainingId;
+
+    @NotNull
+    @Schema(description = "상점 id kc는 html5_inicis 아니면 inicis")
+    private String pg;
+
+    @NotNull
+    @Schema(description = "결제 방법")
+    private String payMethod;
+
+    @NotNull
+    @Schema(description = "포트원 거래고유번호")
+    private String impUid;
+
+    @NotNull
+    @Schema(description = "주문 번호")
+    private String merchantUid;
+
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/PaymentResDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/PaymentResDto.java
@@ -1,0 +1,11 @@
+package com.fithub.fithubbackend.domain.Training.dto;
+
+import lombok.Builder;
+
+@Builder
+public class PaymentResDto {
+    private String impUid;
+    private String merchantUid;
+    private String payMethod;
+    private int amount;
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/ReserveReqDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/ReserveReqDto.java
@@ -1,0 +1,43 @@
+package com.fithub.fithubbackend.domain.Training.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Schema(description = "트레이닝 결제 검증 후 정보 저장을 위한 dto")
+public class ReserveReqDto {
+    @NotNull
+    @Schema(description = "예약할 트레이닝의 id")
+    private Long trainingId;
+
+    @NotNull
+    @Schema(description = "상점 id kc는 html5_inicis 아니면 inicis")
+    private String pg;
+
+    @NotNull
+    @Schema(description = "결제 방법")
+    private String payMethod;
+
+    @NotNull
+    @Schema(description = "포트원 거래고유번호")
+    private String impUid;
+
+    @NotNull
+    @Schema(description = "주문 번호")
+    private String merchantUid;
+
+    @NotNull
+    @Schema(description = "가격")
+    private int amount;
+
+    @NotNull
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @Schema(description = "예약한 날짜, 시간")
+    private LocalDateTime reserveDateTime;
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/enums/ReserveStatus.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/enums/ReserveStatus.java
@@ -1,0 +1,8 @@
+package com.fithub.fithubbackend.domain.Training.enums;
+
+public enum ReserveStatus {
+    BEFORE,
+    START,
+    COMPLETE,
+    CANCEL
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
@@ -1,0 +1,7 @@
+package com.fithub.fithubbackend.domain.Training.repository;
+
+import com.fithub.fithubbackend.domain.Training.domain.ReserveInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReserveInfoRepository extends JpaRepository<ReserveInfo, Long> {
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/repository/UserRepository.java
@@ -10,4 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     Optional<User> findByEmailAndProvider(String email, String provider);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
@@ -5,7 +5,6 @@ import com.fithub.fithubbackend.global.util.HeaderUtil;
 import com.fithub.fithubbackend.global.util.RedisUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -20,8 +19,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.Arrays;
-
-import static com.fithub.fithubbackend.global.exception.ErrorCode.EXPIRED_REFRESH_TOKEN;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -47,7 +44,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-
+        log.info("[doFilterInternal] - 요청 path: {}", request.getServletPath());
         // 1. 쿠키에서 token 추출
         String accessToken = headerUtil.resolveAccessToken(request);
         String refreshToken = headerUtil.resolveRefreshToken(request);

--- a/src/main/java/com/fithub/fithubbackend/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/exception/CustomExceptionHandler.java
@@ -2,6 +2,8 @@ package com.fithub.fithubbackend.global.exception;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -13,5 +15,13 @@ public class CustomExceptionHandler {
     public ResponseEntity<ErrorResponseDto> handleCustomException(CustomException exception) {
         log.info(exception.toString());
         return ErrorResponseDto.toResponseEntity(exception.getErrorCode(), exception.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponseDto> handleValidException(MethodArgumentNotValidException exception) {
+        log.info("[CustomExceptionHandler] - @Valid 에러");
+        BindingResult bindingResult = exception.getBindingResult();
+        String message = bindingResult.getFieldError().getDefaultMessage();
+        return ErrorResponseDto.toResponseEntity(ErrorCode.INVALID_FORM_DATA, exception.getMessage());
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/fithub/fithubbackend/global/exception/ErrorCode.java
@@ -27,8 +27,10 @@ public enum ErrorCode {
 
     AUTHENTICATION_ERROR(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다."),
     PARSING_ERROR(HttpStatus.BAD_GATEWAY,"파싱에 실패하였습니다."),
-    INVALID_IMAGE(HttpStatus.CONFLICT, "이미지 파일이 아닙니다.");
+    INVALID_IMAGE(HttpStatus.CONFLICT, "이미지 파일이 아닙니다."),
 
+    IAMPORT_PRICE_ERROR(HttpStatus.CONFLICT, "결제된 금액이 달라 결제가 취소되었습니다."),
+    RESERVE_DATE_OR_TIME_ERROR(HttpStatus.BAD_REQUEST, "불가능한 날짜 또는 시간대입니다.");
     private final HttpStatus httpStatus;
     private final String message;
 }


### PR DESCRIPTION
## pr 유형
- 기능 추가

## 반영 브랜치
- feature/training -> main

## 변경 사항
1. 포트원(아임포트) 추가
2. 예약 엔티티 생성
3. 예약(결제) 기능 추가
4. 예약(결제) 취소 기능 추가

## 추가 변경 사항
- application.yml에 포트원 관련 키 추가

## 테스트
! 실제 결제가 되는지는 프론트 페이지가 완성되고 결제 시도 후에 알 수 있을 듯
- 결제 완료 후 예약 생성
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/0e522217-913d-4f22-bbc4-3cd514f14ec5)
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/248e1101-8354-464d-b717-cdf9bde2b48f)

트레이닝 예약 가능 시간이 가능 -> 불가능으로 바뀌고 만약 예약한 날짜의 예약 가능 시간대가 없다면 예약 가능 날짜가 불가능으로 바뀌는 것도 확인

- 예약 취소
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/20b572ea-fabf-4450-8025-95b89dc6da54)

트레이닝의 예약 가능 시간들이 불가능 -> 변경으로 바뀌는 것까지 확인
