### PR TITLE
feat: 게시글 전체, 세부 조회 기능 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/board/api/CommentController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/api/CommentController.java
@@ -15,6 +15,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/comments")
@@ -24,7 +25,6 @@ public class CommentController {
 
     @Operation(summary = "댓글 등록", responses = {
             @ApiResponse(responseCode = "200", description = "댓글 등록 완료"),
-            @ApiResponse(responseCode = "", description = "댓글 등록 실패", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
     @PostMapping
     public ResponseEntity<Void> createComment(@Valid CommentCreateDto commentCreateDto, @AuthenticationPrincipal UserDetails userDetails) {
@@ -34,7 +34,7 @@ public class CommentController {
 
     @Operation(summary = "댓글 수정", responses = {
             @ApiResponse(responseCode = "200", description = "댓글 수정 완료"),
-            @ApiResponse(responseCode = "", description = "댓글 수정 실패", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "댓글 작성자가 아니므로 댓글 수정 불가", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
     @PutMapping
     public ResponseEntity<Void> updateComment(@Valid CommentUpdateDto commentUpdateDto, @AuthenticationPrincipal UserDetails userDetails) {
@@ -44,7 +44,7 @@ public class CommentController {
 
     @Operation(summary = "댓글 삭제", responses = {
             @ApiResponse(responseCode = "200", description = "댓글 삭제 완료"),
-            @ApiResponse(responseCode = "", description = "댓글 삭제 실패", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "댓글 작성자가 아니므로 댓글 삭제 불가", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
     @DeleteMapping
     public ResponseEntity<Void> deleteComment(@RequestParam(value = "commentId") long commentId, @AuthenticationPrincipal UserDetails userDetails) {

--- a/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
@@ -2,9 +2,8 @@ package com.fithub.fithubbackend.domain.board.api;
 
 import com.fithub.fithubbackend.domain.board.application.PostService;
 import com.fithub.fithubbackend.domain.board.dto.PostCreateDto;
+import com.fithub.fithubbackend.domain.board.dto.PostInfoDto;
 import com.fithub.fithubbackend.domain.board.dto.PostUpdateDto;
-import com.fithub.fithubbackend.global.exception.CustomException;
-import com.fithub.fithubbackend.global.exception.ErrorCode;
 import com.fithub.fithubbackend.global.exception.ErrorResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -14,6 +13,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -38,9 +41,6 @@ public class PostController {
     })
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> createPost(@Valid PostCreateDto postCreateDto, BindingResult bindingResult, @AuthenticationPrincipal UserDetails userDetails) throws IOException {
-
-        if(bindingResult.hasErrors())
-            throw new CustomException(ErrorCode.NOT_FOUND, bindingResult.getFieldError().getDefaultMessage());
 
         postService.createPost(postCreateDto, userDetails);
         return ResponseEntity.ok().build();
@@ -70,6 +70,23 @@ public class PostController {
         postService.deletePost(postId, userDetails);
         return ResponseEntity.ok().build();
     }
+
+    @Operation(summary = "게시글 전체 조회", responses = {
+            @ApiResponse(responseCode = "200", description = "게시글 전체 조회 성공"),
+    })
+    @GetMapping
+    public ResponseEntity<Page<PostInfoDto>> getPosts(@PageableDefault(size = 9, sort = "id", direction = Sort.Direction.DESC) Pageable pageable, @AuthenticationPrincipal UserDetails userDetails) {
+        return ResponseEntity.ok(postService.getAllPosts(pageable, userDetails));
+    }
+
+    @Operation(summary = "게시글 세부 조회", responses = {
+            @ApiResponse(responseCode = "200", description = "게시글 세부 조회 성공"),
+    })
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostInfoDto> getPost(@PathVariable("postId") long postId, @AuthenticationPrincipal UserDetails userDetails) {
+        return ResponseEntity.ok(postService.getPostDetail(postId, userDetails));
+    }
+
 
     @Operation(summary = "게시글 좋아요", responses = {
             @ApiResponse(responseCode = "200", description = "게시글 좋아요 성공"),

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/CommentService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/CommentService.java
@@ -1,9 +1,12 @@
 package com.fithub.fithubbackend.domain.board.application;
 
 import com.fithub.fithubbackend.domain.board.dto.CommentCreateDto;
+import com.fithub.fithubbackend.domain.board.dto.CommentInfoDto;
 import com.fithub.fithubbackend.domain.board.dto.CommentUpdateDto;
 import com.fithub.fithubbackend.domain.board.post.domain.Post;
 import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.List;
 
 public interface CommentService {
     void createComment(CommentCreateDto commentCreateDto, UserDetails userDetails);
@@ -14,5 +17,5 @@ public interface CommentService {
 
     long countComment(Post post);
 
-    void deleteComments(Post post);
+    List<CommentInfoDto> getComments(Post post);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/CommentService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/CommentService.java
@@ -18,4 +18,6 @@ public interface CommentService {
     long countComment(Post post);
 
     List<CommentInfoDto> getComments(Post post);
+
+    List<CommentInfoDto> getCommentsVer2(Post post);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/CommentServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/CommentServiceImpl.java
@@ -2,6 +2,7 @@ package com.fithub.fithubbackend.domain.board.application;
 
 import com.fithub.fithubbackend.domain.board.comment.domain.Comment;
 import com.fithub.fithubbackend.domain.board.dto.CommentCreateDto;
+import com.fithub.fithubbackend.domain.board.dto.CommentInfoDto;
 import com.fithub.fithubbackend.domain.board.dto.CommentUpdateDto;
 import com.fithub.fithubbackend.domain.board.post.domain.Post;
 import com.fithub.fithubbackend.domain.board.repository.CommentRepository;
@@ -14,6 +15,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -43,7 +46,7 @@ public class CommentServiceImpl implements CommentService {
         Comment comment = getComment(commentUpdateDto.getCommentId());
 
         if (isWriter(getUser(userDetails), comment)) {
-            comment.setContent(commentUpdateDto.getContent());
+            comment.updateContent(commentUpdateDto.getContent());
         }
         else {
             throw new CustomException(ErrorCode.NOT_FOUND, "해당 회원은 댓글 작성자가 아님");
@@ -59,8 +62,14 @@ public class CommentServiceImpl implements CommentService {
         if (isWriter(getUser(userDetails), comment)) {
             if (comment.getParent() == null)  {     // 최상위 댓글 삭제 시, 그 아래 댓글들 모두 삭제
                 commentRepository.deleteByParentAndPost(comment, comment.getPost());
+                commentRepository.delete(comment);
             }
-            commentRepository.delete(comment);
+            else {
+                if (comment.getChildren().isEmpty())
+                    commentRepository.delete(comment);
+                else
+                    comment.deleteComment();
+            }
         }
         else {
             throw new CustomException(ErrorCode.NOT_FOUND, "해당 회원은 댓글 작성자가 아님");
@@ -70,13 +79,26 @@ public class CommentServiceImpl implements CommentService {
     @Override
     @Transactional
     public long countComment(Post post) {
-        return commentRepository.countByPost(post);
+        return commentRepository.countByPostAndDeletedIsNull(post);
     }
 
     @Override
     @Transactional
-    public void deleteComments(Post post) {
+    public List<CommentInfoDto> getComments(Post post) {
 
+        List<CommentInfoDto> commentInfoDtoList  = new ArrayList<>();
+        List<Comment> comments = commentRepository.findByPostWithFetch(post);
+        Map<Long, CommentInfoDto> CommentInfoDtoHashMap = new HashMap<>();
+
+        comments.forEach(c -> {
+            CommentInfoDto commentInfoDto = CommentInfoDto.fromEntity(c);
+            CommentInfoDtoHashMap.put(commentInfoDto.getCommentId(), commentInfoDto);
+            if (c.getParent() != null)
+                CommentInfoDtoHashMap.get(c.getParent().getId()).getChildComment().add(commentInfoDto);
+            else commentInfoDtoList.add(commentInfoDto);
+        });
+
+        return commentInfoDtoList;
     }
 
     @Transactional

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostService.java
@@ -1,7 +1,10 @@
 package com.fithub.fithubbackend.domain.board.application;
 
 import com.fithub.fithubbackend.domain.board.dto.PostCreateDto;
+import com.fithub.fithubbackend.domain.board.dto.PostInfoDto;
 import com.fithub.fithubbackend.domain.board.dto.PostUpdateDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.userdetails.UserDetails;
 
 
@@ -19,4 +22,9 @@ public interface PostService {
     void deleteBookmark(long postId, UserDetails userDetails);
 
     void deletePost(long postId, UserDetails userDetails);
+
+    Page<PostInfoDto> getAllPosts(Pageable pageable, UserDetails userDetails);
+
+    PostInfoDto getPostDetail(long postId, UserDetails userDetails);
+
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostServiceImpl.java
@@ -167,7 +167,8 @@ public class PostServiceImpl implements PostService {
         }
 
         if (post.getComments() != null && !post.getComments().isEmpty())
-            postInfoDto.setComment(commentService.getComments(post));
+//            postInfoDto.setComment(commentService.getComments(post));
+            postInfoDto.setComment(commentService.getCommentsVer2(post));
 
         return postInfoDto;
     }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostServiceImpl.java
@@ -1,7 +1,7 @@
 package com.fithub.fithubbackend.domain.board.application;
 
 import com.fithub.fithubbackend.domain.board.dto.PostCreateDto;
-import com.fithub.fithubbackend.domain.board.dto.PostDocumentUpdateDto;
+import com.fithub.fithubbackend.domain.board.dto.PostInfoDto;
 import com.fithub.fithubbackend.domain.board.dto.PostUpdateDto;
 import com.fithub.fithubbackend.domain.board.post.domain.Post;
 import com.fithub.fithubbackend.domain.board.repository.PostRepository;
@@ -10,11 +10,15 @@ import com.fithub.fithubbackend.domain.user.repository.UserRepository;
 import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -121,6 +125,66 @@ public class PostServiceImpl implements PostService {
         } else {
             throw new CustomException(ErrorCode.NOT_FOUND, "해당 회원은 게시글 작성자가 아님");
         }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<PostInfoDto> getAllPosts(Pageable pageable, UserDetails userDetails) {
+
+        Page<Post> posts = postRepository.findAll(pageable);
+        Page<PostInfoDto> postInfoDtos = posts.map(PostInfoDto::fromEntity);
+
+        if (userDetails != null) {
+            User user = getUser(userDetails);
+
+            postInfoDtos.forEach(postInfoDto -> {
+                if (!postInfoDto.getPostLikedUser().isEmpty() && postInfoDto.getPostLikedUser() != null ) {
+                    List<String> likedUsers = postInfoDto.getPostLikedUser().stream().map(likesInfoDto -> likesInfoDto.getLikedUser()).collect(Collectors.toList());
+                    if (likedUsers.contains(user.getNickname()))
+                        postInfoDto.checkLikes(true);
+                }
+            });
+
+            postInfoDtos.forEach(postInfoDto -> {
+                if (!postInfoDto.getPostBookmarkedUser().isEmpty() && postInfoDto.getPostBookmarkedUser() != null ) {
+                    List<String> bookmarkedUsers = postInfoDto.getPostBookmarkedUser().stream().map(bookmark -> bookmark.getUser().getNickname()).collect(Collectors.toList());
+                    if (bookmarkedUsers.contains(user.getNickname()))
+                        postInfoDto.checkBookmark(true);
+                }
+
+            });
+
+        }
+        return postInfoDtos;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PostInfoDto getPostDetail(long postId, UserDetails userDetails) {
+
+        Post post = getPost(postId);
+
+        User user = getUser(userDetails);
+        PostInfoDto postInfoDto = PostInfoDto.fromEntity(post);
+
+        if (userDetails != null) {
+            if(post.getLikes() != null && !post.getLikes().isEmpty()) {
+                List<String> likedUsers = postInfoDto.getPostLikedUser().stream().map(likesInfoDto -> likesInfoDto.getLikedUser()).collect(Collectors.toList());
+                if (likedUsers.contains(user.getNickname()))
+                    postInfoDto.checkLikes(true);
+            }
+
+            if (!post.getBookmarks().isEmpty() && post.getBookmarks() != null ) {
+                List<String> bookmarkedUsers = postInfoDto.getPostBookmarkedUser().stream().map(bookmark -> bookmark.getUser().getNickname()).collect(Collectors.toList());
+                if (bookmarkedUsers.contains(user.getNickname()))
+                    postInfoDto.checkBookmark(true);
+            }
+        }
+
+        if (post.getComments() != null && !post.getComments().isEmpty())
+            postInfoDto.setComment(commentService.getComments(post));
+
+        return postInfoDto;
     }
 
     @Transactional

--- a/src/main/java/com/fithub/fithubbackend/domain/board/comment/domain/Comment.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/comment/domain/Comment.java
@@ -1,5 +1,6 @@
 package com.fithub.fithubbackend.domain.board.comment.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fithub.fithubbackend.domain.board.post.domain.Post;
 import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.global.common.BaseTimeEntity;
@@ -8,6 +9,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.*;
 
 
 @Entity
@@ -19,11 +22,11 @@ public class Comment extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @org.hibernate.annotations.Comment("작성자")
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
@@ -37,6 +40,9 @@ public class Comment extends BaseTimeEntity {
     @JoinColumn(name = "parent_comment_id")
     private Comment parent;
 
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
+    private List<Comment> children = new ArrayList<>();
+
     @Builder
     public Comment(Post post, User user, String content, Comment parent) {
         this.post = post;
@@ -45,14 +51,12 @@ public class Comment extends BaseTimeEntity {
         this.parent = parent;
     }
 
-    public void setContent(String content) {
-        this.content = content;
+    public void deleteComment() {
+        this.deleted = true;
     }
 
-    public void deleteComment(User user, String content, Boolean deleted) {
-        this.user = user;
+    public void updateContent(String content) {
         this.content = content;
-        this.deleted = deleted;
     }
 
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/dto/CommentInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/dto/CommentInfoDto.java
@@ -1,8 +1,10 @@
 package com.fithub.fithubbackend.domain.board.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fithub.fithubbackend.domain.board.comment.domain.Comment;
 import lombok.Data;
 
+import java.time.LocalDateTime;
 import java.util.*;
 
 @Data
@@ -22,6 +24,9 @@ public class CommentInfoDto {
 
     private boolean deleted;
 
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createdDate;
+
 
     private List<CommentInfoDto> childComment = new ArrayList<>();
 
@@ -36,6 +41,7 @@ public class CommentInfoDto {
         commentInfoDto.setProfileInputName(comment.getUser().getProfileImg().getInputName());
         commentInfoDto.setContent(comment.getContent());
         commentInfoDto.setParentCommentId(comment.getParent() == null ? null : comment.getParent().getId());
+        commentInfoDto.setCreatedDate(comment.getCreatedDate());
 
         return commentInfoDto;
     }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/dto/CommentInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/dto/CommentInfoDto.java
@@ -1,0 +1,44 @@
+package com.fithub.fithubbackend.domain.board.dto;
+
+import com.fithub.fithubbackend.domain.board.comment.domain.Comment;
+import lombok.Data;
+
+import java.util.*;
+
+@Data
+public class CommentInfoDto {
+
+    private Long commentId;
+
+    private String writerNickName;
+
+    private String content;
+
+    private Long parentCommentId;
+
+    private String profileUrl;
+
+    private String profileInputName;
+
+    private boolean deleted;
+
+
+    private List<CommentInfoDto> childComment = new ArrayList<>();
+
+
+    public static CommentInfoDto fromEntity(Comment comment) {
+        CommentInfoDto commentInfoDto = new CommentInfoDto();
+
+        commentInfoDto.setCommentId(comment.getId());
+        commentInfoDto.setDeleted(comment.getDeleted() == null ? false : comment.getDeleted());
+        commentInfoDto.setWriterNickName(comment.getUser().getNickname());
+        commentInfoDto.setProfileUrl(comment.getUser().getProfileImg().getUrl());
+        commentInfoDto.setProfileInputName(comment.getUser().getProfileImg().getInputName());
+        commentInfoDto.setContent(comment.getContent());
+        commentInfoDto.setParentCommentId(comment.getParent() == null ? null : comment.getParent().getId());
+
+        return commentInfoDto;
+    }
+
+
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/board/dto/LikesInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/dto/LikesInfoDto.java
@@ -1,0 +1,24 @@
+package com.fithub.fithubbackend.domain.board.dto;
+
+import com.fithub.fithubbackend.domain.board.post.domain.Likes;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class LikesInfoDto {
+
+    private String likedUser;
+
+    private String likedUserProfileUrl;
+
+    private String likedUserBio;
+
+    public static LikesInfoDto fromEntity(Likes likes) {
+        return LikesInfoDto.builder()
+                .likedUser(likes.getUser().getNickname())
+                .likedUserProfileUrl(likes.getUser().getProfileImg().getUrl())
+                .likedUserBio(likes.getUser().getBio()).build();
+    }
+
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostInfoDto.java
@@ -1,25 +1,110 @@
 package com.fithub.fithubbackend.domain.board.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fithub.fithubbackend.domain.board.comment.domain.Comment;
+import com.fithub.fithubbackend.domain.board.post.domain.Bookmark;
+import com.fithub.fithubbackend.domain.board.post.domain.Post;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Data;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Data
 @Schema(description = "게시글 dto")
 public class PostInfoDto {
 
-    @NotNull
     @Schema(description = "게시글 id")
-    private Long id;
+    private Long postId;
 
-    @NotNull
     @Schema(description = "게시글 내용")
-    private String content;
+    private String postContent;
 
     @Schema(description = "게시글 작성자")
-    private String userId;
+    private String postWriter;
 
-    @Schema(description = "게시글 헤시태그")
-    private String hashTags;
+    @Schema(description = "게시글 작성자 프로필 url")
+    private String postWriterProfileUrl;
 
+    @Schema(description = "게시글 해시태그")
+    private List<String> postHashTags;
+
+    @Schema(description = "게시글 조회수")
+    private Integer postViews;
+
+    @Schema(description = "게시글 좋아요 수")
+    private Long postLikesCount;
+
+    @Schema(description = "게시글 좋아요 리스트")
+    private List<LikesInfoDto> postLikedUser;
+
+    @JsonIgnore
+    private List<Bookmark> postBookmarkedUser;
+
+    @Schema(description = "게시글 첨부 이미지 url 리스트")
+    private List<String> postDocumentUrls;
+
+    @Schema(description = "게시글 댓글 수")
+    private Integer postCommentsCount;
+
+    @Schema(description = "게시글 댓글 리스트")
+    private List<CommentInfoDto> postComments;
+
+    @Schema(description = "게시글 좋아요 여부")
+    private boolean isLiked;
+
+    @Schema(description = "게시글 북마크 여부")
+    private boolean isBookmark;
+
+    public void setComment(List<CommentInfoDto> comments) {
+        this.postComments = comments;
+    }
+
+    public void checkLikes(boolean isLiked) {
+        this.isLiked = isLiked;
+    }
+
+    public void checkBookmark(boolean isBookmark) {
+        this.isBookmark = isBookmark;
+    }
+
+    @Builder
+    public PostInfoDto(Long postId, String postContent, String postWriter, String postWriterProfileUrl, List<String> postHashTags,
+                       Integer postViews, Long postLikesCount, List<LikesInfoDto> postLikedUser, List<String> postDocumentUrls, Integer postCommentsCount,
+                       List<Bookmark> postBookmarkedUser) {
+        this.postId = postId;
+        this.postContent = postContent;
+        this.postWriter = postWriter;
+        this.postWriterProfileUrl = postWriterProfileUrl;
+        this.postHashTags = postHashTags;
+        this.postViews = postViews;
+        this.postLikesCount = postLikesCount;
+        this.postLikedUser = postLikedUser;
+        this.postDocumentUrls = postDocumentUrls;
+        this.postCommentsCount = postCommentsCount;
+        this.postBookmarkedUser = postBookmarkedUser;
+    }
+
+    public static PostInfoDto fromEntity(Post post) {
+
+        Integer commentsCount = 0;
+        for (Comment comment: post.getComments()) 
+            if (comment.getDeleted() == null)
+                commentsCount++;
+        
+        return PostInfoDto.builder()
+                .postId(post.getId())
+                .postContent(post.getContent())
+                .postWriter(post.getUser().getNickname())
+                .postWriterProfileUrl(post.getUser().getProfileImg().getUrl())
+                .postViews(post.getViews())
+                .postLikesCount((long) post.getLikes().size())
+                .postCommentsCount(commentsCount)
+                .postLikedUser(post.getLikes().stream().map(LikesInfoDto::fromEntity).collect(Collectors.toList()))
+                .postHashTags(post.getPostHashtags().stream().map(hashtag -> hashtag.getHashtag().getContent()).collect(Collectors.toList()))
+                .postDocumentUrls(post.getPostDocuments().stream().map(postDocument -> postDocument.getUrl()).collect(Collectors.toList()))
+                .postBookmarkedUser(post.getBookmarks())
+                .build();
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostInfoDto.java
@@ -1,5 +1,6 @@
 package com.fithub.fithubbackend.domain.board.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fithub.fithubbackend.domain.board.comment.domain.Comment;
 import com.fithub.fithubbackend.domain.board.post.domain.Bookmark;
@@ -8,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -17,6 +19,10 @@ public class PostInfoDto {
 
     @Schema(description = "게시글 id")
     private Long postId;
+
+    @Schema(description = "게시글 생성일")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime postCreatedDate;
 
     @Schema(description = "게시글 내용")
     private String postContent;
@@ -72,7 +78,7 @@ public class PostInfoDto {
     @Builder
     public PostInfoDto(Long postId, String postContent, String postWriter, String postWriterProfileUrl, List<String> postHashTags,
                        Integer postViews, Long postLikesCount, List<LikesInfoDto> postLikedUser, List<String> postDocumentUrls, Integer postCommentsCount,
-                       List<Bookmark> postBookmarkedUser) {
+                       List<Bookmark> postBookmarkedUser, LocalDateTime postCreatedDate) {
         this.postId = postId;
         this.postContent = postContent;
         this.postWriter = postWriter;
@@ -84,6 +90,7 @@ public class PostInfoDto {
         this.postDocumentUrls = postDocumentUrls;
         this.postCommentsCount = postCommentsCount;
         this.postBookmarkedUser = postBookmarkedUser;
+        this.postCreatedDate = postCreatedDate;
     }
 
     public static PostInfoDto fromEntity(Post post) {
@@ -105,6 +112,7 @@ public class PostInfoDto {
                 .postHashTags(post.getPostHashtags().stream().map(hashtag -> hashtag.getHashtag().getContent()).collect(Collectors.toList()))
                 .postDocumentUrls(post.getPostDocuments().stream().map(postDocument -> postDocument.getUrl()).collect(Collectors.toList()))
                 .postBookmarkedUser(post.getBookmarks())
+                .postCreatedDate(post.getCreatedDate())
                 .build();
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/post/domain/Post.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/post/domain/Post.java
@@ -31,6 +31,8 @@ public class Post extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     private User user;
 
+
+    @BatchSize(size = 100)
     @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 

--- a/src/main/java/com/fithub/fithubbackend/domain/board/repository/CommentRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/repository/CommentRepository.java
@@ -3,11 +3,18 @@ package com.fithub.fithubbackend.domain.board.repository;
 import com.fithub.fithubbackend.domain.board.comment.domain.Comment;
 import com.fithub.fithubbackend.domain.board.post.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     void deleteByParentAndPost(Comment comment, Post post);
 
-    Long countByPost(Post post);
+    Long countByPostAndDeletedIsNull(Post post);
 
+    @Query(value = "SELECT c  FROM Comment c  LEFT JOIN FETCH Comment pc ON c.parent = pc " +
+            "WHERE c.post = :post ORDER BY COALESCE(pc.id, 0) ASC, c.createdDate ASC")
+    List<Comment> findByPostWithFetch(@Param("post") Post post);
 }


### PR DESCRIPTION
## PR 유형
- 기능 추가 

## 반영 브랜치
- feature/post -> main

## 변경 사항
- 게시글 전체, 세부 조회 

## 테스트 결과 

### 게시글 전체 조회
> GET /posts

![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/98f7c6bc-1f12-4776-a431-c5bb0abd9262)

- liked, bookmark -> 로그인한 사용자의 게시글 좋아요, 북마크 여부 확인
- 전체 조회는 댓글 리스트 대신 댓글 개수만 확인 가능

### 게시글 세부 조회 ver 1
> GET /posts/{postId}

![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/d04bb2e8-6193-4b96-99dd-b8831dde2a0f)
![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/ff7740fe-3813-4843-9679-4cb85b757e0c)
![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/3e789264-1fdd-4aab-b58d-c356faa92f86)

- "deleted" -> 댓글 삭제 여부 체크
- 댓글 수는 deleted가 true인 댓글 제외하고 카운트

### 게시글 세부 조회 ver 2
> GET /posts/{postId}

![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/4875d3ef-c033-430a-bdde-979905d0dd4a)
![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/b2719be3-d1b5-45d0-9301-0ea1cbde639b)
![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/5d2ca73e-4d76-4a31-b4e8-4ffd2c2b190f)


## 이슈
- 댓글 조회 기능을 두 가지 방법으로 구현했는데 어떤 방법이 편한지 게시글 담당자분과 얘기 나눠보겠습니다!