### PR TITLE
feat: 임시 비밀번호 발급 기능 추가 /  update:  JwtAuthenticationFilter, SecurityConfig에 인증 필요 없는 api 추가 및  게시글 조회 수정

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/board/api/CommentController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/api/CommentController.java
@@ -29,7 +29,7 @@ public class CommentController {
             @ApiResponse(responseCode = "200", description = "댓글 등록 완료"),
     })
     @PostMapping
-    public ResponseEntity<Void> createComment(@Valid CommentCreateDto commentCreateDto, @AuthUser User user) {
+    public ResponseEntity<Void> createComment(@RequestBody @Valid CommentCreateDto commentCreateDto, @AuthUser User user) {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         commentService.createComment(commentCreateDto, user);
         return ResponseEntity.ok().build();
@@ -40,7 +40,7 @@ public class CommentController {
             @ApiResponse(responseCode = "404", description = "댓글 작성자가 아니므로 댓글 수정 불가", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
     @PutMapping
-    public ResponseEntity<Void> updateComment(@Valid CommentUpdateDto commentUpdateDto, @AuthUser User user) {
+    public ResponseEntity<Void> updateComment(@RequestBody @Valid CommentUpdateDto commentUpdateDto, @AuthUser User user) {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         commentService.updateComment(commentUpdateDto, user);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
@@ -1,10 +1,7 @@
 package com.fithub.fithubbackend.domain.board.api;
 
 import com.fithub.fithubbackend.domain.board.application.PostService;
-import com.fithub.fithubbackend.domain.board.dto.PostCreateDto;
-import com.fithub.fithubbackend.domain.board.dto.PostDetailInfoDto;
-import com.fithub.fithubbackend.domain.board.dto.PostInfoDto;
-import com.fithub.fithubbackend.domain.board.dto.PostUpdateDto;
+import com.fithub.fithubbackend.domain.board.dto.*;
 import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.global.domain.AuthUser;
 import com.fithub.fithubbackend.global.exception.CustomException;
@@ -74,36 +71,20 @@ public class PostController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "게시글 전체 조회 (회원 ver)", responses = {
+    @Operation(summary = "게시글 전체 조회", responses = {
             @ApiResponse(responseCode = "200", description = "게시글 전체 조회 성공"),
     })
     @GetMapping
-    public ResponseEntity<Page<PostInfoDto>> getAllPostsForUser(@PageableDefault(size = 9, sort = "id", direction = Sort.Direction.DESC) Pageable pageable, @AuthUser User user) {
-        return ResponseEntity.ok(postService.getAllPostsForUser(pageable, user));
+    public ResponseEntity<Page<PostOutlineDto>> getAllPosts(@PageableDefault(size = 9, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(postService.getAllPosts(pageable));
     }
 
-    @Operation(summary = "게시글 전체 조회 (비회원 ver)", responses = {
-            @ApiResponse(responseCode = "200", description = "게시글 전체 조회 성공"),
-    })
-    @GetMapping("/non-user")
-    public ResponseEntity<Page<PostInfoDto>> getAllPostsForNonUser(@PageableDefault(size = 9, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ResponseEntity.ok(postService.getAllPostsForNonUser(pageable));
-    }
-
-    @Operation(summary = "게시글 세부 조회 (회원 ver)", responses = {
+    @Operation(summary = "게시글 세부 조회", responses = {
             @ApiResponse(responseCode = "200", description = "게시글 세부 조회 성공"),
     })
     @GetMapping("/{postId}")
-    public ResponseEntity<PostDetailInfoDto> getPostDetailForUser(@PathVariable("postId") long postId, @AuthUser User user) {
-        return ResponseEntity.ok(postService.getPostDetailForUser(postId, user));
-    }
-
-    @Operation(summary = "게시글 세부 조회 (비회원 ver)", responses = {
-            @ApiResponse(responseCode = "200", description = "게시글 세부 조회 성공"),
-    })
-    @GetMapping("/non-user/{postId}")
-    public ResponseEntity<PostDetailInfoDto> getPostDetailForNonUser(@PathVariable("postId") long postId) {
-        return ResponseEntity.ok(postService.getPostDetailForNonUser(postId));
+    public ResponseEntity<PostDetailInfoDto> getPostDetail(@PathVariable("postId") long postId) {
+        return ResponseEntity.ok(postService.getPostDetail(postId));
     }
 
 

--- a/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
@@ -2,6 +2,7 @@ package com.fithub.fithubbackend.domain.board.api;
 
 import com.fithub.fithubbackend.domain.board.application.PostService;
 import com.fithub.fithubbackend.domain.board.dto.PostCreateDto;
+import com.fithub.fithubbackend.domain.board.dto.PostDetailInfoDto;
 import com.fithub.fithubbackend.domain.board.dto.PostInfoDto;
 import com.fithub.fithubbackend.domain.board.dto.PostUpdateDto;
 import com.fithub.fithubbackend.domain.user.domain.User;
@@ -73,20 +74,36 @@ public class PostController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "게시글 전체 조회", responses = {
+    @Operation(summary = "게시글 전체 조회 (회원 ver)", responses = {
             @ApiResponse(responseCode = "200", description = "게시글 전체 조회 성공"),
     })
     @GetMapping
-    public ResponseEntity<Page<PostInfoDto>> getPosts(@PageableDefault(size = 9, sort = "id", direction = Sort.Direction.DESC) Pageable pageable, @AuthUser User user) {
-        return ResponseEntity.ok(postService.getAllPosts(pageable, user));
+    public ResponseEntity<Page<PostInfoDto>> getAllPostsForUser(@PageableDefault(size = 9, sort = "id", direction = Sort.Direction.DESC) Pageable pageable, @AuthUser User user) {
+        return ResponseEntity.ok(postService.getAllPostsForUser(pageable, user));
     }
 
-    @Operation(summary = "게시글 세부 조회", responses = {
+    @Operation(summary = "게시글 전체 조회 (비회원 ver)", responses = {
+            @ApiResponse(responseCode = "200", description = "게시글 전체 조회 성공"),
+    })
+    @GetMapping("/non-user")
+    public ResponseEntity<Page<PostInfoDto>> getAllPostsForNonUser(@PageableDefault(size = 9, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(postService.getAllPostsForNonUser(pageable));
+    }
+
+    @Operation(summary = "게시글 세부 조회 (회원 ver)", responses = {
             @ApiResponse(responseCode = "200", description = "게시글 세부 조회 성공"),
     })
     @GetMapping("/{postId}")
-    public ResponseEntity<PostInfoDto> getPost(@PathVariable("postId") long postId, @AuthUser User user) {
-        return ResponseEntity.ok(postService.getPostDetail(postId, user));
+    public ResponseEntity<PostDetailInfoDto> getPostDetailForUser(@PathVariable("postId") long postId, @AuthUser User user) {
+        return ResponseEntity.ok(postService.getPostDetailForUser(postId, user));
+    }
+
+    @Operation(summary = "게시글 세부 조회 (비회원 ver)", responses = {
+            @ApiResponse(responseCode = "200", description = "게시글 세부 조회 성공"),
+    })
+    @GetMapping("/non-user/{postId}")
+    public ResponseEntity<PostDetailInfoDto> getPostDetailForNonUser(@PathVariable("postId") long postId) {
+        return ResponseEntity.ok(postService.getPostDetailForNonUser(postId));
     }
 
 

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostService.java
@@ -1,9 +1,6 @@
 package com.fithub.fithubbackend.domain.board.application;
 
-import com.fithub.fithubbackend.domain.board.dto.PostCreateDto;
-import com.fithub.fithubbackend.domain.board.dto.PostDetailInfoDto;
-import com.fithub.fithubbackend.domain.board.dto.PostInfoDto;
-import com.fithub.fithubbackend.domain.board.dto.PostUpdateDto;
+import com.fithub.fithubbackend.domain.board.dto.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import com.fithub.fithubbackend.domain.user.domain.User;
@@ -24,11 +21,7 @@ public interface PostService {
 
     void deletePost(long postId, User user);
 
-    Page<PostInfoDto> getAllPostsForUser(Pageable pageable, User use);
+    Page<PostOutlineDto> getAllPosts(Pageable pageable);
 
-    PostDetailInfoDto getPostDetailForUser(long postId, User use);
-
-    Page<PostInfoDto> getAllPostsForNonUser(Pageable pageable);
-
-    PostDetailInfoDto getPostDetailForNonUser(long postId);
+    PostDetailInfoDto getPostDetail(long postId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostService.java
@@ -1,6 +1,7 @@
 package com.fithub.fithubbackend.domain.board.application;
 
 import com.fithub.fithubbackend.domain.board.dto.PostCreateDto;
+import com.fithub.fithubbackend.domain.board.dto.PostDetailInfoDto;
 import com.fithub.fithubbackend.domain.board.dto.PostInfoDto;
 import com.fithub.fithubbackend.domain.board.dto.PostUpdateDto;
 import org.springframework.data.domain.Page;
@@ -23,7 +24,11 @@ public interface PostService {
 
     void deletePost(long postId, User user);
 
-    Page<PostInfoDto> getAllPosts(Pageable pageable, User use);
+    Page<PostInfoDto> getAllPostsForUser(Pageable pageable, User use);
 
-    PostInfoDto getPostDetail(long postId, User use);
+    PostDetailInfoDto getPostDetailForUser(long postId, User use);
+
+    Page<PostInfoDto> getAllPostsForNonUser(Pageable pageable);
+
+    PostDetailInfoDto getPostDetailForNonUser(long postId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostServiceImpl.java
@@ -121,26 +121,25 @@ public class PostServiceImpl implements PostService {
         Page<Post> posts = postRepository.findAll(pageable);
         Page<PostInfoDto> postInfoDtos = posts.map(PostInfoDto::fromEntity);
 
-        if (user != null) {
-
-            postInfoDtos.forEach(postInfoDto -> {
-                if (!postInfoDto.getPostLikedUser().isEmpty() && postInfoDto.getPostLikedUser() != null ) {
+        postInfoDtos.forEach(postInfoDto -> {
+            if (user != null) {
+                if (!postInfoDto.getPostLikedUser().isEmpty() && postInfoDto.getPostLikedUser() != null) {
                     List<String> likedUsers = postInfoDto.getPostLikedUser().stream().map(likesInfoDto -> likesInfoDto.getLikedUser()).collect(Collectors.toList());
                     if (likedUsers.contains(user.getNickname()))
                         postInfoDto.checkLikes(true);
                 }
-            });
 
-            postInfoDtos.forEach(postInfoDto -> {
-                if (!postInfoDto.getPostBookmarkedUser().isEmpty() && postInfoDto.getPostBookmarkedUser() != null ) {
+                if (!postInfoDto.getPostBookmarkedUser().isEmpty() && postInfoDto.getPostBookmarkedUser() != null) {
                     List<String> bookmarkedUsers = postInfoDto.getPostBookmarkedUser().stream().map(bookmark -> bookmark.getUser().getNickname()).collect(Collectors.toList());
                     if (bookmarkedUsers.contains(user.getNickname()))
                         postInfoDto.checkBookmark(true);
                 }
+            }
 
-            });
+            if (postInfoDto.getPost().getComments() != null && !postInfoDto.getPost().getComments().isEmpty())
+                postInfoDto.setComment(commentService.getCommentsVer2(postInfoDto.getPost()));
+        });
 
-        }
         return postInfoDtos;
     }
 
@@ -153,13 +152,13 @@ public class PostServiceImpl implements PostService {
         PostInfoDto postInfoDto = PostInfoDto.fromEntity(post);
 
         if (user != null) {
-            if(post.getLikes() != null && !post.getLikes().isEmpty()) {
+            if (post.getLikes() != null && !post.getLikes().isEmpty()) {
                 List<String> likedUsers = postInfoDto.getPostLikedUser().stream().map(likesInfoDto -> likesInfoDto.getLikedUser()).collect(Collectors.toList());
                 if (likedUsers.contains(user.getNickname()))
                     postInfoDto.checkLikes(true);
             }
 
-            if (!post.getBookmarks().isEmpty() && post.getBookmarks() != null ) {
+            if (!post.getBookmarks().isEmpty() && post.getBookmarks() != null) {
                 List<String> bookmarkedUsers = postInfoDto.getPostBookmarkedUser().stream().map(bookmark -> bookmark.getUser().getNickname()).collect(Collectors.toList());
                 if (bookmarkedUsers.contains(user.getNickname()))
                     postInfoDto.checkBookmark(true);

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostServiceImpl.java
@@ -1,6 +1,7 @@
 package com.fithub.fithubbackend.domain.board.application;
 
 import com.fithub.fithubbackend.domain.board.dto.PostCreateDto;
+import com.fithub.fithubbackend.domain.board.dto.PostDetailInfoDto;
 import com.fithub.fithubbackend.domain.board.dto.PostInfoDto;
 import com.fithub.fithubbackend.domain.board.dto.PostUpdateDto;
 import com.fithub.fithubbackend.domain.board.post.domain.Post;
@@ -116,13 +117,12 @@ public class PostServiceImpl implements PostService {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<PostInfoDto> getAllPosts(Pageable pageable, User user) {
+    public Page<PostInfoDto> getAllPostsForUser(Pageable pageable, User user) {
 
         Page<Post> posts = postRepository.findAll(pageable);
         Page<PostInfoDto> postInfoDtos = posts.map(PostInfoDto::fromEntity);
 
         postInfoDtos.forEach(postInfoDto -> {
-            if (user != null) {
                 if (!postInfoDto.getPostLikedUser().isEmpty() && postInfoDto.getPostLikedUser() != null) {
                     List<String> likedUsers = postInfoDto.getPostLikedUser().stream().map(likesInfoDto -> likesInfoDto.getLikedUser()).collect(Collectors.toList());
                     if (likedUsers.contains(user.getNickname()))
@@ -134,10 +134,6 @@ public class PostServiceImpl implements PostService {
                     if (bookmarkedUsers.contains(user.getNickname()))
                         postInfoDto.checkBookmark(true);
                 }
-            }
-
-            if (postInfoDto.getPost().getComments() != null && !postInfoDto.getPost().getComments().isEmpty())
-                postInfoDto.setComment(commentService.getCommentsVer2(postInfoDto.getPost()));
         });
 
         return postInfoDtos;
@@ -145,31 +141,48 @@ public class PostServiceImpl implements PostService {
 
     @Override
     @Transactional(readOnly = true)
-    public PostInfoDto getPostDetail(long postId, User user) {
+    public PostDetailInfoDto getPostDetailForUser(long postId, User user) {
 
         Post post = getPost(postId);
 
-        PostInfoDto postInfoDto = PostInfoDto.fromEntity(post);
+        PostDetailInfoDto postDetailInfoDto = PostDetailInfoDto.fromEntity(post);
 
-        if (user != null) {
-            if (post.getLikes() != null && !post.getLikes().isEmpty()) {
-                List<String> likedUsers = postInfoDto.getPostLikedUser().stream().map(likesInfoDto -> likesInfoDto.getLikedUser()).collect(Collectors.toList());
-                if (likedUsers.contains(user.getNickname()))
-                    postInfoDto.checkLikes(true);
-            }
+        if (post.getLikes() != null && !post.getLikes().isEmpty()) {
+            List<String> likedUsers = postDetailInfoDto.getPostLikedUser().stream().map(likesInfoDto -> likesInfoDto.getLikedUser()).collect(Collectors.toList());
+            if (likedUsers.contains(user.getNickname()))
+                postDetailInfoDto.checkLikes(true);
+        }
 
-            if (!post.getBookmarks().isEmpty() && post.getBookmarks() != null) {
-                List<String> bookmarkedUsers = postInfoDto.getPostBookmarkedUser().stream().map(bookmark -> bookmark.getUser().getNickname()).collect(Collectors.toList());
-                if (bookmarkedUsers.contains(user.getNickname()))
-                    postInfoDto.checkBookmark(true);
-            }
+        if (!post.getBookmarks().isEmpty() && post.getBookmarks() != null) {
+            List<String> bookmarkedUsers = postDetailInfoDto.getPostBookmarkedUser().stream().map(bookmark -> bookmark.getUser().getNickname()).collect(Collectors.toList());
+            if (bookmarkedUsers.contains(user.getNickname()))
+                postDetailInfoDto.checkBookmark(true);
         }
 
         if (post.getComments() != null && !post.getComments().isEmpty())
-//            postInfoDto.setComment(commentService.getComments(post));
-            postInfoDto.setComment(commentService.getCommentsVer2(post));
+            postDetailInfoDto.setComment(commentService.getCommentsVer2(post));
 
-        return postInfoDto;
+        return postDetailInfoDto;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<PostInfoDto> getAllPostsForNonUser(Pageable pageable) {
+        Page<Post> posts = postRepository.findAll(pageable);
+        Page<PostInfoDto> postInfoDtos = posts.map(PostInfoDto::fromEntity);
+        return postInfoDtos;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PostDetailInfoDto getPostDetailForNonUser(long postId) {
+        Post post = getPost(postId);
+        PostDetailInfoDto postDetailInfoDto = PostDetailInfoDto.fromEntity(post);
+
+        if (post.getComments() != null && !post.getComments().isEmpty())
+            postDetailInfoDto.setComment(commentService.getCommentsVer2(post));
+
+        return postDetailInfoDto;
     }
 
     @Transactional

--- a/src/main/java/com/fithub/fithubbackend/domain/board/dto/LikedUsersInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/dto/LikedUsersInfoDto.java
@@ -1,0 +1,38 @@
+package com.fithub.fithubbackend.domain.board.dto;
+
+import com.fithub.fithubbackend.domain.board.post.domain.Post;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+@Schema(description = "게시글 좋아요 정보 dto")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LikedUsersInfoDto {
+
+    @Schema(description = "게시글 좋아요 수")
+    private Long likedCount;
+
+    @Schema(description = "게시글 좋아요 리스트")
+    private List<LikesInfoDto> likedUsers;
+
+    @Builder
+    public LikedUsersInfoDto(Long likedCount, List<LikesInfoDto> likedUsers) {
+        this.likedCount = likedCount;
+        this.likedUsers = likedUsers;
+    }
+
+    public static LikedUsersInfoDto toDo(Post post) {
+        return LikedUsersInfoDto.builder()
+                .likedCount((long) post.getLikes().size())
+                .likedUsers(post.getLikes().stream().limit(3).map(LikesInfoDto::toDto).collect(Collectors.toList()))
+                .build();
+    }
+
+}
+

--- a/src/main/java/com/fithub/fithubbackend/domain/board/dto/LikesInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/dto/LikesInfoDto.java
@@ -1,24 +1,31 @@
 package com.fithub.fithubbackend.domain.board.dto;
 
 import com.fithub.fithubbackend.domain.board.post.domain.Likes;
-import lombok.Builder;
-import lombok.Data;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
 
 @Data
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "게시글 좋아요 정보 dto")
 public class LikesInfoDto {
 
-    private String likedUser;
+    @Schema(description = "게시글 좋아요한 사용자의 닉네임")
+    private String nickname;
 
-    private String likedUserProfileUrl;
+    @Schema(description = "게시글 좋아요한 사용자의 프로필")
+    private String profileUrl;
 
-    private String likedUserBio;
+    @Builder
+    public LikesInfoDto(String nickname, String profileUrl) {
+        this.nickname = nickname;
+        this.profileUrl = profileUrl;
+    }
 
-    public static LikesInfoDto fromEntity(Likes likes) {
+    public static LikesInfoDto toDto(Likes likes) {
         return LikesInfoDto.builder()
-                .likedUser(likes.getUser().getNickname())
-                .likedUserProfileUrl(likes.getUser().getProfileImg().getUrl())
-                .likedUserBio(likes.getUser().getBio()).build();
+                .nickname(likes.getUser().getNickname())
+                .profileUrl(likes.getUser().getProfileImg().getUrl())
+                .build();
     }
 
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostCreateDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostCreateDto.java
@@ -1,6 +1,5 @@
 package com.fithub.fithubbackend.domain.board.dto;
 
-import com.fithub.fithubbackend.domain.user.domain.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;

--- a/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostDetailInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostDetailInfoDto.java
@@ -6,16 +6,16 @@ import com.fithub.fithubbackend.domain.board.comment.domain.Comment;
 import com.fithub.fithubbackend.domain.board.post.domain.Bookmark;
 import com.fithub.fithubbackend.domain.board.post.domain.Post;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.List;
 import java.util.stream.Collectors;
 
 @Data
-@Schema(description = "게시글 dto")
-public class PostInfoDto {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "게시글 세부 정보 dto")
+public class PostDetailInfoDto {
 
     @Schema(description = "게시글 id")
     private Long postId;
@@ -45,23 +45,30 @@ public class PostInfoDto {
     @Schema(description = "게시글 좋아요 리스트")
     private List<LikesInfoDto> postLikedUser;
 
-    @JsonIgnore
-    private Post post;
-
-    @JsonIgnore
-    private List<Bookmark> postBookmarkedUser;
-
     @Schema(description = "게시글 첨부 이미지 url 리스트")
     private List<String> postDocumentUrls;
 
     @Schema(description = "게시글 댓글 수")
     private Integer postCommentsCount;
 
+    @Schema(description = "게시글 댓글 리스트")
+    private List<CommentInfoDto> postComments;
+
     @Schema(description = "게시글 좋아요 여부")
     private boolean isLiked;
 
     @Schema(description = "게시글 북마크 여부")
     private boolean isBookmark;
+
+    @JsonIgnore
+    private Post post;
+
+    @JsonIgnore
+    private List<Bookmark> postBookmarkedUser;
+
+    public void setComment(List<CommentInfoDto> comments) {
+        this.postComments = comments;
+    }
 
     public void checkLikes(boolean isLiked) {
         this.isLiked = isLiked;
@@ -72,7 +79,7 @@ public class PostInfoDto {
     }
 
     @Builder
-    public PostInfoDto(Long postId, String postContent, String postWriter, String postWriterProfileUrl, List<String> postHashTags,
+    public PostDetailInfoDto(Long postId, String postContent, String postWriter, String postWriterProfileUrl, List<String> postHashTags,
                        Integer postViews, Long postLikesCount, List<LikesInfoDto> postLikedUser, List<String> postDocumentUrls, Integer postCommentsCount,
                        List<Bookmark> postBookmarkedUser, LocalDateTime postCreatedDate, Post post) {
         this.postId = postId;
@@ -90,14 +97,14 @@ public class PostInfoDto {
         this.post = post;
     }
 
-    public static PostInfoDto fromEntity(Post post) {
+    public static PostDetailInfoDto fromEntity(Post post) {
 
         Integer commentsCount = 0;
-        for (Comment comment: post.getComments()) 
+        for (Comment comment: post.getComments())
             if (comment.getDeleted() == null)
                 commentsCount++;
-        
-        return PostInfoDto.builder()
+
+        return PostDetailInfoDto.builder()
                 .postId(post.getId())
                 .postContent(post.getContent())
                 .postWriter(post.getUser().getNickname())

--- a/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostDetailInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostDetailInfoDto.java
@@ -1,123 +1,34 @@
 package com.fithub.fithubbackend.domain.board.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fithub.fithubbackend.domain.board.comment.domain.Comment;
-import com.fithub.fithubbackend.domain.board.post.domain.Bookmark;
 import com.fithub.fithubbackend.domain.board.post.domain.Post;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Data
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "게시글 세부 정보 dto")
 public class PostDetailInfoDto {
 
-    @Schema(description = "게시글 id")
-    private Long postId;
-
-    @Schema(description = "게시글 생성일")
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-    private LocalDateTime postCreatedDate;
-
-    @Schema(description = "게시글 내용")
-    private String postContent;
-
-    @Schema(description = "게시글 작성자")
-    private String postWriter;
-
-    @Schema(description = "게시글 작성자 프로필 url")
-    private String postWriterProfileUrl;
-
-    @Schema(description = "게시글 해시태그")
-    private List<String> postHashTags;
-
-    @Schema(description = "게시글 조회수")
-    private Integer postViews;
-
-    @Schema(description = "게시글 좋아요 수")
-    private Long postLikesCount;
-
-    @Schema(description = "게시글 좋아요 리스트")
-    private List<LikesInfoDto> postLikedUser;
-
-    @Schema(description = "게시글 첨부 이미지 url 리스트")
-    private List<String> postDocumentUrls;
-
-    @Schema(description = "게시글 댓글 수")
-    private Integer postCommentsCount;
+    @Schema(description = "게시글 정보")
+    private PostOutlineDto postOutlineDto;
 
     @Schema(description = "게시글 댓글 리스트")
     private List<CommentInfoDto> postComments;
-
-    @Schema(description = "게시글 좋아요 여부")
-    private boolean isLiked;
-
-    @Schema(description = "게시글 북마크 여부")
-    private boolean isBookmark;
-
-    @JsonIgnore
-    private Post post;
-
-    @JsonIgnore
-    private List<Bookmark> postBookmarkedUser;
 
     public void setComment(List<CommentInfoDto> comments) {
         this.postComments = comments;
     }
 
-    public void checkLikes(boolean isLiked) {
-        this.isLiked = isLiked;
-    }
-
-    public void checkBookmark(boolean isBookmark) {
-        this.isBookmark = isBookmark;
-    }
-
     @Builder
-    public PostDetailInfoDto(Long postId, String postContent, String postWriter, String postWriterProfileUrl, List<String> postHashTags,
-                       Integer postViews, Long postLikesCount, List<LikesInfoDto> postLikedUser, List<String> postDocumentUrls, Integer postCommentsCount,
-                       List<Bookmark> postBookmarkedUser, LocalDateTime postCreatedDate, Post post) {
-        this.postId = postId;
-        this.postContent = postContent;
-        this.postWriter = postWriter;
-        this.postWriterProfileUrl = postWriterProfileUrl;
-        this.postHashTags = postHashTags;
-        this.postViews = postViews;
-        this.postLikesCount = postLikesCount;
-        this.postLikedUser = postLikedUser;
-        this.postDocumentUrls = postDocumentUrls;
-        this.postCommentsCount = postCommentsCount;
-        this.postBookmarkedUser = postBookmarkedUser;
-        this.postCreatedDate = postCreatedDate;
-        this.post = post;
+    public PostDetailInfoDto(PostOutlineDto postOutlineDto) {
+        this.postOutlineDto = postOutlineDto;
     }
 
-    public static PostDetailInfoDto fromEntity(Post post) {
-
-        Integer commentsCount = 0;
-        for (Comment comment: post.getComments())
-            if (comment.getDeleted() == null)
-                commentsCount++;
-
+    public static PostDetailInfoDto toDto(Post post) {
         return PostDetailInfoDto.builder()
-                .postId(post.getId())
-                .postContent(post.getContent())
-                .postWriter(post.getUser().getNickname())
-                .postWriterProfileUrl(post.getUser().getProfileImg().getUrl())
-                .postViews(post.getViews())
-                .postLikesCount((long) post.getLikes().size())
-                .postCommentsCount(commentsCount)
-                .postLikedUser(post.getLikes().stream().limit(3).map(LikesInfoDto::fromEntity).collect(Collectors.toList()))
-                .postHashTags(post.getPostHashtags().stream().map(hashtag -> hashtag.getHashtag().getContent()).collect(Collectors.toList()))
-                .postDocumentUrls(post.getPostDocuments().stream().map(postDocument -> postDocument.getUrl()).collect(Collectors.toList()))
-                .postBookmarkedUser(post.getBookmarks())
-                .postCreatedDate(post.getCreatedDate())
-                .post(post)
+                .postOutlineDto(PostOutlineDto.toDto(post))
                 .build();
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostDocumentUpdateDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostDocumentUpdateDto.java
@@ -1,10 +1,13 @@
 package com.fithub.fithubbackend.domain.board.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
 @Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "게시글 이미지 수정 dto")
 public class PostDocumentUpdateDto {
 

--- a/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostInfoDto.java
@@ -46,6 +46,9 @@ public class PostInfoDto {
     private List<LikesInfoDto> postLikedUser;
 
     @JsonIgnore
+    private Post post;
+
+    @JsonIgnore
     private List<Bookmark> postBookmarkedUser;
 
     @Schema(description = "게시글 첨부 이미지 url 리스트")
@@ -78,7 +81,7 @@ public class PostInfoDto {
     @Builder
     public PostInfoDto(Long postId, String postContent, String postWriter, String postWriterProfileUrl, List<String> postHashTags,
                        Integer postViews, Long postLikesCount, List<LikesInfoDto> postLikedUser, List<String> postDocumentUrls, Integer postCommentsCount,
-                       List<Bookmark> postBookmarkedUser, LocalDateTime postCreatedDate) {
+                       List<Bookmark> postBookmarkedUser, LocalDateTime postCreatedDate, Post post) {
         this.postId = postId;
         this.postContent = postContent;
         this.postWriter = postWriter;
@@ -91,6 +94,7 @@ public class PostInfoDto {
         this.postCommentsCount = postCommentsCount;
         this.postBookmarkedUser = postBookmarkedUser;
         this.postCreatedDate = postCreatedDate;
+        this.post = post;
     }
 
     public static PostInfoDto fromEntity(Post post) {
@@ -113,6 +117,7 @@ public class PostInfoDto {
                 .postDocumentUrls(post.getPostDocuments().stream().map(postDocument -> postDocument.getUrl()).collect(Collectors.toList()))
                 .postBookmarkedUser(post.getBookmarks())
                 .postCreatedDate(post.getCreatedDate())
+                .post(post)
                 .build();
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostInfoDto.java
@@ -1,116 +1,66 @@
 package com.fithub.fithubbackend.domain.board.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fithub.fithubbackend.domain.board.comment.domain.Comment;
-import com.fithub.fithubbackend.domain.board.post.domain.Bookmark;
 import com.fithub.fithubbackend.domain.board.post.domain.Post;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
 @Data
-@Schema(description = "게시글 dto")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "게시글 정보 dto")
 public class PostInfoDto {
 
     @Schema(description = "게시글 id")
     private Long postId;
 
+    @Schema(description = "게시글 작성자 정보")
+    private PostWriterInfoDto writerInfo;
+
     @Schema(description = "게시글 생성일")
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-    private LocalDateTime postCreatedDate;
+    private LocalDateTime createdDate;
 
     @Schema(description = "게시글 내용")
-    private String postContent;
-
-    @Schema(description = "게시글 작성자")
-    private String postWriter;
-
-    @Schema(description = "게시글 작성자 프로필 url")
-    private String postWriterProfileUrl;
+    private String content;
 
     @Schema(description = "게시글 해시태그")
-    private List<String> postHashTags;
+    private List<String> hashTags;
 
     @Schema(description = "게시글 조회수")
-    private Integer postViews;
-
-    @Schema(description = "게시글 좋아요 수")
-    private Long postLikesCount;
-
-    @Schema(description = "게시글 좋아요 리스트")
-    private List<LikesInfoDto> postLikedUser;
-
-    @JsonIgnore
-    private Post post;
-
-    @JsonIgnore
-    private List<Bookmark> postBookmarkedUser;
+    private Integer views;
 
     @Schema(description = "게시글 첨부 이미지 url 리스트")
-    private List<String> postDocumentUrls;
-
-    @Schema(description = "게시글 댓글 수")
-    private Integer postCommentsCount;
-
-    @Schema(description = "게시글 좋아요 여부")
-    private boolean isLiked;
-
-    @Schema(description = "게시글 북마크 여부")
-    private boolean isBookmark;
-
-    public void checkLikes(boolean isLiked) {
-        this.isLiked = isLiked;
-    }
-
-    public void checkBookmark(boolean isBookmark) {
-        this.isBookmark = isBookmark;
-    }
+    private List<String> documentUrls;
 
     @Builder
-    public PostInfoDto(Long postId, String postContent, String postWriter, String postWriterProfileUrl, List<String> postHashTags,
-                       Integer postViews, Long postLikesCount, List<LikesInfoDto> postLikedUser, List<String> postDocumentUrls, Integer postCommentsCount,
-                       List<Bookmark> postBookmarkedUser, LocalDateTime postCreatedDate, Post post) {
+    public PostInfoDto(Long postId, String content, Integer views, PostWriterInfoDto writerInfo,
+                       List<String> documentUrls, List<String> hashTags,LocalDateTime createdDate) {
         this.postId = postId;
-        this.postContent = postContent;
-        this.postWriter = postWriter;
-        this.postWriterProfileUrl = postWriterProfileUrl;
-        this.postHashTags = postHashTags;
-        this.postViews = postViews;
-        this.postLikesCount = postLikesCount;
-        this.postLikedUser = postLikedUser;
-        this.postDocumentUrls = postDocumentUrls;
-        this.postCommentsCount = postCommentsCount;
-        this.postBookmarkedUser = postBookmarkedUser;
-        this.postCreatedDate = postCreatedDate;
-        this.post = post;
+        this.writerInfo = writerInfo;
+        this.content = content;
+        this.hashTags = hashTags;
+        this.views = views;
+        this.documentUrls = documentUrls;
+        this.createdDate = createdDate;
     }
 
-    public static PostInfoDto fromEntity(Post post) {
+    public static PostInfoDto toDto(Post post) {
 
-        Integer commentsCount = 0;
-        for (Comment comment: post.getComments()) 
-            if (comment.getDeleted() == null)
-                commentsCount++;
-        
         return PostInfoDto.builder()
                 .postId(post.getId())
-                .postContent(post.getContent())
-                .postWriter(post.getUser().getNickname())
-                .postWriterProfileUrl(post.getUser().getProfileImg().getUrl())
-                .postViews(post.getViews())
-                .postLikesCount((long) post.getLikes().size())
-                .postCommentsCount(commentsCount)
-                .postLikedUser(post.getLikes().stream().limit(3).map(LikesInfoDto::fromEntity).collect(Collectors.toList()))
-                .postHashTags(post.getPostHashtags().stream().map(hashtag -> hashtag.getHashtag().getContent()).collect(Collectors.toList()))
-                .postDocumentUrls(post.getPostDocuments().stream().map(postDocument -> postDocument.getUrl()).collect(Collectors.toList()))
-                .postBookmarkedUser(post.getBookmarks())
-                .postCreatedDate(post.getCreatedDate())
-                .post(post)
+                .writerInfo(PostWriterInfoDto.toDto(post.getUser()))
+                .content(post.getContent())
+                .views(post.getViews())
+                .hashTags(post.getPostHashtags().stream().map(hashtag -> hashtag.getHashtag().getContent()).collect(Collectors.toList()))
+                .documentUrls(post.getPostDocuments().stream().map(postDocument -> postDocument.getUrl()).collect(Collectors.toList()))
+                .createdDate(post.getCreatedDate())
                 .build();
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostOutlineDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostOutlineDto.java
@@ -1,0 +1,46 @@
+package com.fithub.fithubbackend.domain.board.dto;
+
+import com.fithub.fithubbackend.domain.board.comment.domain.Comment;
+import com.fithub.fithubbackend.domain.board.post.domain.Post;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "게시글 요약 정보 dto")
+public class PostOutlineDto {
+
+    @Schema(description = "게시글 정보")
+    private PostInfoDto postInfo;
+
+    @Schema(description = "게시글 좋아요 정보")
+    private LikedUsersInfoDto postLikedInfo;
+
+    @Schema(description = "게시글 댓글 수")
+    private Integer postCommentsCount;
+
+    @Builder
+    public PostOutlineDto(PostInfoDto postInfo, LikedUsersInfoDto postLikedInfo,
+                          Integer postCommentsCount) {
+        this.postInfo = postInfo;
+        this.postLikedInfo = postLikedInfo;
+        this.postCommentsCount = postCommentsCount;
+    }
+
+    public static PostOutlineDto toDto(Post post) {
+
+        Integer commentsCount = 0;
+        for (Comment comment: post.getComments())
+            if (comment.getDeleted() == null)
+                commentsCount++;
+
+        return PostOutlineDto.builder()
+                .postInfo(PostInfoDto.toDto(post))
+                .postLikedInfo(LikedUsersInfoDto.toDo(post))
+                .postCommentsCount(commentsCount)
+                .build();
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostWriterInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostWriterInfoDto.java
@@ -1,0 +1,30 @@
+package com.fithub.fithubbackend.domain.board.dto;
+
+import com.fithub.fithubbackend.domain.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "게시글 작성자 정보 dto")
+public class PostWriterInfoDto {
+
+    @Schema(description = "작성자 닉네임")
+    private String nickname;
+
+    @Schema(description = "게시글 작성자 프로필 url")
+    private String profileUrl;
+
+    @Builder
+    public PostWriterInfoDto(String nickname, String profileUrl) {
+        this.nickname = nickname;
+        this.profileUrl = profileUrl;
+    }
+
+    public static PostWriterInfoDto toDto(User user) {
+        return PostWriterInfoDto.builder()
+                .nickname(user.getNickname())
+                .profileUrl(user.getProfileImg().getUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/board/post/domain/Post.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/post/domain/Post.java
@@ -34,23 +34,23 @@ public class Post extends BaseTimeEntity {
 
     @BatchSize(size = 100)
     @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY, orphanRemoval = true)
-    private List<Comment> comments = new ArrayList<>();
+    private Set<Comment> comments = new HashSet<>();
 
     @BatchSize(size = 100)
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
-    private List<Bookmark> bookmarks = new ArrayList<>();
+    private Set<Bookmark> bookmarks = new HashSet<>();
 
     @BatchSize(size = 100)
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
-    private List<Likes> likes = new ArrayList<>();
+    private Set<Likes> likes = new HashSet<>();
 
     @BatchSize(size = 100)
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
-    private List<PostHashtag> postHashtags = new ArrayList<>();
+    private Set<PostHashtag> postHashtags = new HashSet<>();
 
     @BatchSize(size = 100)
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
-    private List<PostDocument> postDocuments = new ArrayList<>();
+    private Set<PostDocument> postDocuments = new HashSet<>();
 
     public void setUser(User user) {
         this.user = user;

--- a/src/main/java/com/fithub/fithubbackend/domain/board/repository/PostHashtagRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/repository/PostHashtagRepository.java
@@ -10,7 +10,7 @@ import java.util.*;
 
 public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long> {
 
-    @Query(value = "SELECT h.content FROM PostHashtag p JOIN Hashtag h ON p.hashtag = h WHERE p.post.id = :postId order by p.id")
+    @Query(value = "SELECT h.content FROM PostHashtag p JOIN FETCH Hashtag h ON p.hashtag = h WHERE p.post.id = :postId order by p.id")
     List<String> findHashtagByPostId(@Param("postId") Long postId);
 
     @Query(value = "SELECT ph FROM PostHashtag ph LEFT JOIN FETCH ph.hashtag WHERE ph.post.id = :postId")

--- a/src/main/java/com/fithub/fithubbackend/domain/board/repository/PostRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/repository/PostRepository.java
@@ -10,10 +10,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    @Override
-    @EntityGraph(attributePaths = {"user", "user.profileImg", "likes", "postHashtags", "postDocuments", "postHashtags.hashtag"})
-    Page<Post> findAll(Pageable pageable);
-
     @EntityGraph(attributePaths = {"user", "user.profileImg", "likes", "postHashtags", "postDocuments", "postHashtags.hashtag", "comments"})
     @Query(value = "SELECT post " +
             "FROM Post post " +

--- a/src/main/java/com/fithub/fithubbackend/domain/board/repository/PostRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/repository/PostRepository.java
@@ -1,7 +1,22 @@
 package com.fithub.fithubbackend.domain.board.repository;
 
 import com.fithub.fithubbackend.domain.board.post.domain.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    @Override
+    @EntityGraph(attributePaths = {"user", "user.profileImg", "likes", "postHashtags", "postDocuments", "postHashtags.hashtag"})
+    Page<Post> findAll(Pageable pageable);
+
+    @EntityGraph(attributePaths = {"user", "user.profileImg", "likes", "postHashtags", "postDocuments", "postHashtags.hashtag", "comments"})
+    @Query(value = "SELECT post " +
+            "FROM Post post " +
+            "WHERE post.id = :postId")
+    Post findPostWithHashtags(@Param("postId") long postId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/api/AuthController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/api/AuthController.java
@@ -87,4 +87,14 @@ public class AuthController {
     public ResponseEntity<String> oAuthSignUp(@RequestBody OAuthSignUpDto oAuthSignUpDto, HttpServletResponse response) {
         return ResponseEntity.ok(authService.oAuthSignUp(oAuthSignUpDto, response));
     }
+
+    @Operation(summary = "비밀번호 변경", responses = {
+            @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),
+            @ApiResponse(responseCode = "400", description = "기존 비밀번호와 동일하므로 다른 비밀번호로 변경 필요")
+    })
+    @PostMapping("/change/password")
+    public ResponseEntity<Void> updatePassword(@RequestBody @Valid PasswordUpdateDto passwordUpdateDto) {
+        authService.updatePassword(passwordUpdateDto);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/api/EmailController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/api/EmailController.java
@@ -34,14 +34,14 @@ public class EmailController {
         return emailService.checkCertificationNumber(emailNumberDto);
     }
 
-    @Operation(summary = "비밀번호 찾기 위해 회원 가입 여부 확인 및 이메일 전송(인증번호) ", responses = {
-            @ApiResponse(responseCode = "200", description = "이메일(인증번호) 전송 완료"),
+    @Operation(summary = "임시 비밀번호 이메일 전송", responses = {
+            @ApiResponse(responseCode = "200", description = "이메일 전송 완료"),
             @ApiResponse(responseCode = "404", description = "가입되지 않는 이메일", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
             @ApiResponse(responseCode = "409", description = "소셜 로그인으로 가입된 이메일", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
     })
-    @PostMapping("/validation/send")
-    public ResponseEntity<Void> isUserSignedUpAndSendEmail(@RequestBody EmailDto emailDto) throws MessagingException {
-        emailService.isUserSignedUpAndSendEmail(emailDto);
+    @PostMapping("/send/temporary-password")
+    public ResponseEntity<Void> sendEmailWithTemporaryPassword(@RequestBody EmailDto emailDto) throws MessagingException {
+        emailService.sendEmailWithTemporaryPassword(emailDto);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/api/EmailController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/api/EmailController.java
@@ -1,31 +1,27 @@
 package com.fithub.fithubbackend.domain.user.api;
 
-import com.fithub.fithubbackend.domain.user.application.EmailServiceImpl;
+import com.fithub.fithubbackend.domain.user.application.EmailService;
 import com.fithub.fithubbackend.domain.user.dto.EmailDto;
 import com.fithub.fithubbackend.domain.user.dto.EmailNumberDto;
 import com.fithub.fithubbackend.global.exception.ErrorResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/auth")
+@RequestMapping("/auth/email")
 public class EmailController {
-    private final EmailServiceImpl emailService;
+    private final EmailService emailService;
     @Operation(summary = "이메일 전송(인증번호)", responses = {
             @ApiResponse(responseCode = "200", description = "전송완료"),
     })
-    @PostMapping("/email/send")
+    @PostMapping("/send")
     public void sendEmail(@RequestBody EmailDto emailDto) throws MessagingException {
         emailService.sendEmail(emailDto);
     }
@@ -33,8 +29,19 @@ public class EmailController {
             @ApiResponse(responseCode = "200", description = "생성됨"),
             @ApiResponse(responseCode = "409", description = "생성된 인증번호와 일치하지 않음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
     })
-    @PostMapping("/email/check")
+    @PostMapping("/check")
     public ResponseEntity<String> checkCertificationNumber(@RequestBody EmailNumberDto emailNumberDto){
         return emailService.checkCertificationNumber(emailNumberDto);
+    }
+
+    @Operation(summary = "비밀번호 찾기 위해 회원 가입 여부 확인 및 이메일 전송(인증번호) ", responses = {
+            @ApiResponse(responseCode = "200", description = "이메일(인증번호) 전송 완료"),
+            @ApiResponse(responseCode = "404", description = "가입되지 않는 이메일", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "409", description = "소셜 로그인으로 가입된 이메일", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
+    })
+    @PostMapping("/validation/send")
+    public ResponseEntity<Void> isUserSignedUpAndSendEmail(@RequestBody EmailDto emailDto) throws MessagingException {
+        emailService.isUserSignedUpAndSendEmail(emailDto);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthService.java
@@ -20,4 +20,6 @@ public interface AuthService {
     TokenInfoDto reissue(String cookieRefreshToken, HttpServletRequest request, HttpServletResponse response);
 
     String oAuthSignUp(OAuthSignUpDto oAuthSignUpDto, HttpServletResponse response);
+
+    void updatePassword(PasswordUpdateDto passwordDto);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthServiceImpl.java
@@ -195,8 +195,6 @@ public class AuthServiceImpl implements AuthService {
     @Override
     @Transactional
     public void updatePassword(PasswordUpdateDto passwordUpdateDto) {
-        System.out.println(passwordUpdateDto.getEmail());
-
         User user = userRepository.findByEmail(passwordUpdateDto.getEmail()).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 회원"));
 
         if (passwordEncoder.matches(passwordUpdateDto.getPassword(), user.getPassword()))

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthServiceImpl.java
@@ -192,6 +192,20 @@ public class AuthServiceImpl implements AuthService {
         return tokenInfoDto.getAccessToken();
     }
 
+    @Override
+    @Transactional
+    public void updatePassword(PasswordUpdateDto passwordUpdateDto) {
+        System.out.println(passwordUpdateDto.getEmail());
+
+        User user = userRepository.findByEmail(passwordUpdateDto.getEmail()).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 회원"));
+
+        if (passwordEncoder.matches(passwordUpdateDto.getPassword(), user.getPassword()))
+            throw new CustomException(ErrorCode.BAD_REQUEST, "기존 비밀번호와 동일하므로 다른 비밀번호로 변경 필요");
+
+        user.updatePassword(passwordEncoder.encode(passwordUpdateDto.getPassword()));
+
+    }
+
     private void duplicateNickname(String nickname){
         if(userRepository.findByNickname(nickname).isPresent())
             throw new CustomException(ErrorCode.DUPLICATE,"중복된 닉네임 입니다.");

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/EmailService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/EmailService.java
@@ -8,4 +8,5 @@ import org.springframework.http.ResponseEntity;
 public interface EmailService {
     void sendEmail(EmailDto emailDto) throws MessagingException;
     ResponseEntity<String> checkCertificationNumber(EmailNumberDto emailNumberDto);
+    void isUserSignedUpAndSendEmail(EmailDto emailDto) throws MessagingException;
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/EmailService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/EmailService.java
@@ -8,5 +8,5 @@ import org.springframework.http.ResponseEntity;
 public interface EmailService {
     void sendEmail(EmailDto emailDto) throws MessagingException;
     ResponseEntity<String> checkCertificationNumber(EmailNumberDto emailNumberDto);
-    void isUserSignedUpAndSendEmail(EmailDto emailDto) throws MessagingException;
+    void sendEmailWithTemporaryPassword(EmailDto emailDto) throws MessagingException;
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/EmailServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/EmailServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,9 +26,17 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class EmailServiceImpl implements EmailService {
     private final String SUBJECT = "핏헙 인증메일 입니다.";
+
+    private final String SUBJECT_TEMPORARY_PW = "핏헙 임시 비밀번호 발급";
+
     private final String MESSAGE = "인증번호는 %s 입니다.";
+
+    private final String MESSAGE_TEMPORARY_PW = "임시 비밀번호는 %s 입니다. \n ※ 임시 비밀번호로 로그인 한 후 마이페이지에서 비밀번호를 변경해 주세요";
+
     private final JavaMailSender javaMailSender;
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
     @Value("${spring.mail.username}")
     private String from;
     private HashMap<String,String> sentMail = new HashMap<>();
@@ -65,12 +74,24 @@ public class EmailServiceImpl implements EmailService {
     }
 
     @Override
-    @Transactional(readOnly = true)
-    public void isUserSignedUpAndSendEmail(EmailDto emailDto) throws MessagingException {
+    @Transactional
+    public void sendEmailWithTemporaryPassword(EmailDto emailDto) throws MessagingException {
         User user = userRepository.findByEmail(emailDto.getTo()).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 회원"));
-        if (! user.getProvider().isEmpty())
+        if (! user.getProvider().isEmpty() && user.getProvider() != null )
             throw new CustomException(ErrorCode.DUPLICATE, user.getProvider() + "로 가입된 이메일");
 
-        sendEmail(emailDto);
+        boolean useLetters = true;
+        boolean useNumbers = true;
+        String temporaryPassword = RandomStringUtils.random(8, useLetters, useNumbers);
+
+        user.updatePassword(passwordEncoder.encode(temporaryPassword));
+
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+        mimeMessageHelper.setFrom(from);
+        mimeMessageHelper.setTo(emailDto.getTo()); // 메일 수신자
+        mimeMessageHelper.setSubject(SUBJECT_TEMPORARY_PW); // 메일 제목
+        mimeMessageHelper.setText(emailDto.certificationNumberFormat(MESSAGE_TEMPORARY_PW, temporaryPassword), true); // 메일 본문 내용, HTML 여부
+        javaMailSender.send(mimeMessage);
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/domain/User.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/domain/User.java
@@ -152,6 +152,10 @@ public class User extends BaseTimeEntity implements UserDetails {
         this.roles.set(this.roles.indexOf("ROLE_GUEST"), "ROLE_USER");
     }
 
+    public void updatePassword(String password) {
+        this.password =password;
+    }
+
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/com/fithub/fithubbackend/domain/user/dto/PasswordUpdateDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/dto/PasswordUpdateDto.java
@@ -1,0 +1,18 @@
+package com.fithub.fithubbackend.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Schema(description = "비밀번호 변경 dto")
+public class PasswordUpdateDto {
+
+    @NotNull
+    private String email;
+
+    @NotNull
+    private String password;
+}

--- a/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
@@ -33,7 +33,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final String[] SHOULD_NOT_FILTER_URI_ALL_LIST = new String[]{
             "/auth/sign-in", "/auth/sign-up", "/auth/oauth/**", "exception",
-            "/admin/sign-in", "**exception**","/auth/email/**", "/auth/change/password"
+            "/admin/sign-in", "**exception**","/auth/email/**"
     };
 
     private static final String[] SHOULD_NOT_FILTER_GET_URI_LIST = new String[] {

--- a/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
@@ -37,7 +37,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     };
 
     private static final String[] SHOULD_NOT_FILTER_GET_URI_LIST = new String[] {
-            "/users/training", "/users/training/all", "/auth/oauth/login", "/posts/non-user/**"
+            "/users/training", "/users/training/all", "/auth/oauth/login", "/posts"
     };
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
@@ -37,7 +37,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     };
 
     private static final String[] SHOULD_NOT_FILTER_GET_URI_LIST = new String[] {
-            "/users/training", "/users/training/all", "/auth/oauth/login", "/posts"
+            "/users/training", "/users/training/all", "/auth/oauth/login", "/posts/**"
     };
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
@@ -33,11 +33,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final String[] SHOULD_NOT_FILTER_URI_ALL_LIST = new String[]{
             "/auth/sign-in", "/auth/sign-up", "/auth/oauth/regist", "exception",
-            "/admin/sign-in", "**exception**","/auth/email/**"
+            "/admin/sign-in", "**exception**","/auth/email/**", "/auth/change/password"
     };
 
     private static final String[] SHOULD_NOT_FILTER_GET_URI_LIST = new String[] {
-            "/users/training", "/users/training/all"
+            "/users/training", "/users/training/all", "/posts/**"
     };
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
@@ -37,7 +37,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     };
 
     private static final String[] SHOULD_NOT_FILTER_GET_URI_LIST = new String[] {
-            "/users/training", "/users/training/all", "/posts/**"
+            "/users/training", "/users/training/all", "/posts/non-user/**"
     };
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
@@ -47,7 +47,7 @@ public class SecurityConfig {
     };
 
     private static final String[] PERMIT_ALL_GET_PATTERNS = new String[] {
-        "/users/training/all", "/users/training"
+        "/users/training/all", "/users/training", "/posts/**"
     };
 
     @Bean

--- a/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
@@ -47,7 +47,7 @@ public class SecurityConfig {
     };
 
     private static final String[] PERMIT_ALL_GET_PATTERNS = new String[] {
-        "/users/training/all", "/users/training", "/posts/**"
+        "/users/training/all", "/users/training", "/posts/non-user/**"
     };
 
     @Bean

--- a/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig {
     };
 
     private static final String[] PERMIT_ALL_GET_PATTERNS = new String[] {
-        "/users/training/all", "/users/training", "/posts"
+        "/users/training/all", "/users/training", "/posts/**"
     };
 
     @Bean

--- a/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig {
     };
 
     private static final String[] PERMIT_ALL_GET_PATTERNS = new String[] {
-        "/users/training/all", "/users/training", "/posts/non-user/**"
+        "/users/training/all", "/users/training", "/posts"
     };
 
     @Bean


### PR DESCRIPTION
## PR 유형
- 기능 추가, 수정

## 반영 브랜치
- feature/auth -> main

## 변경사항
- 비밀번호 찾기 기능 추가
- JwtAuthenticationFilter, SecurityConfig에 인증 필요 없는 api 추가 (게시글 전체, 세부 조회 api / 비밀번호 변경 api)

### 2024/01/18 update
- 게시글 세부 조회 시에만 댓글 리스트 확인 가능, 
- stream의  limit 사용하여 게시글 좋아요 리스트 최대 3개까지만 가져오도록 수정
- 게시글 조회 리팩토링 (@entitygraph 사용하여 게시글 조회 시 연관된 객체 불러오기)
- 게시글 정보 Dto 세분화

### 2024/01/20 update
- 임시 비밀번호 이메일로 전송
- 메모리 낭비 이슈로 게시글 전체 조회 시 fetch join 삭제

## 테스트 결과

#### 1. 임시 비밀번호 이메일로 전송

> POST auth/email/send/temporary-password

1-1. 가입되지 않는 이메일인 경우 (404 error code 전달)
![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/91b04012-8b95-4dcc-8d5e-707451168c99)

1-2. 소셜 로그인으로 가입한 이메일인 경우 (소셜 provider와 함께 409 error code 전달)
![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/e88e22b6-2825-4912-a84a-ee823f7a8bc0)

1-3. 일반 회원 가입으로 회원 가입한 회원인 경우 (200 http state code와 임시 비밀번호를 이메일로 전송) 
![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/2a8e9c78-1d23-447f-9f2b-091390cd486c)

### 2024/01/18 update

#### 2. 게시글 전체 조회

> GET /posts

![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/6e34813b-81c1-4b62-ad9e-702de691830f)
![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/3ee6b8b2-80ec-4bbf-8d53-06c6619f0f7f)
![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/bfa67ca6-8242-48a3-bfff-955200d55d97)
- 좋아요한 사용자 리스트 최대 3개의 정보만 가져옴
- 댓글 리스트 조회 불가

<hr>

#### 4. 게시글 세부 조회

> GET /posts/{postId}

![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/2e5cac5d-f2f4-4630-b597-d48ae242b3fb)
![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/c233e84c-094c-4d71-ae3c-682772a8a112)
![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/1af6cc5f-f477-4822-8245-8914121f396d)
![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/3ac52d42-9155-4ce2-946e-3830d991d757)
![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/a94535a2-0125-4dfb-a774-02715cb86487)
![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/4b7d15a6-cb20-45c7-9eb8-69cab8d17f92)
- 좋아요한 사용자 리스트 최대 3개의 정보만 가져옴

## 이슈
- 회원과 비회원이 동일한 게시글 조회 api를 사용하고, 인증 절차를 거치지 않으면 좋아요 및 북마크 여부 확인 불가능
  - 해결: 회원과 비회원에게 다른 api를 제공 (회원: 인증이 필요한 api 호출, 비회원: 인증이 필요하지 않는 api 호출 ex) '/posts/non-user' )
  
### 2024/01/18 update
  - 게시글 조회는 인증 없이 조회 가능하고, 로그인 여부에 따라 게시글 좋아요 및 북마크 여부 확인 api 호출하도록 수정하기 

### 2024/01/20 update
  - fetch join과 pagination 같이 사용할 경우 [WARN] firstResult/maxResults specified with collection fetch; applying in memory! 경고 문구 발생
  - 발생 원인 : paging을 적용하더라도 모든 데이터를 가져와 메모리에 불러와서 페이징을 적용. 추후에 @entitygraph 대신 spring.jpa.properties.hibernate.default_batch_fetch_size=1000 사용하는 방향으로 수정