### PR TITLE
feat/auth: 소셜 회원가입, 로그인 수정

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/user/api/AuthController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/api/AuthController.java
@@ -81,10 +81,10 @@ public class AuthController {
 
     @Operation(summary = "소셜 회원가입 추가 정보 저장", responses = {
             @ApiResponse(responseCode = "200", description = "accessToken 반환. 세션 쿠키로 설정 필요"),
-            @ApiResponse(responseCode = "500", description = "소셜 회원가입이 제대로 성공하지 못 해 db에 user 정보가 저장된게 없음. 다시 회원가입부터 진행 필요")
+            @ApiResponse(responseCode = "404", description = "소셜 회원가입이 제대로 성공하지 못 해 db에 user 정보가 저장된게 없음. 다시 회원가입부터 진행 필요")
     })
     @PostMapping("/oauth/regist")
-    public ResponseEntity<String> oAuthSignUp(@RequestBody OAuthSignUpDto oAuthSignUpDto, @RequestParam String email, HttpServletResponse response) {
-        return ResponseEntity.ok(authService.oAuthSignUp(oAuthSignUpDto, email, response));
+    public ResponseEntity<String> oAuthSignUp(@RequestBody OAuthSignUpDto oAuthSignUpDto, HttpServletResponse response) {
+        return ResponseEntity.ok(authService.oAuthSignUp(oAuthSignUpDto, response));
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthService.java
@@ -5,7 +5,6 @@ import com.fithub.fithubbackend.global.auth.TokenInfoDto;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -20,5 +19,5 @@ public interface AuthService {
 
     TokenInfoDto reissue(String cookieRefreshToken, HttpServletRequest request, HttpServletResponse response);
 
-    String oAuthSignUp(OAuthSignUpDto oAuthSignUpDto, String email, HttpServletResponse response);
+    String oAuthSignUp(OAuthSignUpDto oAuthSignUpDto, HttpServletResponse response);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/domain/User.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/domain/User.java
@@ -1,5 +1,6 @@
 package com.fithub.fithubbackend.domain.user.domain;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fithub.fithubbackend.domain.user.dto.OAuthSignUpDto;
 import com.fithub.fithubbackend.domain.user.dto.ProfileDto;
 import com.fithub.fithubbackend.domain.user.dto.SignUpDto;
@@ -10,7 +11,6 @@ import com.fithub.fithubbackend.global.common.BaseTimeEntity;
 import com.fithub.fithubbackend.global.domain.Document;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,7 +18,6 @@ import lombok.NoArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -131,18 +130,14 @@ public class User extends BaseTimeEntity implements UserDetails {
         this.phone = phone;
     }
 
-    public User updateNicknameAndEmail(String nickname, String email) {
-        this.nickname = nickname;
-        this.email = email;
-        return this;
-    }
-
-    public void updateNameAndPhoneAndBioAndGender(OAuthSignUpDto oAuthSignUpDto) {
+    public void setOAuthSignUp(OAuthSignUpDto oAuthSignUpDto) {
+        this.email = oAuthSignUpDto.getEmail();
         this.name = oAuthSignUpDto.getName();
         this.phone = oAuthSignUpDto.getPhone();
         this.bio = oAuthSignUpDto.getBio();
         this.gender = oAuthSignUpDto.getGender();
     }
+
     public void updateProfile(ProfileDto dto) {
         if(dto.getNickname() != null) this.nickname = dto.getNickname();
         if(dto.getEmail() != null) this.email = dto.getEmail();

--- a/src/main/java/com/fithub/fithubbackend/domain/user/dto/OAuthSignUpDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/dto/OAuthSignUpDto.java
@@ -7,12 +7,15 @@ import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 
-import static com.fithub.fithubbackend.domain.user.dto.constants.SignUpDtoConstants.NAME_REGEXP;
-import static com.fithub.fithubbackend.domain.user.dto.constants.SignUpDtoConstants.PHONE_NUMBER_REGEXP;
+import static com.fithub.fithubbackend.domain.user.dto.constants.SignUpDtoConstants.*;
 
 @Getter
 @Setter
 public class OAuthSignUpDto {
+
+    @NotNull
+    @Pattern(regexp = EMAIL_REGEXP, message = "이메일 형식에 맞지 않습니다.")
+    private String email;
 
     @NotNull
     @Pattern(regexp = NAME_REGEXP, message = "특수문자 및 숫자는 포함될 수 없습니다.")
@@ -28,4 +31,8 @@ public class OAuthSignUpDto {
 
     @NotNull
     private Gender gender;
+
+    @NotNull
+    @Schema(description = "소셜 회원가입, 로그인시에 저장된 제공자 + id", example = "kakao_121211")
+    private String providerId;
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/repository/UserRepository.java
@@ -10,6 +10,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     Optional<User> findByEmailAndProvider(String email, String provider);
+    Optional<User> findByProviderId(String providerId);
 
     boolean existsByEmail(String email);
 }

--- a/src/main/java/com/fithub/fithubbackend/global/auth/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/CustomAccessDeniedHandler.java
@@ -1,0 +1,33 @@
+package com.fithub.fithubbackend.global.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fithub.fithubbackend.global.exception.ErrorCode;
+import com.fithub.fithubbackend.global.exception.ErrorResponseDto;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        log.error("[AccessDeniedHandler] - 해당 엔드포인트에 접근할 권한 없음: {}, {}", request.getUserPrincipal().getName(), request.getServletPath());
+        ObjectMapper objectMapper = new ObjectMapper();
+        ErrorResponseDto errorResponseDto = ErrorResponseDto.toResponseEntity(ErrorCode.PERMISSION_DENIED, "해당 작업을 수행할 권한이 없습니다.").getBody();
+
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("utf-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponseDto));
+    }
+}
+

--- a/src/main/java/com/fithub/fithubbackend/global/auth/OAuthFailureHandler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/OAuthFailureHandler.java
@@ -8,23 +8,22 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
-@Component
 @Slf4j
-public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+@Component
+public class OAuthFailureHandler implements AuthenticationFailureHandler  {
 
     @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response,
-                         AuthenticationException authException) throws IOException, ServletException {
-        log.info("[AuthenticationEntryPoint] - 인증 실패: {}, endPoint: {}", authException.getMessage(), request.getServletPath());
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        log.error("소셜 로그인 실패: {} , endpoint: {}", exception.getMessage(), request.getServletPath());
         ObjectMapper objectMapper = new ObjectMapper();
-        ErrorResponseDto errorResponseDto = ErrorResponseDto.toResponseEntity(ErrorCode.AUTHENTICATION_ERROR, "인증 실패").getBody();
+        ErrorResponseDto errorResponseDto = ErrorResponseDto.toResponseEntity(ErrorCode.BAD_REQUEST, exception.getMessage()).getBody();
 
-        response.setStatus(401);
+        response.setStatus(400);
         response.setContentType("application/json");
         response.setCharacterEncoding("utf-8");
         response.getWriter().write(objectMapper.writeValueAsString(errorResponseDto));

--- a/src/main/java/com/fithub/fithubbackend/global/auth/OAuthSuccessHandler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/OAuthSuccessHandler.java
@@ -46,7 +46,7 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
         boolean isGuest = oAuth2User.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_GUEST"));
         String accessToken = "";
 
-        if (isGuest == true && oAuth2User.getAttributes().get("provider").equals("naver")) {
+        if (isGuest && oAuth2User.getAttributes().get("provider").equals("naver")) {
             User user = userRepository.findByEmail((String) oAuth2User.getAttributes().get("email")).orElseThrow(() -> new UsernameNotFoundException("소셜 회원가입을 다시 진행해주십시오."));
             user.updateGuestToUser();
             isGuest = false;
@@ -78,6 +78,7 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private String getGuestTargetUrl(Map<String, Object> attributes) {
         return UriComponentsBuilder.fromUriString(firstRedirect)
                 .queryParam("provider", attributes.get("provider"))
+                .queryParam("providerId", attributes.get("providerId"))
                 .queryParam("email", attributes.get("email"))
                 .queryParam("name", attributes.get("name"))
                 .queryParam("phone", attributes.get("phone"))

--- a/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
 
     private final OAuthService oAuthService;
     private final OAuthSuccessHandler oAuthSuccessHandler;
+    private final OAuthFailureHandler oAuthFailureHandler;
 
     private static final String[] PERMIT_ALL_PATTERNS = new String[] {
             "/", "/auth/**", "/oauth2/**"
@@ -74,11 +75,12 @@ public class SecurityConfig {
                 )
                 .exceptionHandling(e -> {
                     e.authenticationEntryPoint(new CustomAuthenticationEntryPoint());
-                    e.accessDeniedHandler(((request, response, accessDeniedException) -> response.sendRedirect("/login")));
+                    e.accessDeniedHandler(new CustomAccessDeniedHandler());
                 })
                 .oauth2Login(oauth2Login -> {
                     oauth2Login.userInfoEndpoint(userInfoEndPoint -> userInfoEndPoint.userService(oAuthService));
                     oauth2Login.successHandler(oAuthSuccessHandler);
+                    oauth2Login.failureHandler(oAuthFailureHandler);
                 })
                 .build();
     }


### PR DESCRIPTION
## pr 유형
- 기능 수정

## 반영 브랜치
- auth -> main

## 변경 사항
1. 소셜 로그인/회원가입 시 일반 회원가입을 진행한 이메일이면 에러 발생(400)
2. 소셜 로그인/회원가입 시 카카오면 이메일이 아닌 providerId로 회원 조회
3. oauth2 로그인 실패 핸들러, 전체 권한 에러 핸들러 추가
4. 소셜 회원가입 추가 정보 입력 시 user를 email이 아닌 providerId로 찾도록 수정 (kakao에서 이메일을 안 받으니 에러가 났었는데 그냥 전체 다 providerId로 조회해도 문제가 없다고 생각)
5. 소셜 회원가입 추가 정보 입력 시 providerId를 전달해줘야됨 (successhandler에서 쿼리로 providerId 전달해주도록 함)

## 테스트 결과
- 이미 일반 회원가입 이력이 있을 경우
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/822b8d7f-480c-4819-9c09-76e900117f02)

- 일반 회원이 트레이너 권한을 가지고 있어야 가능한 api 요청 시
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/6442b313-5ea1-4d90-8172-c9a2ab52ad52)
