### PR TITLE
Update: 소셜 로그인 성공, 실패 수정

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainingAvailableDateDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainingAvailableDateDto.java
@@ -1,0 +1,34 @@
+package com.fithub.fithubbackend.domain.Training.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fithub.fithubbackend.domain.Training.domain.AvailableDate;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class TrainingAvailableDateDto {
+    private Long id;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate date;
+
+    private boolean enabled;
+
+    private List<TrainingAvailableTimeDto> availableTimes = new ArrayList<>();
+
+    public static TrainingAvailableDateDto toDto(AvailableDate date) {
+        return TrainingAvailableDateDto.builder()
+                .id(date.getId())
+                .date(date.getDate())
+                .enabled(date.isEnabled())
+                .availableTimes(date.getAvailableTimes().stream().map(TrainingAvailableTimeDto::toDto).toList())
+                .build();
+    }
+
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainingAvailableTimeDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainingAvailableTimeDto.java
@@ -1,0 +1,29 @@
+package com.fithub.fithubbackend.domain.Training.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fithub.fithubbackend.domain.Training.domain.AvailableTime;
+import lombok.*;
+
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class TrainingAvailableTimeDto {
+
+    private Long id;
+
+    @JsonFormat(pattern = "HH:mm:ss")
+    private LocalTime time;
+
+    private boolean enabled;
+
+    public static TrainingAvailableTimeDto toDto(AvailableTime time) {
+        return TrainingAvailableTimeDto.builder()
+                .id(time.getId())
+                .time(time.getTime())
+                .enabled(time.isEnabled())
+                .build();
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainingInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainingInfoDto.java
@@ -1,7 +1,6 @@
 package com.fithub.fithubbackend.domain.Training.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fithub.fithubbackend.domain.Training.domain.AvailableDate;
 import com.fithub.fithubbackend.domain.Training.domain.Training;
 import lombok.*;
 
@@ -34,7 +33,7 @@ public class TrainingInfoDto {
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate endDate;
 
-    private List<AvailableDate> availableDates;
+    private List<TrainingAvailableDateDto> availableDates;
 
     public static TrainingInfoDto toDto(Training training) {
         return TrainingInfoDto.builder()
@@ -47,7 +46,7 @@ public class TrainingInfoDto {
                 .price(training.getPrice())
                 .startDate(training.getStartDate())
                 .endDate(training.getEndDate())
-                .availableDates(training.getAvailableDates())
+                .availableDates(training.getAvailableDates().stream().map(TrainingAvailableDateDto::toDto).toList())
                 .build();
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/user/api/AuthController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/api/AuthController.java
@@ -80,11 +80,22 @@ public class AuthController {
 
 
     @Operation(summary = "소셜 회원가입 추가 정보 저장", responses = {
-            @ApiResponse(responseCode = "200", description = "accessToken 반환. 세션 쿠키로 설정 필요"),
+            @ApiResponse(responseCode = "200", description = "accessToken 헤더 세팅됨"),
             @ApiResponse(responseCode = "404", description = "소셜 회원가입이 제대로 성공하지 못 해 db에 user 정보가 저장된게 없음. 다시 회원가입부터 진행 필요")
     })
     @PostMapping("/oauth/regist")
     public ResponseEntity<String> oAuthSignUp(@RequestBody OAuthSignUpDto oAuthSignUpDto, HttpServletResponse response) {
-        return ResponseEntity.ok(authService.oAuthSignUp(oAuthSignUpDto, response));
+        authService.oAuthSignUp(oAuthSignUpDto, response);
+        return ResponseEntity.ok().body("완료");
+    }
+
+    @Operation(summary = "소셜 로그인 성공 시 토큰 발급을 위한 api", responses = {
+            @ApiResponse(responseCode = "200", description = "accessToken 헤더 세팅됨"),
+            @ApiResponse(responseCode = "400", description = "이메일과 provider를 검사한 결과 해당 provider로 가입된 이에일이 아님")
+    })
+    @GetMapping("/oauth/login")
+    public ResponseEntity<String> oAuthLogin(@Parameter String email, @Parameter String provider, HttpServletResponse response) {
+        authService.oAuthLogin(email, provider, response);
+        return ResponseEntity.ok().body("완료");
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthService.java
@@ -19,5 +19,7 @@ public interface AuthService {
 
     TokenInfoDto reissue(String cookieRefreshToken, HttpServletRequest request, HttpServletResponse response);
 
-    String oAuthSignUp(OAuthSignUpDto oAuthSignUpDto, HttpServletResponse response);
+    void oAuthSignUp(OAuthSignUpDto oAuthSignUpDto, HttpServletResponse response);
+
+    void oAuthLogin(String email, String provider, HttpServletResponse response);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthServiceImpl.java
@@ -32,6 +32,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -211,9 +212,16 @@ public class AuthServiceImpl implements AuthService {
             throw new CustomException(ErrorCode.DUPLICATE,"중복된 닉네임 입니다.");
     }
     private void duplicateEmail(String email){
-        if(userRepository.findByEmail(email).isPresent())
+        Optional<User> optionalUser = userRepository.findByEmail(email);
+        if(optionalUser.isPresent()) {
+            User user = optionalUser.get();
+            if (user.getProvider() != null && !user.getProvider().isEmpty()) {
+                throw new CustomException(ErrorCode.DUPLICATE, "해당 이메일은 " + user.getProvider() + " 소셜 로그인이 진행된 이메일입니다.");
+            }
             throw new CustomException(ErrorCode.DUPLICATE,"중복된 이메일 입니다.");
+        }
     }
+
     private void formValidate(BindingResult bindingResult){
         String message = String.valueOf(bindingResult.getFieldErrors().stream()
                         .findFirst().map(DefaultMessageSourceResolvable::getDefaultMessage))

--- a/src/main/java/com/fithub/fithubbackend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/repository/UserRepository.java
@@ -12,6 +12,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmailAndProvider(String email, String provider);
     Optional<User> findByProviderId(String providerId);
 
+    boolean existsByNickname(String nickname);
     boolean existsByEmail(String email);
     boolean existsByEmailAndProviderIsNull(String email);
+    boolean existsByEmailAndProvider(String email, String provider);
 }

--- a/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
@@ -32,12 +32,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 
     private static final String[] SHOULD_NOT_FILTER_URI_ALL_LIST = new String[]{
-            "/auth/sign-in", "/auth/sign-up", "/auth/oauth/regist", "exception",
+            "/auth/sign-in", "/auth/sign-up", "/auth/oauth/**", "exception",
             "/admin/sign-in", "**exception**","/auth/email/**"
     };
 
     private static final String[] SHOULD_NOT_FILTER_GET_URI_LIST = new String[] {
-            "/users/training", "/users/training/all"
+            "/users/training", "/users/training/all", "/auth/oauth/login"
     };
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/global/auth/OAuthFailureHandler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/OAuthFailureHandler.java
@@ -1,31 +1,30 @@
 package com.fithub.fithubbackend.global.auth;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fithub.fithubbackend.global.exception.ErrorCode;
-import com.fithub.fithubbackend.global.exception.ErrorResponseDto;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 
 @Slf4j
 @Component
-public class OAuthFailureHandler implements AuthenticationFailureHandler  {
+public class OAuthFailureHandler extends SimpleUrlAuthenticationFailureHandler {
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
         log.error("소셜 로그인 실패: {} , endpoint: {}", exception.getMessage(), request.getServletPath());
-        ObjectMapper objectMapper = new ObjectMapper();
-        ErrorResponseDto errorResponseDto = ErrorResponseDto.toResponseEntity(ErrorCode.BAD_REQUEST, exception.getMessage()).getBody();
 
-        response.setStatus(400);
-        response.setContentType("application/json");
-        response.setCharacterEncoding("utf-8");
-        response.getWriter().write(objectMapper.writeValueAsString(errorResponseDto));
+        String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:3000/oauth/fail")
+                .queryParam("status", HttpStatus.BAD_REQUEST)
+                .queryParam("message", exception.getMessage())
+                .build()
+                .encode().toString();
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
@@ -1,7 +1,6 @@
 package com.fithub.fithubbackend.global.config;
 
 import com.fithub.fithubbackend.global.auth.*;
-import com.fithub.fithubbackend.global.util.CookieUtil;
 import com.fithub.fithubbackend.global.util.HeaderUtil;
 import com.fithub.fithubbackend.global.util.RedisUtil;
 import lombok.RequiredArgsConstructor;
@@ -36,7 +35,6 @@ public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisUtil redisUtil;
     private final HeaderUtil headerUtil;
-    private final CookieUtil cookieUtil;
 
     private final OAuthService oAuthService;
     private final OAuthSuccessHandler oAuthSuccessHandler;


### PR DESCRIPTION
## pr 유형
- 기능 수정, 추가

## 반영 브랜치
- update -> main

## 변경 사항
1. 소셜 로그인 -> 성공 -> 리다이렉트(파라미터에 socia_login true값을 줌?) -> socia_login = true면 프론트에서 /auth/oauth/login 요청 -> 백에서 토큰 설정
2. 소셜 로그인 -> 실패 -> 실패 시 보여줄 페이지로 리다이렉트 (파라미터에 실패 이유 포함 (http://localhost:3000/oauth/fail)) -> 프론트에서 처리

3. 소셜 로그인 시 토큰 반환 X. 어차피 헤더에 설정해주니까 반환할 필요 없다고 생각. "완료"라고만 보내줌
4. 일반 회원가입 이메일 중복 체크할 때 소셜로 있는 이메일이면 어떤 소셜로 있는 건지 알려줌

## 테스트 결과
- 소셜 로그인 성공 후 토큰 발급: /auth/oauth/login?email=~ &provider=~
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/9434a456-c62e-4787-a545-1bd693a38fc0)

- 소셜 로그인 성공 후 토큰 발급: 토큰 발급할 때 주어진 이메일과 provider가 db에 저장된 것과 다르면 
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/e623d3f4-8bbe-4960-9ae2-d57dff7cee1a)

- 소셜 회원가입: 이미 일반 회원가입이 진행된 이메일이라면
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/0e2b95d9-82f2-4f03-bd3d-48f7ffc84033)

- 일반 회원가입: 이미 소셜 회원가입이 진행된 이메일이라면
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/bebf1ede-5c52-472f-b90a-8fba6bf4a6a6)
