### PR TITLE
update: 트레이닝 마감 스케줄 작동 시 트레이닝 예약 시간도 마감하도록 수정

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/AvailableDate.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/AvailableDate.java
@@ -74,6 +74,22 @@ public class AvailableDate {
         }
     }
 
+    public void closeCurrentTime(LocalTime now) {
+        for (AvailableTime time : this.getAvailableTimes()) {
+            if (time.isEnabled() && time.getTime().getHour() == now.getHour()) {
+                time.closeTime();
+                return;
+            }
+        }
+    }
+
+    public boolean isAllClosed() {
+        for (AvailableTime time : this.getAvailableTimes()) {
+            if (time.isEnabled()) return false;
+        }
+        return true;
+    }
+
     public void closeDate() {
         this.enabled = false;
     }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
@@ -152,4 +152,11 @@ public class Training extends BaseTimeEntity {
         }
         return true;
     }
+
+    public AvailableDate getToday(LocalDate today) {
+        for (AvailableDate date : this.getAvailableDates()) {
+            if (date.getDate().equals(today)) return date;
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/global/component/Scheduler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/component/Scheduler.java
@@ -1,5 +1,6 @@
 package com.fithub.fithubbackend.global.component;
 
+import com.fithub.fithubbackend.domain.Training.domain.AvailableDate;
 import com.fithub.fithubbackend.domain.Training.domain.Training;
 import com.fithub.fithubbackend.domain.Training.repository.TrainingRepository;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +33,12 @@ public class Scheduler {
         LocalDate date = LocalDate.now();
         LocalTime time = LocalTime.now();
         for (Training training : openTrainingList) {
+            AvailableDate today = training.getToday(date);
+            if (today != null && today.isEnabled()) {
+                today.closeCurrentTime(time);
+                if (today.isAllClosed()) today.closeDate();
+            }
+
             if (training.getEndDate().isEqual(date) && !training.getEndHour().isBefore(time)) continue;
             training.updateClosed(true);
         }


### PR DESCRIPTION
## pr 유형
- 기능 수정

## 반영 브랜치
- feature/training -> main

## 변경 사항
트레이닝 마감 스케줄러
- 기존에는 시간 체크 후( 트레이닝 마감일 && 마지막 시간이 현 시간)이면 트레이닝 전체 마감만 했는데, 매 시간마다 체크하는 스케줄러이다 보니 트레이닝 예약 가능 날짜가 오늘이고, 오늘 예약 가능한 시간들 중에 스케줄러가 돌아간 시간이면 (예약 불가능한 상태) 지났으면 그 시간도 마감하도록 추가
- 시간 마감 후, 해당 트레이닝에 오늘 더 이상 가능한 예약 시간이 없으면 오늘 날짜도 마감되도록