### PR TITLE
update: 액세스 토큰 쿠키 대신 헤더에서 추출, 일반 및 소셜(카카오, 구글) 로그인 성공 시 액세스 토큰 헤더에 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthServiceImpl.java
@@ -186,6 +186,9 @@ public class AuthServiceImpl implements AuthService {
         cookieUtil.addRefreshTokenCookie(response, tokenInfoDto);
         // Redis에 Key(이메일):Value(refreshToken) 저장
         redisUtil.setData(oAuthSignUpDto.getEmail(), tokenInfoDto.getRefreshToken(), tokenInfoDto.getRefreshTokenExpirationTime());
+
+        response.setHeader(AUTHORIZATION_HEADER, BEARER_TYPE + tokenInfoDto.getAccessToken());
+
         return tokenInfoDto.getAccessToken();
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthServiceImpl.java
@@ -51,6 +51,12 @@ public class AuthServiceImpl implements AuthService {
 
     @Value("${default.image.address}")
     private String profileImgUrl;
+
+    private static final String BEARER_TYPE = "Bearer ";
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+
+
     @Override
     @Transactional
     public ResponseEntity<SignUpResponseDto> signUp(SignUpDto signUpDto, MultipartFile profileImg, BindingResult bindingResult) throws IOException {
@@ -100,6 +106,7 @@ public class AuthServiceImpl implements AuthService {
             // Redis에 Key(이메일):Value(refreshToken) 저장
             redisUtil.setData(authentication.getName(), tokenInfoDto.getRefreshToken(), tokenInfoDto.getRefreshTokenExpirationTime());
 
+            response.setHeader(AUTHORIZATION_HEADER, BEARER_TYPE + tokenInfoDto.getAccessToken());
             return tokenInfoDto;
         } catch (BadCredentialsException e) {
             throw new CustomException(ErrorCode.INVALID_PWD);

--- a/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
@@ -52,7 +52,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         log.info("[doFilterInternal] - 요청 path: {}", request.getServletPath());
-        // 1. 쿠키에서 token 추출
+        // 1. 헤더, 쿠키에서 token 추출
         String accessToken = headerUtil.resolveAccessToken(request);
         String refreshToken = headerUtil.resolveRefreshToken(request);
 

--- a/src/main/java/com/fithub/fithubbackend/global/auth/JwtExceptionFilter.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/JwtExceptionFilter.java
@@ -26,7 +26,6 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final HeaderUtil headerUtil;
-    private final CookieUtil cookieUtil;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {

--- a/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
@@ -59,7 +59,7 @@ public class SecurityConfig {
 
                 // jwtFilter 추가
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, redisUtil, headerUtil), UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(new JwtExceptionFilter(jwtTokenProvider, headerUtil, cookieUtil), JwtAuthenticationFilter.class)
+                .addFilterBefore(new JwtExceptionFilter(jwtTokenProvider, headerUtil), JwtAuthenticationFilter.class)
 
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(requests -> requests

--- a/src/main/java/com/fithub/fithubbackend/global/util/CookieUtil.java
+++ b/src/main/java/com/fithub/fithubbackend/global/util/CookieUtil.java
@@ -47,20 +47,6 @@ public class CookieUtil {
         return response;
     }
 
-    @Description("access Token 쿠키 생성")
-    public HttpServletResponse addAccessTokenCookie(HttpServletResponse response, String accessToken) {
-
-        ResponseCookie cookie = ResponseCookie.from("accessToken", accessToken)
-//                .maxAge(1800)
-                .path("/")
-                .sameSite("None")
-                .httpOnly(true)
-                .secure(true)  //    HTTPS 프로토콜에서만 쿠키 전송 가능
-                .build();
-        response.addHeader("Set-Cookie", cookie.toString());
-        return response;
-    }
-
     @Description("refresh token 쿠키 삭제")
     public void deleteRefreshTokenCookie(HttpServletRequest request, HttpServletResponse response) {
         Optional<Cookie> refreshTokenCookie = Arrays

--- a/src/main/java/com/fithub/fithubbackend/global/util/HeaderUtil.java
+++ b/src/main/java/com/fithub/fithubbackend/global/util/HeaderUtil.java
@@ -3,22 +3,23 @@ package com.fithub.fithubbackend.global.util;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 @Service
 public class HeaderUtil {
 
-    public static final String ACCESS_TOKEN_COOKIE = "accessToken";
+    private static final String BEARER_TYPE = "Bearer";
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
 
     public static final String REFRESH_TOKEN_COOKIE = "refreshToken";
 
 
     public String resolveAccessToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
 
-        Cookie[] cookies = request.getCookies();
-        if (cookies != null) {
-            for (Cookie cookie : cookies)
-                if (ACCESS_TOKEN_COOKIE.equals(cookie.getName()))
-                    return cookie.getValue();
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_TYPE)) {
+            return bearerToken.substring(7);
         }
         return null;
     }


### PR DESCRIPTION
## PR 유형
- 수정

## 반영 브랜치
- feature/auth -> main

## 변경 사항
- 액세스 토큰 쿠키 대신 헤더에서 추출
- 일반 및 소셜(카카오, 구글) 로그인 성공 시 액세스 토큰 헤더에 추가

## 테스트 결과

> POST /auth/sign-in

![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/221c5a73-b16f-446d-8f9b-1c38cbaaec11)

## 이슈
- 소셜 회원 가입 후 로그인하게 되면 토큰 dto를 response body에 넣어야 하는데, redirect 이라 HttpServletResponse이 새로 생성되면서 dto가 넘어가지 않는 문제가 생기네요... 
- 구글링해보니 UriComponentsBuilder의 queryParam로 전달하는 경우가 꽤 있는데 보안 상 문제가 발생할 수 있어서 좀 더 생각해봐야 될 것 같아요! ;(
