### PR TITLE
Feat/training: 트레이닝 예약 리스트 조회 기능 추가(회원,트레이너)

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainingController.java
@@ -1,14 +1,20 @@
 package com.fithub.fithubbackend.domain.Training.api;
 
 import com.fithub.fithubbackend.domain.Training.application.TrainingService;
+import com.fithub.fithubbackend.domain.Training.dto.TrainersReserveInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingCreateDto;
 import com.fithub.fithubbackend.global.exception.ErrorResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -52,5 +58,18 @@ public class TrainingController {
     public ResponseEntity<Void> updateTrainingClosed(@RequestParam Long trainingId, @RequestParam boolean closed, @AuthenticationPrincipal UserDetails userDetails) {
         trainingService.updateClosed(trainingId, closed, userDetails.getUsername());
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "트레이너의 예약 리스트 조회", parameters = {
+            @Parameter(name = "pageable", description = "조회할 목록의 page, size, sort(기본은 id (생성 순), 예약된 트레이닝 날짜 순은 reserveDateTime으로 주면 됨)")
+    }, responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "회원이 트레이너가 아님", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 회원", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+    })
+    @GetMapping("/reservations")
+    public ResponseEntity<Page<TrainersReserveInfoDto>> getReservationList(@AuthenticationPrincipal UserDetails userDetails,
+                                                                           @PageableDefault(sort="id", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(trainingService.getReservationList(userDetails.getUsername(), pageable));
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainingController.java
@@ -72,8 +72,9 @@ public class TrainingController {
             @ApiResponse(responseCode = "404", description = "존재하지 않는 회원", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
     @GetMapping("/reservations")
-    public ResponseEntity<Page<TrainersReserveInfoDto>> getReservationList(@AuthenticationPrincipal UserDetails userDetails,
+    public ResponseEntity<Page<TrainersReserveInfoDto>> getReservationList(@AuthUser User user,
                                                                            @PageableDefault(sort="id", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ResponseEntity.ok(trainingService.getReservationList(userDetails.getUsername(), pageable));
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        return ResponseEntity.ok(trainingService.getReservationList(user, pageable));
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/UserTrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/UserTrainingController.java
@@ -4,6 +4,7 @@ import com.fithub.fithubbackend.domain.Training.application.UserTrainingService;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingLikesInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingOutlineDto;
+import com.fithub.fithubbackend.domain.Training.dto.UsersReserveInfoDto;
 import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
 import com.fithub.fithubbackend.global.exception.ErrorResponseDto;
@@ -75,5 +76,17 @@ public class UserTrainingController {
     @GetMapping("/likes")
     public ResponseEntity<List<TrainingLikesInfoDto>> getUserTrainingLikesList(@AuthenticationPrincipal UserDetails userDetails) {
         return ResponseEntity.ok(userTrainingService.getTrainingLikesList(userDetails.getUsername()));
+    }
+
+    @Operation(summary = "회원의 트레이닝 예약 리스트", parameters = {
+            @Parameter(name = "pageable", description = "조회할 목록의 page, size, sort(기본은 id desc(생성 순), 예약된 트레이닝 날짜 순은 reserveDateTime으로 주면 됨)")
+    }, responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 회원", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+    })
+    @GetMapping("/reservations")
+    public ResponseEntity<Page<UsersReserveInfoDto>> getUsersTrainingReservationList(@AuthenticationPrincipal UserDetails userDetails,
+                                                                                     @PageableDefault(sort="id", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(userTrainingService.getTrainingReservationList(userDetails.getUsername(), pageable));
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/UserTrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/UserTrainingController.java
@@ -82,8 +82,9 @@ public class UserTrainingController {
             @ApiResponse(responseCode = "404", description = "존재하지 않는 회원", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
     @GetMapping("/reservations")
-    public ResponseEntity<Page<UsersReserveInfoDto>> getUsersTrainingReservationList(@AuthenticationPrincipal UserDetails userDetails,
+    public ResponseEntity<Page<UsersReserveInfoDto>> getUsersTrainingReservationList(@AuthUser User user,
                                                                                      @PageableDefault(sort="id", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ResponseEntity.ok(userTrainingService.getTrainingReservationList(userDetails.getUsername(), pageable));
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        return ResponseEntity.ok(userTrainingService.getTrainingReservationList(user, pageable));
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingService.java
@@ -13,5 +13,5 @@ public interface TrainingService {
 
     void updateClosed(Long id, boolean closed, User user);
 
-    Page<TrainersReserveInfoDto> getReservationList(String email, Pageable pageable);
+    Page<TrainersReserveInfoDto> getReservationList(User user, Pageable pageable);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingService.java
@@ -1,6 +1,9 @@
 package com.fithub.fithubbackend.domain.Training.application;
 
+import com.fithub.fithubbackend.domain.Training.dto.TrainersReserveInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingCreateDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface TrainingService {
     Long createTraining(TrainingCreateDto dto, String email);
@@ -8,4 +11,6 @@ public interface TrainingService {
     void deleteTraining(Long id);
 
     void updateClosed(Long id, boolean closed, String email);
+
+    Page<TrainersReserveInfoDto> getReservationList(String email, Pageable pageable);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingServiceImpl.java
@@ -136,8 +136,7 @@ public class TrainingServiceImpl implements TrainingService {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<TrainersReserveInfoDto> getReservationList(String email, Pageable pageable) {
-        User user = userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 회원입니다."));
+    public Page<TrainersReserveInfoDto> getReservationList(User user, Pageable pageable) {
         Trainer trainer = trainerRepository.findByUserId(user.getId()).orElseThrow(() -> new CustomException(ErrorCode.AUTHENTICATION_ERROR, "해당 회원은 트레이너가 아닙니다."));
 
         Page<ReserveInfo> reserveInfoPage = reserveInfoRepository.findByTrainerId(trainer.getId(), pageable);

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingService.java
@@ -18,5 +18,5 @@ public interface UserTrainingService {
     void likesTraining(Long trainingId, boolean likes, User user);
     List<TrainingLikesInfoDto> getTrainingLikesList(User user);
 
-    Page<UsersReserveInfoDto> getTrainingReservationList(String email, Pageable pageable);
+    Page<UsersReserveInfoDto> getTrainingReservationList(User user, Pageable pageable);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingService.java
@@ -3,6 +3,7 @@ package com.fithub.fithubbackend.domain.Training.application;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingLikesInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingOutlineDto;
+import com.fithub.fithubbackend.domain.Training.dto.UsersReserveInfoDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -15,4 +16,6 @@ public interface UserTrainingService {
     boolean isLikesTraining(Long trainingId, String email);
     void likesTraining(Long trainingId, boolean likes, String email);
     List<TrainingLikesInfoDto> getTrainingLikesList(String email);
+
+    Page<UsersReserveInfoDto> getTrainingReservationList(String email, Pageable pageable);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingServiceImpl.java
@@ -1,11 +1,10 @@
 package com.fithub.fithubbackend.domain.Training.application;
 
+import com.fithub.fithubbackend.domain.Training.domain.ReserveInfo;
 import com.fithub.fithubbackend.domain.Training.domain.Training;
 import com.fithub.fithubbackend.domain.Training.domain.TrainingLikes;
-import com.fithub.fithubbackend.domain.Training.dto.TrainingDocumentDto;
-import com.fithub.fithubbackend.domain.Training.dto.TrainingInfoDto;
-import com.fithub.fithubbackend.domain.Training.dto.TrainingLikesInfoDto;
-import com.fithub.fithubbackend.domain.Training.dto.TrainingOutlineDto;
+import com.fithub.fithubbackend.domain.Training.dto.*;
+import com.fithub.fithubbackend.domain.Training.repository.ReserveInfoRepository;
 import com.fithub.fithubbackend.domain.Training.repository.TrainingLikesRepository;
 import com.fithub.fithubbackend.domain.Training.repository.TrainingRepository;
 import com.fithub.fithubbackend.domain.user.domain.User;
@@ -27,6 +26,7 @@ public class UserTrainingServiceImpl implements UserTrainingService {
     private final TrainingRepository trainingRepository;
     private final TrainingLikesRepository trainingLikesRepository;
     private final UserRepository userRepository;
+    private final ReserveInfoRepository reserveInfoRepository;
 
     @Override
     @Transactional(readOnly = true)
@@ -83,6 +83,14 @@ public class UserTrainingServiceImpl implements UserTrainingService {
                 .id(t.getId())
                 .trainingOutlineDto(TrainingOutlineDto.toDto(t.getTraining()))
                 .build()).toList();
+    }
+
+    @Override
+    public Page<UsersReserveInfoDto> getTrainingReservationList(String email, Pageable pageable) {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 회원입니다."));
+        Page<ReserveInfo> page = reserveInfoRepository.findByUserId(user.getId(), pageable);
+
+        return page.map(UsersReserveInfoDto::toDto);
     }
 
     private void checkClosed(boolean closed) {

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingServiceImpl.java
@@ -83,10 +83,8 @@ public class UserTrainingServiceImpl implements UserTrainingService {
     }
 
     @Override
-    public Page<UsersReserveInfoDto> getTrainingReservationList(String email, Pageable pageable) {
-        User user = userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 회원입니다."));
+    public Page<UsersReserveInfoDto> getTrainingReservationList(User user, Pageable pageable) {
         Page<ReserveInfo> page = reserveInfoRepository.findByUserId(user.getId(), pageable);
-
         return page.map(UsersReserveInfoDto::toDto);
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/ReserveInfo.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/ReserveInfo.java
@@ -1,7 +1,9 @@
 package com.fithub.fithubbackend.domain.Training.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fithub.fithubbackend.domain.Training.dto.ReserveReqDto;
 import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
+import com.fithub.fithubbackend.domain.trainer.domain.Trainer;
 import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
@@ -28,6 +30,10 @@ public class ReserveInfo extends BaseTimeEntity {
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    private Trainer trainer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JsonIgnoreProperties({"trainer"})
     private Training training;
 
     @NotNull
@@ -59,6 +65,7 @@ public class ReserveInfo extends BaseTimeEntity {
     @Builder
     public ReserveInfo(User user, Training training, ReserveReqDto dto) {
         this.user = user;
+        this.trainer = training.getTrainer();
         this.training = training;
         this.reserveDateTime = dto.getReserveDateTime();
         this.status = ReserveStatus.BEFORE;

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
@@ -1,5 +1,6 @@
 package com.fithub.fithubbackend.domain.Training.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingCreateDto;
 import com.fithub.fithubbackend.domain.trainer.domain.Trainer;
@@ -30,6 +31,7 @@ public class Training extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(optional = false, cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JsonIgnore
     private Trainer trainer;
 
     @NotNull

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainersReserveInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainersReserveInfoDto.java
@@ -1,0 +1,50 @@
+package com.fithub.fithubbackend.domain.Training.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fithub.fithubbackend.domain.Training.domain.ReserveInfo;
+import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "트레이너의 트레이닝 예약 정보 확인")
+public class TrainersReserveInfoDto {
+    @Schema(description = "트레이닝 id")
+    private Long id;
+
+    @Schema(description = "트레이닝 제목")
+    private String title;
+
+    @Schema(description = "트레이닝 예약자 이름")
+    private String userName;
+
+    @Schema(description = "예약한 트레이닝 날짜, 시간")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime trainingDateTime;
+    
+    @Schema(description = "트레이닝을 예약한 날짜, 시간")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createdDateTime;
+    
+    @Schema(description = "트레이닝 진행 상황(진행 전, 진행중, 진행완료, 취소)")
+    private ReserveStatus status;
+
+    @Schema(description = "트레이닝 결제 금액")
+    private int price;
+    
+   public static TrainersReserveInfoDto toDto(ReserveInfo reserveInfo) {
+            return TrainersReserveInfoDto.builder()
+                    .id(reserveInfo.getId())
+                    .title(reserveInfo.getTraining().getTitle())
+                    .userName(reserveInfo.getUser().getName())
+                    .trainingDateTime(reserveInfo.getReserveDateTime())
+                    .createdDateTime(reserveInfo.getCreatedDate())
+                    .status(reserveInfo.getStatus())
+                    .price(reserveInfo.getPrice())
+                    .build();
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/UsersReserveInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/UsersReserveInfoDto.java
@@ -1,0 +1,55 @@
+package com.fithub.fithubbackend.domain.Training.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fithub.fithubbackend.domain.Training.domain.ReserveInfo;
+import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "회원의 트레이닝 예약 정보 확인")
+public class UsersReserveInfoDto {
+    @Schema(description = "트레이닝 id")
+    private Long id;
+
+    @Schema(description = "트레이닝 제목")
+    private String title;
+
+    @Schema(description = "트레이닝을 담당하는 트레이너 이름")
+    private String trainerName;
+
+    @Schema(description = "예약한 트레이닝 날짜, 시간")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime trainingDateTime;
+
+    @Schema(description = "트레이닝을 예약한 날짜, 시간")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime reserveDateTime;
+
+    @Schema(description = "트레이닝 진행 상황(진행 전, 진행중, 진행완료, 취소)")
+    private ReserveStatus status;
+
+    @Schema(description = "트레이닝 결제 금액")
+    private int price;
+
+    @Schema(description = "트레이닝 구매 번호")
+    private String merchantUid;
+
+    // TODO: 트레이너용 dto, 회원용 dto로 나누기 (트레이너한테는 자기 이름 필요없으니까 불필요한 trainer 조회 없이가도록)
+    public static UsersReserveInfoDto toDto(ReserveInfo reserveInfo) {
+        return UsersReserveInfoDto.builder()
+                .id(reserveInfo.getId())
+                .title(reserveInfo.getTraining().getTitle())
+                .trainerName(reserveInfo.getTrainer().getName())
+                .trainingDateTime(reserveInfo.getReserveDateTime())
+                .reserveDateTime(reserveInfo.getCreatedDate())
+                .status(reserveInfo.getStatus())
+                .price(reserveInfo.getPrice())
+                .merchantUid(reserveInfo.getMerchantUid())
+                .build();
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/enums/ReserveStatus.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/enums/ReserveStatus.java
@@ -4,5 +4,6 @@ public enum ReserveStatus {
     BEFORE,
     START,
     COMPLETE,
-    CANCEL
+    CANCEL,
+    NOSHOW
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
@@ -1,7 +1,11 @@
 package com.fithub.fithubbackend.domain.Training.repository;
 
 import com.fithub.fithubbackend.domain.Training.domain.ReserveInfo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReserveInfoRepository extends JpaRepository<ReserveInfo, Long> {
+    Page<ReserveInfo> findByTrainerId(Long trainerId, Pageable pageable);
+    Page<ReserveInfo> findByUserId(Long userId, Pageable pageable);
 }


### PR DESCRIPTION
## pr 유형
- 기능 추가

## 반영 브랜치
- feature/training -> main

## 변경 사항
1. 트레이너의 예약 리스트 조회 기능 추가
2. 회원의 예약 리스트 조회 기능 추가 (추후에 진행 상황(진행정, 진행중, 완료, 취소)에 따라 나눠서 보내줄지 아니면 프론트에서 나눌지 상의 필요)

## 테스트 결과
- 트레이너의 예약 리스트 조회 (자신이 올린 트레이닝에 예약된 내용 조회)
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/9076e808-13c0-4bdc-a4fa-e1e66ce5ddb4)

- 회원의 트레이닝 예약 리스트 조회 (자신이 예약한 트레이닝 조회 - 현재는 생성 순이지만 프론트에서 정렬 기준 주면 변경)
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/278539bc-5ddb-4a91-b961-6272472d4454)
