### PR TITLE
update: AuthenticationPrincipal -> AuthUser로 수정, 이메일 인증 에러 수정

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/PaymentController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/PaymentController.java
@@ -5,12 +5,14 @@ import com.fithub.fithubbackend.domain.Training.dto.CancelReqDto;
 import com.fithub.fithubbackend.domain.Training.dto.PaymentReqDto;
 import com.fithub.fithubbackend.domain.Training.dto.PaymentResDto;
 import com.fithub.fithubbackend.domain.Training.dto.ReserveReqDto;
+import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.global.domain.AuthUser;
+import com.fithub.fithubbackend.global.exception.CustomException;
+import com.fithub.fithubbackend.global.exception.ErrorCode;
 import com.siot.IamportRestClient.exception.IamportResponseException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,14 +34,16 @@ public class PaymentController {
 
     @PostMapping("/order")
     //TODO: 예약 완료 후 찜에 있는 트레이닝이면 삭제할거냐고 물어보는게 좋을수도
-    public ResponseEntity<String> reserveComplete(@RequestBody @Valid ReserveReqDto dto, @AuthenticationPrincipal UserDetails userDetails) {
-        paymentService.reserveComplete(dto, userDetails.getUsername());
+    public ResponseEntity<String> reserveComplete(@RequestBody @Valid ReserveReqDto dto, @AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        paymentService.reserveComplete(dto, user);
         return ResponseEntity.ok().body("완료");
     }
 
     @PostMapping("/cancel")
-    public ResponseEntity<String> cancelPayment(@RequestBody @Valid CancelReqDto dto, @AuthenticationPrincipal UserDetails userDetails) throws IamportResponseException, IOException {
-        paymentService.cancelPayment(dto, userDetails.getUsername());
+    public ResponseEntity<String> cancelPayment(@RequestBody @Valid CancelReqDto dto, @AuthUser User user) throws IamportResponseException, IOException {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        paymentService.cancelPayment(dto, user.getEmail());
         return ResponseEntity.ok().body("완료");
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainingController.java
@@ -2,6 +2,10 @@ package com.fithub.fithubbackend.domain.Training.api;
 
 import com.fithub.fithubbackend.domain.Training.application.TrainingService;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingCreateDto;
+import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.global.domain.AuthUser;
+import com.fithub.fithubbackend.global.exception.CustomException;
+import com.fithub.fithubbackend.global.exception.ErrorCode;
 import com.fithub.fithubbackend.global.exception.ErrorResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -10,8 +14,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -26,8 +28,9 @@ public class TrainingController {
             @ApiResponse(responseCode = "409", description = "예약 가능 날짜에 현재보다 이전 날짜가 들어있음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
     @PostMapping
-    public ResponseEntity<Long> createTraining(@Valid TrainingCreateDto dto, @AuthenticationPrincipal UserDetails userDetails) {
-        return ResponseEntity.ok(trainingService.createTraining(dto, userDetails.getUsername()));
+    public ResponseEntity<Long> createTraining(@Valid TrainingCreateDto dto, @AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        return ResponseEntity.ok(trainingService.createTraining(dto, user));
     }
 
 //    @Operation(summary = "트레이닝 수정", responses = {
@@ -49,8 +52,9 @@ public class TrainingController {
 //    }
 
     @PutMapping("/close")
-    public ResponseEntity<Void> updateTrainingClosed(@RequestParam Long trainingId, @RequestParam boolean closed, @AuthenticationPrincipal UserDetails userDetails) {
-        trainingService.updateClosed(trainingId, closed, userDetails.getUsername());
+    public ResponseEntity<Void> updateTrainingClosed(@RequestParam Long trainingId, @RequestParam boolean closed, @AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        trainingService.updateClosed(trainingId, closed, user);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/UserTrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/UserTrainingController.java
@@ -4,6 +4,8 @@ import com.fithub.fithubbackend.domain.Training.application.UserTrainingService;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingLikesInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingOutlineDto;
+import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.global.domain.AuthUser;
 import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
 import com.fithub.fithubbackend.global.exception.ErrorResponseDto;
@@ -18,8 +20,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -49,22 +49,18 @@ public class UserTrainingController {
             @Parameter(name = "trainingId", description = "조회할 트레이닝의 primary key(id)")
     })
     @GetMapping("/check/likes")
-    public ResponseEntity<Boolean> isLikesTraining(@RequestParam Long trainingId, @AuthenticationPrincipal UserDetails userDetails) {
-        if (userDetails == null) {
-            throw new CustomException(ErrorCode.UNKNOWN_ERROR, "로그인한 사용자만 가능합니다.");
-        }
-        return ResponseEntity.ok(userTrainingService.isLikesTraining(trainingId, userDetails.getUsername()));
+    public ResponseEntity<Boolean> isLikesTraining(@RequestParam Long trainingId, @AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        return ResponseEntity.ok(userTrainingService.isLikesTraining(trainingId, user));
     }
 
     @Operation(summary = "트레이닝 찜 설정 및 해제", parameters = {
             @Parameter(name = "trainingId", description = "조회할 트레이닝의 primary key(id)")
     })
     @PostMapping("/likes")
-    public ResponseEntity<String> likes(@RequestParam Long trainingId, boolean likes, @AuthenticationPrincipal UserDetails userDetails) {
-        if (userDetails == null) {
-            return ResponseEntity.badRequest().body("로그인한 사용자만 가능합니다.");
-        }
-        userTrainingService.likesTraining(trainingId, likes, userDetails.getUsername());
+    public ResponseEntity<String> likes(@RequestParam Long trainingId, boolean likes, @AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        userTrainingService.likesTraining(trainingId, likes, user);
         return ResponseEntity.ok().body("완료");
     }
 
@@ -73,7 +69,8 @@ public class UserTrainingController {
             @ApiResponse(responseCode = "404", description = "존재하지 않는 회원", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
     @GetMapping("/likes")
-    public ResponseEntity<List<TrainingLikesInfoDto>> getUserTrainingLikesList(@AuthenticationPrincipal UserDetails userDetails) {
-        return ResponseEntity.ok(userTrainingService.getTrainingLikesList(userDetails.getUsername()));
+    public ResponseEntity<List<TrainingLikesInfoDto>> getUserTrainingLikesList(@AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        return ResponseEntity.ok(userTrainingService.getTrainingLikesList(user));
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/PaymentService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/PaymentService.java
@@ -4,12 +4,13 @@ import com.fithub.fithubbackend.domain.Training.dto.CancelReqDto;
 import com.fithub.fithubbackend.domain.Training.dto.PaymentReqDto;
 import com.fithub.fithubbackend.domain.Training.dto.PaymentResDto;
 import com.fithub.fithubbackend.domain.Training.dto.ReserveReqDto;
+import com.fithub.fithubbackend.domain.user.domain.User;
 import com.siot.IamportRestClient.exception.IamportResponseException;
 
 import java.io.IOException;
 
 public interface PaymentService {
     PaymentResDto validate(PaymentReqDto dto) throws IamportResponseException, IOException;
-    void reserveComplete(ReserveReqDto dto, String email);
+    void reserveComplete(ReserveReqDto dto, User user);
     void cancelPayment(CancelReqDto dto, String email) throws IamportResponseException, IOException;
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/PaymentServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/PaymentServiceImpl.java
@@ -74,8 +74,7 @@ public class PaymentServiceImpl implements PaymentService {
 
     @Override
     @Transactional
-    public void reserveComplete(ReserveReqDto dto, String email) {
-        User user = userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 회원입니다."));
+    public void reserveComplete(ReserveReqDto dto, User user) {
         Training training = trainingRepository.findById(dto.getTrainingId()).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 트레이닝입니다."));
 
         ReserveInfo reserveInfo = ReserveInfo.builder().dto(dto).user(user).training(training).build();

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingService.java
@@ -1,11 +1,12 @@
 package com.fithub.fithubbackend.domain.Training.application;
 
 import com.fithub.fithubbackend.domain.Training.dto.TrainingCreateDto;
+import com.fithub.fithubbackend.domain.user.domain.User;
 
 public interface TrainingService {
-    Long createTraining(TrainingCreateDto dto, String email);
-    Long updateTraining(TrainingCreateDto dto, Long trainingId, String email);
+    Long createTraining(TrainingCreateDto dto, User user);
+    Long updateTraining(TrainingCreateDto dto, Long trainingId, User user);
     void deleteTraining(Long id);
 
-    void updateClosed(Long id, boolean closed, String email);
+    void updateClosed(Long id, boolean closed, User user);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingServiceImpl.java
@@ -41,8 +41,7 @@ public class TrainingServiceImpl implements TrainingService {
 
     @Override
     @Transactional
-    public Long createTraining(TrainingCreateDto dto, String email) {
-        User user = userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 회원입니다."));
+    public Long createTraining(TrainingCreateDto dto, User user) {
         Trainer trainer = trainerRepository.findByUserId(user.getId()).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 트레이너"));
 
         dateValidate(dto.getStartDate(), dto.getEndDate());
@@ -93,9 +92,9 @@ public class TrainingServiceImpl implements TrainingService {
 
     @Override
     @Transactional
-    public Long updateTraining(TrainingCreateDto dto, Long trainingId, String email) {
+    public Long updateTraining(TrainingCreateDto dto, Long trainingId, User user) {
         Training training = trainingRepository.findById(trainingId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 트레이닝입니다."));
-        permissionValidate(training.getTrainer(), email);
+        permissionValidate(training.getTrainer(), user.getEmail());
 
         if (training.isClosed()) {
             throw new CustomException(ErrorCode.UNCORRECTABLE_DATA, "마감된 트레이닝은 수정할 수 없습니다.");
@@ -126,9 +125,9 @@ public class TrainingServiceImpl implements TrainingService {
 
     @Override
     @Transactional
-    public void updateClosed(Long id, boolean closed, String email) {
+    public void updateClosed(Long id, boolean closed, User user) {
         Training training = trainingRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "해당하는 트레이닝을 찾을 수 없습니다."));
-        permissionValidate(training.getTrainer(), email);
+        permissionValidate(training.getTrainer(), user.getEmail());
         training.updateClosed(closed);
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingService.java
@@ -3,6 +3,7 @@ package com.fithub.fithubbackend.domain.Training.application;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingLikesInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingOutlineDto;
+import com.fithub.fithubbackend.domain.user.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -12,7 +13,7 @@ public interface UserTrainingService {
     Page<TrainingOutlineDto> searchAll(Pageable pageable);
     TrainingInfoDto searchById(Long id);
 
-    boolean isLikesTraining(Long trainingId, String email);
-    void likesTraining(Long trainingId, boolean likes, String email);
-    List<TrainingLikesInfoDto> getTrainingLikesList(String email);
+    boolean isLikesTraining(Long trainingId, User user);
+    void likesTraining(Long trainingId, boolean likes, User user);
+    List<TrainingLikesInfoDto> getTrainingLikesList(User user);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingServiceImpl.java
@@ -49,20 +49,18 @@ public class UserTrainingServiceImpl implements UserTrainingService {
 
     @Override
     @Transactional(readOnly = true)
-    public boolean isLikesTraining(Long trainingId, String email) {
+    public boolean isLikesTraining(Long trainingId, User user) {
         Training training = trainingRepository.findById(trainingId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 트레이닝입니다."));
         checkClosed(training.isClosed());
-        User user = userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 회원입니다."));
         return trainingLikesRepository.existsByTrainingIdAndUserId(trainingId, user.getId());
     }
 
     @Override
     @Transactional
-    public void likesTraining(Long trainingId, boolean likes, String email) {
+    public void likesTraining(Long trainingId, boolean likes, User user) {
         Training training = trainingRepository.findById(trainingId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 트레이닝입니다."));
         checkClosed(training.isClosed());
 
-        User user = userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 회원입니다."));
         if (user.getId().equals(training.getTrainer().getUser().getId())) {
             throw new CustomException(ErrorCode.UNKNOWN_ERROR, "트레이너는 자신의 트레이닝을 찜할 수 없습니다.");
         }
@@ -76,8 +74,7 @@ public class UserTrainingServiceImpl implements UserTrainingService {
     }
 
     @Override
-    public List<TrainingLikesInfoDto> getTrainingLikesList(String email) {
-        User user = userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 회원입니다."));
+    public List<TrainingLikesInfoDto> getTrainingLikesList(User user) {
         List<TrainingLikes> trainingLikes = trainingLikesRepository.findByUserId(user.getId());
         return trainingLikes.stream().map(t -> TrainingLikesInfoDto.builder()
                 .id(t.getId())

--- a/src/main/java/com/fithub/fithubbackend/domain/board/api/CommentController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/api/CommentController.java
@@ -3,6 +3,10 @@ package com.fithub.fithubbackend.domain.board.api;
 import com.fithub.fithubbackend.domain.board.application.CommentService;
 import com.fithub.fithubbackend.domain.board.dto.CommentCreateDto;
 import com.fithub.fithubbackend.domain.board.dto.CommentUpdateDto;
+import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.global.domain.AuthUser;
+import com.fithub.fithubbackend.global.exception.CustomException;
+import com.fithub.fithubbackend.global.exception.ErrorCode;
 import com.fithub.fithubbackend.global.exception.ErrorResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -11,8 +15,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -27,8 +29,9 @@ public class CommentController {
             @ApiResponse(responseCode = "", description = "댓글 등록 실패", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
     @PostMapping
-    public ResponseEntity<Void> createComment(@Valid CommentCreateDto commentCreateDto, @AuthenticationPrincipal UserDetails userDetails) {
-        commentService.createComment(commentCreateDto, userDetails);
+    public ResponseEntity<Void> createComment(@Valid CommentCreateDto commentCreateDto, @AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        commentService.createComment(commentCreateDto, user);
         return ResponseEntity.ok().build();
     }
 
@@ -37,8 +40,9 @@ public class CommentController {
             @ApiResponse(responseCode = "", description = "댓글 수정 실패", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
     @PutMapping
-    public ResponseEntity<Void> updateComment(@Valid CommentUpdateDto commentUpdateDto, @AuthenticationPrincipal UserDetails userDetails) {
-        commentService.updateComment(commentUpdateDto, userDetails);
+    public ResponseEntity<Void> updateComment(@Valid CommentUpdateDto commentUpdateDto, @AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        commentService.updateComment(commentUpdateDto, user);
         return ResponseEntity.ok().build();
     }
 
@@ -47,8 +51,9 @@ public class CommentController {
             @ApiResponse(responseCode = "", description = "댓글 삭제 실패", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
     @DeleteMapping
-    public ResponseEntity<Void> deleteComment(@RequestParam(value = "commentId") long commentId, @AuthenticationPrincipal UserDetails userDetails) {
-        commentService.deleteComment(commentId, userDetails);
+    public ResponseEntity<Void> deleteComment(@RequestParam(value = "commentId") long commentId, @AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        commentService.deleteComment(commentId, user);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
@@ -3,6 +3,8 @@ package com.fithub.fithubbackend.domain.board.api;
 import com.fithub.fithubbackend.domain.board.application.PostService;
 import com.fithub.fithubbackend.domain.board.dto.PostCreateDto;
 import com.fithub.fithubbackend.domain.board.dto.PostUpdateDto;
+import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.global.domain.AuthUser;
 import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
 import com.fithub.fithubbackend.global.exception.ErrorResponseDto;
@@ -11,17 +13,12 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
-
-import java.io.IOException;
 
 @RestController
 @RequiredArgsConstructor
@@ -37,12 +34,12 @@ public class PostController {
             @ApiResponse(responseCode = "409", description = "이미지가 아닌 파일 업로드 또는 이미지 확장자 검사 실패", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
     })
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Void> createPost(@Valid PostCreateDto postCreateDto, BindingResult bindingResult, @AuthenticationPrincipal UserDetails userDetails) throws IOException {
-
+    public ResponseEntity<Void> createPost(@Valid PostCreateDto postCreateDto, BindingResult bindingResult, @AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         if(bindingResult.hasErrors())
             throw new CustomException(ErrorCode.NOT_FOUND, bindingResult.getFieldError().getDefaultMessage());
 
-        postService.createPost(postCreateDto, userDetails);
+        postService.createPost(postCreateDto, user);
         return ResponseEntity.ok().build();
     }
 
@@ -53,8 +50,9 @@ public class PostController {
             @ApiResponse(responseCode = "409", description = "이미지가 아닌 파일 업로드 또는 이미지 확장자 검사 실패", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
     })
     @PutMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Void> updatePost(@Valid PostUpdateDto postUpdateDto, @AuthenticationPrincipal UserDetails userDetails) throws IOException {
-        postService.updatePost(postUpdateDto, userDetails);
+    public ResponseEntity<Void> updatePost(@Valid PostUpdateDto postUpdateDto, @AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        postService.updatePost(postUpdateDto, user);
         return ResponseEntity.ok().build();
     }
 
@@ -66,8 +64,9 @@ public class PostController {
             @Parameter(name = "postId", description = "삭제할 게시글 id")
     })
     @DeleteMapping
-    public ResponseEntity<Void> deletePost(@RequestParam(value = "postId") long postId, @AuthenticationPrincipal UserDetails userDetails) {
-        postService.deletePost(postId, userDetails);
+    public ResponseEntity<Void> deletePost(@RequestParam(value = "postId") long postId, @AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        postService.deletePost(postId, user);
         return ResponseEntity.ok().build();
     }
 
@@ -78,8 +77,9 @@ public class PostController {
             @Parameter(name = "postId", description = "좋아요한 게시글 id")
     })
     @PostMapping("/likes")
-    public ResponseEntity<Void> likesPost(@RequestParam(value = "postId") long postId, @AuthenticationPrincipal UserDetails userDetails) {
-        postService.likesPost(postId, userDetails);
+    public ResponseEntity<Void> likesPost(@RequestParam(value = "postId") long postId, @AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        postService.likesPost(postId, user);
         return ResponseEntity.ok().build();
     }
 
@@ -89,8 +89,9 @@ public class PostController {
             @Parameter(name = "postId", description = "좋아요 취소할 게시글 id")
     })
     @DeleteMapping("/likes")
-    public ResponseEntity<Void> notLikesPost(@RequestParam(value = "postId") long postId, @AuthenticationPrincipal UserDetails userDetails) {
-        postService.notLikesPost(postId, userDetails);
+    public ResponseEntity<Void> notLikesPost(@RequestParam(value = "postId") long postId, @AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        postService.notLikesPost(postId, user);
         return ResponseEntity.ok().build();
     }
 
@@ -102,8 +103,9 @@ public class PostController {
             @Parameter(name = "postId", description = "북마크한 게시글 id")
     })
     @PostMapping("/bookmark")
-    public ResponseEntity<Void> createBookMark(@RequestParam(value = "postId") long postId, @AuthenticationPrincipal UserDetails userDetails) {
-        postService.createBookmark(postId, userDetails);
+    public ResponseEntity<Void> createBookMark(@RequestParam(value = "postId") long postId, @AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        postService.createBookmark(postId, user);
         return ResponseEntity.ok().build();
     }
 
@@ -113,8 +115,9 @@ public class PostController {
             @Parameter(name = "postId", description = "북마크 삭제할 게시글 id")
     })
     @DeleteMapping("/bookmark")
-    public ResponseEntity<Void> deleteBookMark(@RequestParam(value = "postId") long postId, @AuthenticationPrincipal UserDetails userDetails) {
-        postService.deleteBookmark(postId, userDetails);
+    public ResponseEntity<Void> deleteBookMark(@RequestParam(value = "postId") long postId, @AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        postService.deleteBookmark(postId, user);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/CommentService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/CommentService.java
@@ -3,14 +3,14 @@ package com.fithub.fithubbackend.domain.board.application;
 import com.fithub.fithubbackend.domain.board.dto.CommentCreateDto;
 import com.fithub.fithubbackend.domain.board.dto.CommentUpdateDto;
 import com.fithub.fithubbackend.domain.board.post.domain.Post;
-import org.springframework.security.core.userdetails.UserDetails;
+import com.fithub.fithubbackend.domain.user.domain.User;
 
 public interface CommentService {
-    void createComment(CommentCreateDto commentCreateDto, UserDetails userDetails);
+    void createComment(CommentCreateDto commentCreateDto, User user);
 
-    void updateComment(CommentUpdateDto commentUpdateDto, UserDetails userDetails);
+    void updateComment(CommentUpdateDto commentUpdateDto, User user);
 
-    void deleteComment(long commentId, UserDetails userDetails);
+    void deleteComment(long commentId, User user);
 
     long countComment(Post post);
 

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/CommentServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/CommentServiceImpl.java
@@ -11,7 +11,6 @@ import com.fithub.fithubbackend.domain.user.repository.UserRepository;
 import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,11 +24,11 @@ public class CommentServiceImpl implements CommentService {
 
     @Override
     @Transactional
-    public void createComment(CommentCreateDto commentCreateDto, UserDetails userDetails) {
+    public void createComment(CommentCreateDto commentCreateDto, User user) {
 
         Comment comment = Comment.builder()
                 .content(commentCreateDto.getContent())
-                .user(getUser(userDetails))
+                .user(user)
                 .post(getPost(commentCreateDto.getPostId()))
                 .parent(commentCreateDto.getParentCommentId() == null ? null : getComment(commentCreateDto.getParentCommentId()))
                 .build();
@@ -38,11 +37,11 @@ public class CommentServiceImpl implements CommentService {
 
     @Override
     @Transactional
-    public void updateComment(CommentUpdateDto commentUpdateDto, UserDetails userDetails) {
+    public void updateComment(CommentUpdateDto commentUpdateDto, User user) {
 
         Comment comment = getComment(commentUpdateDto.getCommentId());
 
-        if (isWriter(getUser(userDetails), comment)) {
+        if (isWriter(user, comment)) {
             comment.setContent(commentUpdateDto.getContent());
         }
         else {
@@ -52,11 +51,11 @@ public class CommentServiceImpl implements CommentService {
 
     @Override
     @Transactional
-    public void deleteComment(long commentId, UserDetails userDetails) {
+    public void deleteComment(long commentId, User user) {
 
         Comment comment = getComment(commentId);
 
-        if (isWriter(getUser(userDetails), comment)) {
+        if (isWriter(user, comment)) {
             if (comment.getParent() == null)  {     // 최상위 댓글 삭제 시, 그 아래 댓글들 모두 삭제
                 commentRepository.deleteByParentAndPost(comment, comment.getPost());
             }
@@ -77,11 +76,6 @@ public class CommentServiceImpl implements CommentService {
     @Transactional
     public void deleteComments(Post post) {
 
-    }
-
-    @Transactional
-    public User getUser(UserDetails userDetails) {
-        return userRepository.findByEmail(userDetails.getUsername()).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 회원"));
     }
 
     @Transactional

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostService.java
@@ -2,21 +2,21 @@ package com.fithub.fithubbackend.domain.board.application;
 
 import com.fithub.fithubbackend.domain.board.dto.PostCreateDto;
 import com.fithub.fithubbackend.domain.board.dto.PostUpdateDto;
-import org.springframework.security.core.userdetails.UserDetails;
+import com.fithub.fithubbackend.domain.user.domain.User;
 
 
 public interface PostService {
-    void createPost(PostCreateDto postCreateDto, UserDetails userDetails);
+    void createPost(PostCreateDto postCreateDto, User user);
 
-    void updatePost(PostUpdateDto postUpdateDto, UserDetails userDetails);
+    void updatePost(PostUpdateDto postUpdateDto, User user);
 
-    void likesPost(long postId, UserDetails userDetails);
+    void likesPost(long postId, User user);
 
-    void createBookmark(long postId, UserDetails userDetails);
+    void createBookmark(long postId, User user);
 
-    void notLikesPost(long postId, UserDetails userDetails);
+    void notLikesPost(long postId, User user);
 
-    void deleteBookmark(long postId, UserDetails userDetails);
+    void deleteBookmark(long postId, User user);
 
-    void deletePost(long postId, UserDetails userDetails);
+    void deletePost(long postId, User user);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerAuthController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerAuthController.java
@@ -2,6 +2,10 @@ package com.fithub.fithubbackend.domain.trainer.api;
 
 import com.fithub.fithubbackend.domain.trainer.application.TrainerAuthService;
 import com.fithub.fithubbackend.domain.trainer.dto.TrainerCertificationRequestDto;
+import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.global.domain.AuthUser;
+import com.fithub.fithubbackend.global.exception.CustomException;
+import com.fithub.fithubbackend.global.exception.ErrorCode;
 import com.fithub.fithubbackend.global.exception.ErrorResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -12,8 +16,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,11 +37,9 @@ public class TrainerAuthController {
             @Parameter(name="requestDto", description = "트레이너 인증 요청 dto(자격증 이미지 파일 리스트, 자격증 이름, 경력사항 리스트)")
     })
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<String> certificationRequest(@Valid TrainerCertificationRequestDto requestDto, @AuthenticationPrincipal UserDetails userDetails) {
-        if (userDetails == null) {
-            return ResponseEntity.badRequest().body("로그인한 사용자만 가능합니다.");
-        }
-        trainerAuthService.saveTrainerCertificateRequest(requestDto, userDetails.getUsername());
+    public ResponseEntity<String> certificationRequest(@Valid TrainerCertificationRequestDto requestDto, @AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        trainerAuthService.saveTrainerCertificateRequest(requestDto, user);
         return ResponseEntity.ok().body("완료");
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerAuthService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerAuthService.java
@@ -1,7 +1,8 @@
 package com.fithub.fithubbackend.domain.trainer.application;
 
 import com.fithub.fithubbackend.domain.trainer.dto.TrainerCertificationRequestDto;
+import com.fithub.fithubbackend.domain.user.domain.User;
 
 public interface TrainerAuthService {
-    void saveTrainerCertificateRequest(TrainerCertificationRequestDto request, String email);
+    void saveTrainerCertificateRequest(TrainerCertificationRequestDto request, User user);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerAuthServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerAuthServiceImpl.java
@@ -30,9 +30,7 @@ public class TrainerAuthServiceImpl implements TrainerAuthService {
     private final AwsS3Uploader s3Uploader;
 
     @Override
-    public void saveTrainerCertificateRequest(TrainerCertificationRequestDto requestDto, String email) {
-        User user = userRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 회원입니다."));
-
+    public void saveTrainerCertificateRequest(TrainerCertificationRequestDto requestDto, User user) {
         if (trainerRepository.existsByUserId(user.getId())) {
             throw new CustomException(ErrorCode.DUPLICATE, "트레이너 인증이 완료된 회원입니다.");
         }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/api/AuthController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/api/AuthController.java
@@ -1,8 +1,10 @@
 package com.fithub.fithubbackend.domain.user.api;
 
 import com.fithub.fithubbackend.domain.user.application.AuthService;
+import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.domain.user.dto.*;
 import com.fithub.fithubbackend.global.auth.TokenInfoDto;
+import com.fithub.fithubbackend.global.domain.AuthUser;
 import com.fithub.fithubbackend.global.exception.ErrorResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -16,8 +18,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -63,8 +63,8 @@ public class AuthController {
     })
     @DeleteMapping("/sign-out")
     public ResponseEntity signOut(@CookieValue(name = "accessToken") String cookieAccessToken,
-                                  @AuthenticationPrincipal UserDetails userDetails, HttpServletResponse response, HttpServletRequest request){
-        SignOutDto signOutDto = SignOutDto.builder().accessToken(cookieAccessToken).email(userDetails.getUsername()).build();
+                                  @AuthUser User user, HttpServletResponse response, HttpServletRequest request){
+        SignOutDto signOutDto = SignOutDto.builder().accessToken(cookieAccessToken).email(user.getEmail()).build();
         authService.signOut(signOutDto, response, request);
         return new ResponseEntity<>("로그아웃 성공", HttpStatus.OK);
     }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/api/UserController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/api/UserController.java
@@ -17,8 +17,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/users")
 @RequiredArgsConstructor
@@ -30,8 +28,7 @@ public class UserController {
             @ApiResponse(responseCode = "200", description = "프로필 조회")})
     @GetMapping("/profile")
     public ResponseEntity<ProfileDto> myProfile(@AuthUser User user){
-        if(user == null) throw new CustomException(ErrorCode.UNKNOWN_ERROR, "로그인한 사용자만 가능합니다.");
-
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         return ResponseEntity.ok(userService.myProfile(user));
     }
 
@@ -45,7 +42,7 @@ public class UserController {
     })
     @PatchMapping("/profile/update")
     public ResponseEntity<User> updateProfile(@RequestPart(value = "image",required = false) MultipartFile multipartFile, @RequestPart(value = "profileDto", required = false) ProfileDto profileDto, @AuthUser User user){
-        if(user == null) throw new CustomException(ErrorCode.UNKNOWN_ERROR, "로그인한 사용자만 가능합니다.");
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         return ResponseEntity.ok(userService.updateProfile(multipartFile, profileDto, user));
     }
 

--- a/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
@@ -33,7 +33,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final String[] SHOULD_NOT_FILTER_URI_ALL_LIST = new String[]{
             "/auth/sign-in", "/auth/sign-up", "/auth/oauth/regist", "exception",
-            "/admin/sign-in", "**exception**"
+            "/admin/sign-in", "**exception**","/auth/email/**"
     };
 
     @Override


### PR DESCRIPTION
## pr 유형
- 수정

## 반영 브랜치
auth -> main

## 변경사항
- AuthenticationPrincipal로 얻어오던 UserDetails를 AuthUser 인터페이스 사용으로 User를 얻어올 수 있게 됨. 따라서 user를 한 번더 조회하지 않도록 수정
- 이메일 인증 시 필터에서 제외되지 않아 토큰 에러 상황 발생 -> 필터에서 이메일 인증 부분 제외