### PR TITLE
Feature/training: 트레이닝 마감(스케줄러, 수동), 오픈(수동) 기능 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/FithubBackendApplication.java
+++ b/src/main/java/com/fithub/fithubbackend/FithubBackendApplication.java
@@ -4,9 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.client.RestTemplate;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class FithubBackendApplication {
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainingController.java
@@ -57,10 +57,32 @@ public class TrainingController {
 //        return ResponseEntity.ok().build();
 //    }
 
+    @Operation(summary = "트레이닝 수동 마감 설정", parameters = {
+            @Parameter(name = "trainingId", description = "마감할 트레이닝 id")
+    }, responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "403", description = "해당 트레이닝을 작성한 트레이너가 아니라 수정 권한이 없음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "id에 해당하는 트레이닝이 없음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+    })
     @PutMapping("/close")
-    public ResponseEntity<Void> updateTrainingClosed(@RequestParam Long trainingId, @RequestParam boolean closed, @AuthUser User user) {
+    public ResponseEntity<Void> closeTraining(@RequestParam Long trainingId, @AuthUser User user) {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
-        trainingService.updateClosed(trainingId, closed, user);
+        trainingService.closeTraining(trainingId, user);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "트레이닝 수동 마감 해제", parameters = {
+            @Parameter(name = "trainingId", description = "오픈할 트레이닝 id")
+    }, responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "403", description = "해당 트레이닝을 작성한 트레이너가 아니라 수정 권한이 없음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "id에 해당하는 트레이닝이 없음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "409", description = "트레이닝 예약 가능한 마지막 날짜가 현재보다 이전이므로 수정 불가능. 트레이닝 수정을 통해 날짜 추가 필요", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+    })
+    @PutMapping("/open")
+    public ResponseEntity<Void> openTraining(@RequestParam Long trainingId, @AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        trainingService.openTraining(trainingId, user);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainingController.java
@@ -65,10 +65,10 @@ public class TrainingController {
             @ApiResponse(responseCode = "404", description = "id에 해당하는 트레이닝이 없음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
     @PutMapping("/close")
-    public ResponseEntity<Void> closeTraining(@RequestParam Long trainingId, @AuthUser User user) {
+    public ResponseEntity<String> closeTraining(@RequestParam Long trainingId, @AuthUser User user) {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         trainingService.closeTraining(trainingId, user);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok().body("완료");
     }
 
     @Operation(summary = "트레이닝 수동 마감 해제", parameters = {
@@ -80,10 +80,10 @@ public class TrainingController {
             @ApiResponse(responseCode = "409", description = "트레이닝 예약 가능한 마지막 날짜가 현재보다 이전이므로 수정 불가능. 트레이닝 수정을 통해 날짜 추가 필요", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
     @PutMapping("/open")
-    public ResponseEntity<Void> openTraining(@RequestParam Long trainingId, @AuthUser User user) {
+    public ResponseEntity<String> openTraining(@RequestParam Long trainingId, @AuthUser User user) {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         trainingService.openTraining(trainingId, user);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok().body("완료");
     }
 
     @Operation(summary = "트레이너의 예약 리스트 조회", parameters = {

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/PaymentServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/PaymentServiceImpl.java
@@ -84,6 +84,10 @@ public class PaymentServiceImpl implements PaymentService {
             throw new CustomException(ErrorCode.RESERVE_DATE_OR_TIME_ERROR);
         }
 
+        // TODO: 모집이 전부 다 차서 마감되었다는 알림 전송
+        if (training.isAllClosed()) {
+            training.updateClosed(true);
+        }
         reserveInfoRepository.save(reserveInfo);
     }
 
@@ -115,6 +119,11 @@ public class PaymentServiceImpl implements PaymentService {
         // 예약 내역에서 예약 시간 가져와서 트레이닝에 그 시간 다시 예약 가능하도록 변경
         Training training = reserveInfo.getTraining();
         training.addAvailableDateTime(reserveInfo.getReserveDateTime());
+        
+        // TODO: 예약이 취소돼서 모집 마감 -> 오픈되었다는 알림
+        if (training.isClosed()) {
+            training.updateClosed(false);
+        }
     }
 
     private CancelData createCancelData(Payment response) {

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingService.java
@@ -11,7 +11,8 @@ public interface TrainingService {
     Long updateTraining(TrainingCreateDto dto, Long trainingId, User user);
     void deleteTraining(Long id);
 
-    void updateClosed(Long id, boolean closed, User user);
+    void closeTraining(Long id, User user);
+    void openTraining(Long id, User user);
 
     Page<TrainersReserveInfoDto> getReservationList(User user, Pageable pageable);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingServiceImpl.java
@@ -3,6 +3,8 @@ package com.fithub.fithubbackend.domain.Training.application;
 import com.fithub.fithubbackend.domain.Training.domain.*;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingCreateDto;
 import com.fithub.fithubbackend.domain.Training.dto.TrainersReserveInfoDto;
+import com.fithub.fithubbackend.domain.Training.repository.AvailableDateRepository;
+import com.fithub.fithubbackend.domain.Training.repository.AvailableTimeRepository;
 import com.fithub.fithubbackend.domain.Training.repository.ReserveInfoRepository;
 import com.fithub.fithubbackend.domain.Training.repository.TrainingRepository;
 import com.fithub.fithubbackend.domain.trainer.domain.Trainer;
@@ -35,6 +37,9 @@ public class TrainingServiceImpl implements TrainingService {
 
     private final TrainingRepository trainingRepository;
     private final TrainerRepository trainerRepository;
+    private final AvailableDateRepository dateRepository;
+    private final AvailableTimeRepository timeRepository;
+
     private final UserRepository userRepository;
     private final ReserveInfoRepository reserveInfoRepository;
 
@@ -128,10 +133,24 @@ public class TrainingServiceImpl implements TrainingService {
 
     @Override
     @Transactional
-    public void updateClosed(Long id, boolean closed, User user) {
+    public void closeTraining(Long id, User user) {
         Training training = trainingRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "해당하는 트레이닝을 찾을 수 없습니다."));
         permissionValidate(training.getTrainer(), user.getEmail());
-        training.updateClosed(closed);
+        training.updateClosed(true);
+    }
+
+    @Override
+    @Transactional
+    public void openTraining(Long id, User user) {
+        Training training = trainingRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "해당하는 트레이닝을 찾을 수 없습니다."));
+        permissionValidate(training.getTrainer(), user.getEmail());
+
+        AvailableDate availableLastDate = dateRepository.findFirstByTrainingIdOrderByDateDesc(training.getId()).orElseThrow(() -> new CustomException(ErrorCode.UNCORRECTABLE_DATA, "db 저장 정보 없음. 수정을 통해 날짜 추가 필요"));
+        // 트레이닝 예약 가능한 마지막 날이 현재보다 이전이면 오픈 불가능
+        if (!availableLastDate.getDate().isAfter(LocalDate.now())) {
+            throw new CustomException(ErrorCode.UNCORRECTABLE_DATA, "트레이닝 예약 날짜가 현재 날짜 이후가 아니므로 불가능");
+        }
+        training.updateClosed(false);
     }
 
     @Override
@@ -179,7 +198,7 @@ public class TrainingServiceImpl implements TrainingService {
 
     public void permissionValidate(Trainer trainer, String email) {
         if (!trainer.getEmail().equals(email)) {
-            throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "해당 트레이닝을 수정할 권한이 없습니다.");
+            throw new CustomException(ErrorCode.PERMISSION_DENIED, "해당 트레이닝을 수정할 권한이 없습니다.");
         }
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingServiceImpl.java
@@ -1,10 +1,8 @@
 package com.fithub.fithubbackend.domain.Training.application;
 
 import com.fithub.fithubbackend.domain.Training.domain.*;
-import com.fithub.fithubbackend.domain.Training.dto.TrainingCreateDto;
 import com.fithub.fithubbackend.domain.Training.dto.TrainersReserveInfoDto;
-import com.fithub.fithubbackend.domain.Training.repository.AvailableDateRepository;
-import com.fithub.fithubbackend.domain.Training.repository.AvailableTimeRepository;
+import com.fithub.fithubbackend.domain.Training.dto.TrainingCreateDto;
 import com.fithub.fithubbackend.domain.Training.repository.ReserveInfoRepository;
 import com.fithub.fithubbackend.domain.Training.repository.TrainingRepository;
 import com.fithub.fithubbackend.domain.trainer.domain.Trainer;
@@ -37,8 +35,6 @@ public class TrainingServiceImpl implements TrainingService {
 
     private final TrainingRepository trainingRepository;
     private final TrainerRepository trainerRepository;
-    private final AvailableDateRepository dateRepository;
-    private final AvailableTimeRepository timeRepository;
 
     private final UserRepository userRepository;
     private final ReserveInfoRepository reserveInfoRepository;
@@ -144,11 +140,9 @@ public class TrainingServiceImpl implements TrainingService {
     public void openTraining(Long id, User user) {
         Training training = trainingRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "해당하는 트레이닝을 찾을 수 없습니다."));
         permissionValidate(training.getTrainer(), user.getEmail());
-
-        AvailableDate availableLastDate = dateRepository.findFirstByTrainingIdOrderByDateDesc(training.getId()).orElseThrow(() -> new CustomException(ErrorCode.UNCORRECTABLE_DATA, "db 저장 정보 없음. 수정을 통해 날짜 추가 필요"));
         // 트레이닝 예약 가능한 마지막 날이 현재보다 이전이면 오픈 불가능
-        if (!availableLastDate.getDate().isAfter(LocalDate.now())) {
-            throw new CustomException(ErrorCode.UNCORRECTABLE_DATA, "트레이닝 예약 날짜가 현재 날짜 이후가 아니므로 불가능");
+        if (!training.getEndDate().isAfter(LocalDate.now())) {
+            throw new CustomException(ErrorCode.UNCORRECTABLE_DATA, "트레이닝 마지막 예약 날짜가 현재 날짜 이후가 아니므로 불가능");
         }
         training.updateClosed(false);
     }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
@@ -137,4 +137,11 @@ public class Training extends BaseTimeEntity {
             }
         }
     }
+
+    public boolean isAllClosed() {
+        for (AvailableDate availableDate : this.getAvailableDates()) {
+            if (availableDate.isEnabled()) return false;
+        }
+        return true;
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/AvailableDateRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/AvailableDateRepository.java
@@ -4,7 +4,9 @@ import com.fithub.fithubbackend.domain.Training.domain.AvailableDate;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface AvailableDateRepository extends JpaRepository<AvailableDate, Long> {
     List<AvailableDate> findByTrainingIdOrderByDate(Long trainingId);
+    Optional<AvailableDate> findFirstByTrainingIdOrderByDateDesc(Long trainingId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/AvailableDateRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/AvailableDateRepository.java
@@ -1,0 +1,10 @@
+package com.fithub.fithubbackend.domain.Training.repository;
+
+import com.fithub.fithubbackend.domain.Training.domain.AvailableDate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AvailableDateRepository extends JpaRepository<AvailableDate, Long> {
+    List<AvailableDate> findByTrainingIdOrderByDate(Long trainingId);
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/AvailableTimeRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/AvailableTimeRepository.java
@@ -1,0 +1,10 @@
+package com.fithub.fithubbackend.domain.Training.repository;
+
+import com.fithub.fithubbackend.domain.Training.domain.AvailableTime;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AvailableTimeRepository extends JpaRepository<AvailableTime, Long> {
+    List<AvailableTime> findByAvailableDateIdOrderByTime(Long availableDateId);
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/AvailableTimeRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/AvailableTimeRepository.java
@@ -4,7 +4,9 @@ import com.fithub.fithubbackend.domain.Training.domain.AvailableTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface AvailableTimeRepository extends JpaRepository<AvailableTime, Long> {
     List<AvailableTime> findByAvailableDateIdOrderByTime(Long availableDateId);
+    Optional<AvailableTime> findFirstByAvailableDateIdOrderByTimeDesc(Long availableDateId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingRepository.java
@@ -3,5 +3,8 @@ package com.fithub.fithubbackend.domain.Training.repository;
 import com.fithub.fithubbackend.domain.Training.domain.Training;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TrainingRepository extends JpaRepository<Training, Long> {
+    List<Training> findByClosedFalse();
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingRepository.java
@@ -3,8 +3,9 @@ package com.fithub.fithubbackend.domain.Training.repository;
 import com.fithub.fithubbackend.domain.Training.domain.Training;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface TrainingRepository extends JpaRepository<Training, Long> {
-    List<Training> findByClosedFalse();
+    List<Training> findByClosedFalseAndEndDateLessThanEqual(LocalDate now);
 }

--- a/src/main/java/com/fithub/fithubbackend/global/component/Scheduler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/component/Scheduler.java
@@ -12,8 +12,10 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -29,7 +31,9 @@ public class Scheduler {
 
     @Async
     @Scheduled(cron = "0 */1 * * *")
+    @Transactional
     public void checkTrainingDateTimeValidation() {
+        log.info("[SCHEDULE] - checkTrainingDateTimeValidation 실행: {}", LocalDateTime.now());
         List<Training> openTrainingList = trainingRepository.findByClosedFalse();
         LocalDate date = LocalDate.now();
         LocalTime time = LocalTime.now();

--- a/src/main/java/com/fithub/fithubbackend/global/component/Scheduler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/component/Scheduler.java
@@ -36,12 +36,14 @@ public class Scheduler {
         for (Training training : openTrainingList) {
             if (!training.getEndDate().isAfter(date)) {
                 // 트레이닝 예약 가능 날짜 중 마지막 날 조회
-                List<AvailableDate> availableDates = dateRepository.findByTrainingIdOrderByDate(training.getId());
-                AvailableDate lastDate = availableDates.get(availableDates.size() - 1);
-                // 마지막 날의 시간 리스트 조회
-                List<AvailableTime> lastDateTimes = timeRepository.findByAvailableDateIdOrderByTime(lastDate.getId());
-                if (!lastDateTimes.get(lastDateTimes.size() - 1).getTime().isAfter(time)) {
-                    training.updateClosed(true);
+                AvailableDate lastDate = dateRepository.findFirstByTrainingIdOrderByDateDesc(training.getId()).orElse(null);
+                if (lastDate != null) {
+                    AvailableTime lastTime = timeRepository.findFirstByAvailableDateIdOrderByTimeDesc(lastDate.getId()).orElse(null);
+                    if (lastTime != null && !lastTime.getTime().isAfter(time)) {
+                        training.updateClosed(true);
+                    } else if (lastTime == null) {
+                        training.updateClosed(true);
+                    }
                 }
             }
         }

--- a/src/main/java/com/fithub/fithubbackend/global/component/Scheduler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/component/Scheduler.java
@@ -1,0 +1,50 @@
+package com.fithub.fithubbackend.global.component;
+
+import com.fithub.fithubbackend.domain.Training.domain.AvailableDate;
+import com.fithub.fithubbackend.domain.Training.domain.AvailableTime;
+import com.fithub.fithubbackend.domain.Training.domain.Training;
+import com.fithub.fithubbackend.domain.Training.repository.AvailableDateRepository;
+import com.fithub.fithubbackend.domain.Training.repository.AvailableTimeRepository;
+import com.fithub.fithubbackend.domain.Training.repository.TrainingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@EnableAsync
+@RequiredArgsConstructor
+public class Scheduler {
+
+    private final TrainingRepository trainingRepository;
+    private final AvailableDateRepository dateRepository;
+    private final AvailableTimeRepository timeRepository;
+
+    @Async
+    @Scheduled(cron = "0 */1 * * *")
+    public void checkTrainingDateTimeValidation() {
+        List<Training> openTrainingList = trainingRepository.findByClosedFalse();
+        LocalDate date = LocalDate.now();
+        LocalTime time = LocalTime.now();
+        for (Training training : openTrainingList) {
+            if (!training.getEndDate().isAfter(date)) {
+                // 트레이닝 예약 가능 날짜 중 마지막 날 조회
+                List<AvailableDate> availableDates = dateRepository.findByTrainingIdOrderByDate(training.getId());
+                AvailableDate lastDate = availableDates.get(availableDates.size() - 1);
+                // 마지막 날의 시간 리스트 조회
+                List<AvailableTime> lastDateTimes = timeRepository.findByAvailableDateIdOrderByTime(lastDate.getId());
+                if (!lastDateTimes.get(lastDateTimes.size() - 1).getTime().isAfter(time)) {
+                    training.updateClosed(true);
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/fithub/fithubbackend/global/component/Scheduler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/component/Scheduler.java
@@ -1,10 +1,6 @@
 package com.fithub.fithubbackend.global.component;
 
-import com.fithub.fithubbackend.domain.Training.domain.AvailableDate;
-import com.fithub.fithubbackend.domain.Training.domain.AvailableTime;
 import com.fithub.fithubbackend.domain.Training.domain.Training;
-import com.fithub.fithubbackend.domain.Training.repository.AvailableDateRepository;
-import com.fithub.fithubbackend.domain.Training.repository.AvailableTimeRepository;
 import com.fithub.fithubbackend.domain.Training.repository.TrainingRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,11 +22,9 @@ import java.util.List;
 public class Scheduler {
 
     private final TrainingRepository trainingRepository;
-    private final AvailableDateRepository dateRepository;
-    private final AvailableTimeRepository timeRepository;
 
     @Async
-    @Scheduled(cron = "0 */1 * * *")
+    @Scheduled(cron = "0 0 */1 * * *")
     @Transactional
     public void checkTrainingDateTimeValidation() {
         log.info("[SCHEDULE] - checkTrainingDateTimeValidation 실행: {}", LocalDateTime.now());
@@ -38,17 +32,8 @@ public class Scheduler {
         LocalDate date = LocalDate.now();
         LocalTime time = LocalTime.now();
         for (Training training : openTrainingList) {
-            if (!training.getEndDate().isAfter(date)) {
-                // 트레이닝 예약 가능 날짜 중 마지막 날 조회
-                AvailableDate lastDate = dateRepository.findFirstByTrainingIdOrderByDateDesc(training.getId()).orElse(null);
-                if (lastDate != null) {
-                    AvailableTime lastTime = timeRepository.findFirstByAvailableDateIdOrderByTimeDesc(lastDate.getId()).orElse(null);
-                    if (lastTime != null && !lastTime.getTime().isAfter(time)) {
-                        training.updateClosed(true);
-                    } else if (lastTime == null) {
-                        training.updateClosed(true);
-                    }
-                }
+            if (!training.getEndDate().isAfter(date) && !training.getEndHour().isAfter(time)) {
+                training.updateClosed(true);
             }
         }
     }

--- a/src/main/java/com/fithub/fithubbackend/global/component/Scheduler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/component/Scheduler.java
@@ -28,13 +28,12 @@ public class Scheduler {
     @Transactional
     public void checkTrainingDateTimeValidation() {
         log.info("[SCHEDULE] - checkTrainingDateTimeValidation 실행: {}", LocalDateTime.now());
-        List<Training> openTrainingList = trainingRepository.findByClosedFalse();
+        List<Training> openTrainingList = trainingRepository.findByClosedFalseAndEndDateLessThanEqual(LocalDate.now());
         LocalDate date = LocalDate.now();
         LocalTime time = LocalTime.now();
         for (Training training : openTrainingList) {
-            if (!training.getEndDate().isAfter(date) && !training.getEndHour().isAfter(time)) {
-                training.updateClosed(true);
-            }
+            if (training.getEndDate().isEqual(date) && !training.getEndHour().isBefore(time)) continue;
+            training.updateClosed(true);
         }
     }
 

--- a/src/main/java/com/fithub/fithubbackend/global/config/SchedulerConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/SchedulerConfig.java
@@ -1,0 +1,21 @@
+package com.fithub.fithubbackend.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+@Configuration
+public class SchedulerConfig implements SchedulingConfigurer {
+    private final int POOL_SIZE = 3;
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
+
+        threadPoolTaskScheduler.setPoolSize(POOL_SIZE);
+        threadPoolTaskScheduler.setThreadNamePrefix("fithub-scheduled-task-pool");
+        threadPoolTaskScheduler.initialize();
+
+        taskRegistrar.setTaskScheduler(threadPoolTaskScheduler);
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/fithub/fithubbackend/global/exception/ErrorCode.java
@@ -31,7 +31,8 @@ public enum ErrorCode {
     INVALID_IMAGE(HttpStatus.CONFLICT, "이미지 파일이 아닙니다."),
     
     IAMPORT_PRICE_ERROR(HttpStatus.CONFLICT, "결제된 금액이 달라 결제가 취소되었습니다."),
-    RESERVE_DATE_OR_TIME_ERROR(HttpStatus.BAD_REQUEST, "불가능한 날짜 또는 시간대입니다.");
+    RESERVE_DATE_OR_TIME_ERROR(HttpStatus.BAD_REQUEST, "불가능한 날짜 또는 시간대입니다."),
+    PERMISSION_DENIED(HttpStatus.FORBIDDEN, "해당 작업을 수행할 권한이 없습니다.");
     private final HttpStatus httpStatus;
     private final String message;
 }


### PR DESCRIPTION
## pr 유형
- 기능 추가

## 반영 브랜치
- feature/training -> main

## 변경 사항
1. 트레이닝 예약(결제)/취소(환불) 시 트레이닝 마감 설정,해제 추가
2. 스케줄러 설정 추가
3. 트레이닝 자동 마감 스케줄러 추가 (1시간마다 실행)
4. 트레이닝 수동 마감, 오픈 기능 추가

## 테스트 결과
1. 트레이닝 마감 -> 오픈으로 변경 시 변경할 트레이닝의 예약 가능 마지막 날짜가 현재 날짜보다 이전일 경우 에러 발생
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/715f20d4-e9f9-465c-a4ba-b5fe8b90cc54)
