### PR TITLE
Feature/training: 트레이닝 찜/취소 분리, 트레이닝 삭제 기능 추가, filter 거치지 않을 api 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainingController.java
@@ -31,6 +31,7 @@ public class TrainingController {
 
     @Operation(summary = "트레이닝 생성, swagger에서 테스트 불가능, 이미지는 모두 images로 주면 됨", responses = {
             @ApiResponse(responseCode = "200", description = "생성됨"),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
             @ApiResponse(responseCode = "409", description = "예약 가능 날짜에 현재보다 이전 날짜가 들어있음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
     @PostMapping
@@ -41,26 +42,38 @@ public class TrainingController {
 
 //    @Operation(summary = "트레이닝 수정", responses = {
 //            @ApiResponse(responseCode = "200", description = "수정됨"),
+//            @ApiResponse(responseCode = "400", description = "수정 날짜에 현재보다 이전 날짜가 들어있음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
+//            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
 //            @ApiResponse(responseCode = "409", description = "마감 처리 된 트레이닝을 수정하려고 함", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
-//            @ApiResponse(responseCode = "409", description = "수정 날짜에 현재보다 이전 날짜가 들어있음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
 //    })
 //    @PutMapping
-//    public ResponseEntity<Long> updateTraining(@RequestBody @Valid TrainingCreateDto dto, @RequestParam Long trainingId, @AuthenticationPrincipal UserDetails userDetails) {
+//    public ResponseEntity<Long> updateTraining(@RequestBody @Valid TrainingCreateDto dto, @RequestParam Long trainingId, @AuthUser User user) {
 //        // TODO: 예약 관련 기능 끝난 후 수정 필요
-//        return ResponseEntity.ok(trainingService.updateTraining(dto, trainingId, userDetails.getUsername()));
+//        if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+//        return ResponseEntity.ok(trainingService.updateTraining(dto, trainingId, user.getEmail()));
 //    }
 
-//    @DeleteMapping
-//    public ResponseEntity<Void> deleteTraining(@RequestParam Long trainingId) {
-//        // TODO: delete 작업 필요
-//        trainingService.deleteTraining(trainingId);
-//        return ResponseEntity.ok().build();
-//    }
+    @Operation(summary = "트레이닝 삭제 (soft delete)", parameters = {
+            @Parameter(name = "trainingId", description = "삭제할 트레이닝 id")
+    }, responses = {
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "400", description = "해당 트레이닝에 취소/완료되지 않은 예약이 남아 삭제 불가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "403", description = "해당 트레이닝을 작성한 트레이너가 아니라 삭제 권한이 없음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "id에 해당하는 트레이닝이 없음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+    })
+    @DeleteMapping
+    public ResponseEntity<Void> deleteTraining(@RequestParam Long trainingId, @AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        trainingService.deleteTraining(trainingId, user.getEmail());
+        return ResponseEntity.ok().build();
+    }
 
     @Operation(summary = "트레이닝 수동 마감 설정", parameters = {
             @Parameter(name = "trainingId", description = "마감할 트레이닝 id")
     }, responses = {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
             @ApiResponse(responseCode = "403", description = "해당 트레이닝을 작성한 트레이너가 아니라 수정 권한이 없음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
             @ApiResponse(responseCode = "404", description = "id에 해당하는 트레이닝이 없음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
@@ -75,6 +88,7 @@ public class TrainingController {
             @Parameter(name = "trainingId", description = "오픈할 트레이닝 id")
     }, responses = {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
             @ApiResponse(responseCode = "403", description = "해당 트레이닝을 작성한 트레이너가 아니라 수정 권한이 없음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
             @ApiResponse(responseCode = "404", description = "id에 해당하는 트레이닝이 없음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
             @ApiResponse(responseCode = "409", description = "트레이닝 예약 가능한 마지막 날짜가 현재보다 이전이므로 수정 불가능. 트레이닝 수정을 통해 날짜 추가 필요", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainingController.java
@@ -63,10 +63,10 @@ public class TrainingController {
             @ApiResponse(responseCode = "404", description = "id에 해당하는 트레이닝이 없음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
     @DeleteMapping
-    public ResponseEntity<Void> deleteTraining(@RequestParam Long trainingId, @AuthUser User user) {
+    public ResponseEntity<String> deleteTraining(@RequestParam Long trainingId, @AuthUser User user) {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         trainingService.deleteTraining(trainingId, user.getEmail());
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok().body("완료");
     }
 
     @Operation(summary = "트레이닝 수동 마감 설정", parameters = {

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/UserTrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/UserTrainingController.java
@@ -33,7 +33,6 @@ public class UserTrainingController {
 
     @Operation(summary = "트레이닝 전체 조회, page 사용 (size = 9, sort=\"id\" desc 적용되어있음. swagger에서 보낼 때 따로 지정하는 거 없으면 parameter에 pageable은 다 지우고 보내도 됨)")
     @GetMapping("/all")
-    // TODO: Security permitAll, filter X 추가
     public ResponseEntity<Page<TrainingOutlineDto>> searchAll(@PageableDefault(size = 9, sort = "id",  direction = Sort.Direction.DESC) Pageable pageable) {
         return ResponseEntity.ok(userTrainingService.searchAll(pageable));
     }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/UserTrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/UserTrainingController.java
@@ -41,6 +41,7 @@ public class UserTrainingController {
             @Parameter(name = "trainingId", description = "조회할 트레이닝의 primary key(id)")
     }, responses = {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "삭제된 트레이닝", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
             @ApiResponse(responseCode = "404", description = "해당하는 트레이닝 존재 X", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
     })
     @GetMapping

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/UserTrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/UserTrainingController.java
@@ -40,33 +40,18 @@ public class UserTrainingController {
 
     @Operation(summary = "트레이닝 하나 상세 조회", parameters = {
             @Parameter(name = "trainingId", description = "조회할 트레이닝의 primary key(id)")
+    }, responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "해당하는 트레이닝 존재 X", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
     })
     @GetMapping
     public ResponseEntity<TrainingInfoDto> searchById(@RequestParam Long trainingId) {
         return ResponseEntity.ok(userTrainingService.searchById(trainingId));
     }
 
-    @Operation(summary = "트레이닝 찜 여부 조회", parameters = {
-            @Parameter(name = "trainingId", description = "조회할 트레이닝의 primary key(id)")
-    })
-    @GetMapping("/check/likes")
-    public ResponseEntity<Boolean> isLikesTraining(@RequestParam Long trainingId, @AuthUser User user) {
-        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
-        return ResponseEntity.ok(userTrainingService.isLikesTraining(trainingId, user));
-    }
-
-    @Operation(summary = "트레이닝 찜 설정 및 해제", parameters = {
-            @Parameter(name = "trainingId", description = "조회할 트레이닝의 primary key(id)")
-    })
-    @PostMapping("/likes")
-    public ResponseEntity<String> likes(@RequestParam Long trainingId, boolean likes, @AuthUser User user) {
-        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
-        userTrainingService.likesTraining(trainingId, likes, user);
-        return ResponseEntity.ok().body("완료");
-    }
-
     @Operation(summary = "트레이닝 찜 리스트 조회", responses = {
             @ApiResponse(responseCode = "200", description = "리스트 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 회원", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
     @GetMapping("/likes")
@@ -75,11 +60,52 @@ public class UserTrainingController {
         return ResponseEntity.ok(userTrainingService.getTrainingLikesList(user));
     }
 
+    @Operation(summary = "트레이닝 찜 여부 조회", parameters = {
+            @Parameter(name = "trainingId", description = "조회할 트레이닝의 primary key(id)")
+    }, responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "찜 여부를 조회할 트레이닝이 존재하지 않음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
+    })
+    @GetMapping("/check/likes")
+    public ResponseEntity<Boolean> isLikesTraining(@RequestParam Long trainingId, @AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        return ResponseEntity.ok(userTrainingService.isLikesTraining(trainingId, user));
+    }
+
+    @Operation(summary = "트레이닝 찜 설정", parameters = {
+            @Parameter(name = "trainingId", description = "조회할 트레이닝의 primary key(id)")
+    }, responses = {
+            @ApiResponse(responseCode = "400", description = "트레이너는 자신의 트레이닝 찜 불가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "해당 트레이닝이 존재하지 않음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
+    })
+    @PostMapping("/likes")
+    public ResponseEntity<String> likes(@RequestParam Long trainingId, @AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        userTrainingService.likesTraining(trainingId, user);
+        return ResponseEntity.ok().body("완료");
+    }
+
+    @Operation(summary = "트레이닝 찜 취소", parameters = {
+            @Parameter(name = "trainingId", description = "조회할 트레이닝의 primary key(id)")
+    }, responses = {
+            @ApiResponse(responseCode = "404", description = "해당 트레이닝이 존재하지 않음"),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "409", description = "해당 트레이닝을 찜하지 않아 찜 취소 불가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
+    })
+    @DeleteMapping("/likes")
+    public ResponseEntity<String> cancelTrainingLikes(@RequestParam Long trainingId, @AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        userTrainingService.cancelTrainingLikes(trainingId, user);
+        return ResponseEntity.ok().body("완료");
+    }
+
     @Operation(summary = "회원의 트레이닝 예약 리스트", parameters = {
             @Parameter(name = "pageable", description = "조회할 목록의 page, size, sort(기본은 id desc(생성 순), 예약된 트레이닝 날짜 순은 reserveDateTime으로 주면 됨)")
     }, responses = {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 회원", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
     })
     @GetMapping("/reservations")
     public ResponseEntity<Page<UsersReserveInfoDto>> getUsersTrainingReservationList(@AuthUser User user,

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/PaymentServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/PaymentServiceImpl.java
@@ -81,7 +81,7 @@ public class PaymentServiceImpl implements PaymentService {
 
         if (!training.removeAvailableDateTime(dto.getReserveDateTime())) {
             log.error("예약 완료 실패 - 예약 가능한 시간대가 없음: {}", dto.getReserveDateTime());
-            throw new CustomException(ErrorCode.RESERVE_DATE_OR_TIME_ERROR);
+            throw new CustomException(ErrorCode.DATE_OR_TIME_ERROR);
         }
 
         // TODO: 모집이 전부 다 차서 마감되었다는 알림 전송

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingService.java
@@ -8,8 +8,8 @@ import org.springframework.data.domain.Pageable;
 
 public interface TrainingService {
     Long createTraining(TrainingCreateDto dto, User user);
-    Long updateTraining(TrainingCreateDto dto, Long trainingId, User user);
-    void deleteTraining(Long id);
+    Long updateTraining(TrainingCreateDto dto, Long trainingId, String email);
+    void deleteTraining(Long id, String email);
 
     void closeTraining(Long id, User user);
     void openTraining(Long id, User user);

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingServiceImpl.java
@@ -5,6 +5,7 @@ import com.fithub.fithubbackend.domain.Training.dto.TrainersReserveInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingCreateDto;
 import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
 import com.fithub.fithubbackend.domain.Training.repository.ReserveInfoRepository;
+import com.fithub.fithubbackend.domain.Training.repository.TrainingLikesRepository;
 import com.fithub.fithubbackend.domain.Training.repository.TrainingRepository;
 import com.fithub.fithubbackend.domain.trainer.domain.Trainer;
 import com.fithub.fithubbackend.domain.trainer.repository.TrainerRepository;
@@ -36,6 +37,7 @@ public class TrainingServiceImpl implements TrainingService {
 
     private final TrainingRepository trainingRepository;
     private final TrainerRepository trainerRepository;
+    private final TrainingLikesRepository trainingLikesRepository;
 
     private final UserRepository userRepository;
     private final ReserveInfoRepository reserveInfoRepository;
@@ -133,7 +135,12 @@ public class TrainingServiceImpl implements TrainingService {
             throw new CustomException(ErrorCode.BAD_REQUEST, "해당 트레이닝에 완료 또는 취소되지 않은 예약이 존재해 삭제 작업이 불가능합니다.");
         }
 
-        training.updateDeleted(true);
+        List<TrainingLikes> trainingLikesList = trainingLikesRepository.findByTrainingId(id);
+        for (TrainingLikes trainingLikes : trainingLikesList) {
+            trainingLikesRepository.delete(trainingLikes);
+        }
+
+        trainingRepository.delete(training);
     }
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingServiceImpl.java
@@ -126,11 +126,12 @@ public class TrainingServiceImpl implements TrainingService {
     }
 
     @Override
+    @Transactional
     public void deleteTraining(Long id, String email) {
         Training training = trainingRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 트레이닝입니다."));
         permissionValidate(training.getTrainer(), email);
 
-        if (reserveInfoRepository.existsByTrainingIdAndNotStatusNotIn(id,
+        if (reserveInfoRepository.existsByTrainingIdAndStatusNotIn(id,
                 new ReserveStatus[]{ReserveStatus.CANCEL, ReserveStatus.NOSHOW, ReserveStatus.COMPLETE})) {
             throw new CustomException(ErrorCode.BAD_REQUEST, "해당 트레이닝에 완료 또는 취소되지 않은 예약이 존재해 삭제 작업이 불가능합니다.");
         }
@@ -140,7 +141,7 @@ public class TrainingServiceImpl implements TrainingService {
             trainingLikesRepository.delete(trainingLikes);
         }
 
-        trainingRepository.delete(training);
+        training.updateDeleted(true);
     }
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingService.java
@@ -15,7 +15,9 @@ public interface UserTrainingService {
     TrainingInfoDto searchById(Long id);
 
     boolean isLikesTraining(Long trainingId, User user);
-    void likesTraining(Long trainingId, boolean likes, User user);
+    void likesTraining(Long trainingId, User user);
+    void cancelTrainingLikes(Long trainingId, User user);
+
     List<TrainingLikesInfoDto> getTrainingLikesList(User user);
 
     Page<UsersReserveInfoDto> getTrainingReservationList(User user, Pageable pageable);

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingServiceImpl.java
@@ -8,7 +8,6 @@ import com.fithub.fithubbackend.domain.Training.repository.ReserveInfoRepository
 import com.fithub.fithubbackend.domain.Training.repository.TrainingLikesRepository;
 import com.fithub.fithubbackend.domain.Training.repository.TrainingRepository;
 import com.fithub.fithubbackend.domain.user.domain.User;
-import com.fithub.fithubbackend.domain.user.repository.UserRepository;
 import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +24,6 @@ public class UserTrainingServiceImpl implements UserTrainingService {
 
     private final TrainingRepository trainingRepository;
     private final TrainingLikesRepository trainingLikesRepository;
-    private final UserRepository userRepository;
     private final ReserveInfoRepository reserveInfoRepository;
 
     @Override
@@ -50,27 +48,34 @@ public class UserTrainingServiceImpl implements UserTrainingService {
     @Override
     @Transactional(readOnly = true)
     public boolean isLikesTraining(Long trainingId, User user) {
-        Training training = trainingRepository.findById(trainingId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 트레이닝입니다."));
-        checkClosed(training.isClosed());
+        if (!trainingRepository.existsById(trainingId)) {
+            throw new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 트레이닝입니다.");
+        }
         return trainingLikesRepository.existsByTrainingIdAndUserId(trainingId, user.getId());
     }
 
     @Override
     @Transactional
-    public void likesTraining(Long trainingId, boolean likes, User user) {
+    public void likesTraining(Long trainingId, User user) {
         Training training = trainingRepository.findById(trainingId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 트레이닝입니다."));
         checkClosed(training.isClosed());
 
         if (user.getId().equals(training.getTrainer().getUser().getId())) {
             throw new CustomException(ErrorCode.UNKNOWN_ERROR, "트레이너는 자신의 트레이닝을 찜할 수 없습니다.");
         }
-        if (likes) {
-            TrainingLikes trainingLikes = TrainingLikes.builder().training(training).user(user).build();
-            trainingLikesRepository.save(trainingLikes);
-        } else {
-            TrainingLikes trainingLikes = trainingLikesRepository.findByTrainingIdAndUserId(trainingId, user.getId()).orElseThrow(() -> new CustomException(ErrorCode.UNCORRECTABLE_DATA, "트레이닝을 찜하지 않았습니다."));
-            trainingLikesRepository.delete(trainingLikes);
+
+        TrainingLikes trainingLikes = TrainingLikes.builder().training(training).user(user).build();
+        trainingLikesRepository.save(trainingLikes);
+    }
+
+    @Override
+    @Transactional
+    public void cancelTrainingLikes(Long trainingId, User user) {
+        if (!trainingRepository.existsById(trainingId)) {
+            throw new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 트레이닝입니다.");
         }
+        TrainingLikes trainingLikes = trainingLikesRepository.findByTrainingIdAndUserId(trainingId, user.getId()).orElseThrow(() -> new CustomException(ErrorCode.UNCORRECTABLE_DATA, "트레이닝을 찜하지 않았습니다."));
+        trainingLikesRepository.delete(trainingLikes);
     }
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingServiceImpl.java
@@ -29,7 +29,7 @@ public class UserTrainingServiceImpl implements UserTrainingService {
     @Override
     @Transactional(readOnly = true)
     public Page<TrainingOutlineDto> searchAll(Pageable pageable) {
-        Page<Training> trainingPage = trainingRepository.findAll(pageable);
+        Page<Training> trainingPage = trainingRepository.findAllByDeletedFalse(pageable);
         return trainingPage.map(TrainingOutlineDto::toDto);
     }
 
@@ -37,6 +37,10 @@ public class UserTrainingServiceImpl implements UserTrainingService {
     @Transactional(readOnly = true)
     public TrainingInfoDto searchById(Long id) {
         Training training = trainingRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "해당하는 트레이닝이 존재하지 않습니다."));
+        if (training.isDeleted()) {
+            throw new CustomException(ErrorCode.BAD_REQUEST, "삭제된 트레이닝입니다.");
+        }
+
         TrainingInfoDto dto = TrainingInfoDto.toDto(training);
         if (training.getImages() != null && !training.getImages().isEmpty()) {
             List<TrainingDocumentDto> images = training.getImages().stream().map(TrainingDocumentDto::toDto).toList();

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
@@ -77,6 +77,9 @@ public class Training extends BaseTimeEntity {
     @JsonIgnoreProperties({"training"})
     private List<AvailableDate> availableDates;
 
+    @NotNull
+    private boolean deleted;
+
     @Builder
     public Training(TrainingCreateDto dto, Trainer trainer) {
         this.title = dto.getTitle();
@@ -92,6 +95,7 @@ public class Training extends BaseTimeEntity {
         this.trainer = trainer;
         this.availableDates = new ArrayList<>();
         this.images = new ArrayList<>();
+        this.deleted = false;
     }
 
     public void updateTraining(TrainingCreateDto dto) {
@@ -108,6 +112,10 @@ public class Training extends BaseTimeEntity {
 
     public void updateClosed(boolean closed) {
         this.closed = closed;
+    }
+
+    public void updateDeleted(boolean deleted) {
+        this.deleted = deleted;
     }
 
     public void addImages(TrainingDocument document) {

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
@@ -14,7 +14,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.SQLDelete;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -24,7 +23,6 @@ import java.util.List;
 
 @Entity
 @Getter
-@SQLDelete(sql = "UPDATE training SET deleted = 1 WHERE training_id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Training extends BaseTimeEntity {
 
@@ -32,7 +30,7 @@ public class Training extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(optional = false, cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JsonIgnore
     private Trainer trainer;
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
@@ -14,6 +14,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.SQLDelete;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -23,6 +24,7 @@ import java.util.List;
 
 @Entity
 @Getter
+@SQLDelete(sql = "UPDATE training SET deleted = 1 WHERE training_id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Training extends BaseTimeEntity {
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
@@ -10,5 +10,5 @@ public interface ReserveInfoRepository extends JpaRepository<ReserveInfo, Long> 
     Page<ReserveInfo> findByTrainerId(Long trainerId, Pageable pageable);
     Page<ReserveInfo> findByUserId(Long userId, Pageable pageable);
 
-    boolean existsByTrainingIdAndNotStatusNotIn(Long trainingId, ReserveStatus[] statuses);
+    boolean existsByTrainingIdAndStatusNotIn(Long trainingId, ReserveStatus[] statuses);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
@@ -1,6 +1,7 @@
 package com.fithub.fithubbackend.domain.Training.repository;
 
 import com.fithub.fithubbackend.domain.Training.domain.ReserveInfo;
+import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ReserveInfoRepository extends JpaRepository<ReserveInfo, Long> {
     Page<ReserveInfo> findByTrainerId(Long trainerId, Pageable pageable);
     Page<ReserveInfo> findByUserId(Long userId, Pageable pageable);
+
+    boolean existsByTrainingIdAndNotStatusNotIn(Long trainingId, ReserveStatus[] statuses);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingLikesRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingLikesRepository.java
@@ -10,4 +10,6 @@ public interface TrainingLikesRepository extends JpaRepository<TrainingLikes, Lo
     Optional<TrainingLikes> findByTrainingIdAndUserId(Long trainingId, Long userId);
     boolean existsByTrainingIdAndUserId(Long trainingId, Long userId);
     List<TrainingLikes> findByUserId(Long userId);
+
+    List<TrainingLikes> findByTrainingId(Long trainingId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingRepository.java
@@ -1,11 +1,15 @@
 package com.fithub.fithubbackend.domain.Training.repository;
 
 import com.fithub.fithubbackend.domain.Training.domain.Training;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
 import java.util.List;
 
 public interface TrainingRepository extends JpaRepository<Training, Long> {
+
+    Page<Training> findAllByDeletedFalse(Pageable pageable);
     List<Training> findByClosedFalseAndEndDateLessThanEqual(LocalDate now);
 }

--- a/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
@@ -36,8 +36,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/admin/sign-in", "**exception**","/auth/email/**"
     };
 
+    private static final String[] SHOULD_NOT_FILTER_GET_URI_LIST = new String[] {
+            "/users/training/", "/users/training/all"
+    };
+
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        if (request.getMethod().equals("GET")) {
+            return Arrays.stream(SHOULD_NOT_FILTER_GET_URI_LIST).anyMatch(e -> new AntPathMatcher().match(e, request.getServletPath()));
+        }
         return Arrays.stream(SHOULD_NOT_FILTER_URI_ALL_LIST)
                 .anyMatch(e -> new AntPathMatcher().match(e, request.getServletPath()));
     }

--- a/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
@@ -37,7 +37,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     };
 
     private static final String[] SHOULD_NOT_FILTER_GET_URI_LIST = new String[] {
-            "/users/training/", "/users/training/all"
+            "/users/training", "/users/training/all"
     };
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
     };
 
     private static final String[] PERMIT_ALL_GET_PATTERNS = new String[] {
-        "/users/training/all", "/users/training/"
+        "/users/training/all", "/users/training"
     };
 
     @Bean

--- a/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
@@ -46,8 +46,9 @@ public class SecurityConfig {
     };
 
     private static final String[] PERMIT_ALL_GET_PATTERNS = new String[] {
-        "/users/training/**"
+        "/users/training/all", "/users/training/"
     };
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         return httpSecurity

--- a/src/main/java/com/fithub/fithubbackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/fithub/fithubbackend/global/exception/ErrorCode.java
@@ -9,7 +9,6 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 데이터입니다."),
-    INVALID_DATE(HttpStatus.CONFLICT, "유효하지 않은 날짜입니다."),
     UNCORRECTABLE_DATA(HttpStatus.CONFLICT, "현재 수정할 수 없는 데이터입니다."),
     DUPLICATE(HttpStatus.CONFLICT,"중복된 데이터 입니다."),
     INVALID_FORM_DATA(HttpStatus.CONFLICT,"유효하지 않은 형식의 데이터 입니다."),
@@ -31,8 +30,10 @@ public enum ErrorCode {
     INVALID_IMAGE(HttpStatus.CONFLICT, "이미지 파일이 아닙니다."),
     
     IAMPORT_PRICE_ERROR(HttpStatus.CONFLICT, "결제된 금액이 달라 결제가 취소되었습니다."),
-    RESERVE_DATE_OR_TIME_ERROR(HttpStatus.BAD_REQUEST, "불가능한 날짜 또는 시간대입니다."),
-    PERMISSION_DENIED(HttpStatus.FORBIDDEN, "해당 작업을 수행할 권한이 없습니다.");
+    DATE_OR_TIME_ERROR(HttpStatus.BAD_REQUEST, "불가능한 날짜 또는 시간대입니다."),
+    PERMISSION_DENIED(HttpStatus.FORBIDDEN, "해당 작업을 수행할 권한이 없습니다."),
+
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.");
     private final HttpStatus httpStatus;
     private final String message;
 }


### PR DESCRIPTION
## pr 유형
- 기능 추가, 수정

## 반영 브랜치
- feature/training -> main

## 변경 사항
1. 기존: 트레이닝 찜 설정을 파라미터로 구분 -> 변경: 트레이닝 찜과 취소를 분리
2. training에 deleted 컬럼 추가 (soft delete)
3. 트레이닝 삭제 기능 추가
4. 트레이닝 조회 시 deleted = true 제외
5. SecurityConfig, JwtAuthenticationFilter에 거치지 않아야되는 api 추가

## 테스트 결과
- 트레이닝 삭제 시 진행전/진행 중인 트레이닝 예약이 있다면
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/9c4ffeb0-94e6-4cff-9f33-b03859495a9d)
