### PR TITLE
Feature/training: 정각에 예약 상태 변경 스케줄러 추가, 트레이너의 예약 노쇼 처리 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainingController.java
@@ -104,8 +104,8 @@ public class TrainingController {
             @Parameter(name = "pageable", description = "조회할 목록의 page, size, sort(기본은 id (생성 순), 예약된 트레이닝 날짜 순은 reserveDateTime으로 주면 됨)")
     }, responses = {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "401", description = "회원이 트레이너가 아님", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 회원", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "해당 회원은 트레이너가 아님", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
     @GetMapping("/reservations")
     public ResponseEntity<Page<TrainersReserveInfoDto>> getReservationList(@AuthUser User user,
@@ -114,6 +114,15 @@ public class TrainingController {
         return ResponseEntity.ok(trainingService.getReservationList(user, pageable));
     }
 
+    @Operation(summary = "트레이너의 예약 노쇼 처리", parameters = {
+            @Parameter(name = "reservationId", description = "상태를 변경하려는 예약의 id")
+    }, responses = {
+            @ApiResponse(responseCode = "200", description = "노쇼 처리 성공"),
+            @ApiResponse(responseCode = "400", description = "해당 트레이닝이 완료 상태가 아님 (노쇼는 완료 상태인 예약만 가능, 완료 상태는 정각마다 스케줄러에 의해 변경됨)", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "403", description = "해당 트레이닝을 생성한 트레이너가 아님. 권한 없음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 예약", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+    })
     @PutMapping("/reservation/status/noshow")
     public ResponseEntity<String> updateReservationStatusNoShow(@AuthUser User user, @RequestParam Long reservationId) {
         if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainingController.java
@@ -113,4 +113,11 @@ public class TrainingController {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         return ResponseEntity.ok(trainingService.getReservationList(user, pageable));
     }
+
+    @PutMapping("/reservation/status/noshow")
+    public ResponseEntity<String> updateReservationStatusNoShow(@AuthUser User user, @RequestParam Long reservationId) {
+        if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        trainingService.updateReservationStatusNoShow(user.getEmail(), reservationId);
+        return ResponseEntity.ok().body("완료");
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingService.java
@@ -15,4 +15,6 @@ public interface TrainingService {
     void openTraining(Long id, User user);
 
     Page<TrainersReserveInfoDto> getReservationList(User user, Pageable pageable);
+
+    void updateReservationStatusNoShow(String email, Long reservationId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingServiceImpl.java
@@ -167,7 +167,7 @@ public class TrainingServiceImpl implements TrainingService {
     @Override
     @Transactional(readOnly = true)
     public Page<TrainersReserveInfoDto> getReservationList(User user, Pageable pageable) {
-        Trainer trainer = trainerRepository.findByUserId(user.getId()).orElseThrow(() -> new CustomException(ErrorCode.AUTHENTICATION_ERROR, "해당 회원은 트레이너가 아닙니다."));
+        Trainer trainer = trainerRepository.findByUserId(user.getId()).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "해당 회원은 트레이너가 아닙니다."));
 
         Page<ReserveInfo> reserveInfoPage = reserveInfoRepository.findByTrainerId(trainer.getId(), pageable);
         return reserveInfoPage.map(TrainersReserveInfoDto::toDto);

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
@@ -6,9 +6,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface ReserveInfoRepository extends JpaRepository<ReserveInfo, Long> {
     Page<ReserveInfo> findByTrainerId(Long trainerId, Pageable pageable);
     Page<ReserveInfo> findByUserId(Long userId, Pageable pageable);
 
     boolean existsByTrainingIdAndStatusNotIn(Long trainingId, ReserveStatus[] statuses);
+
+    List<ReserveInfo> findByReserveDateTimeAndStatus(LocalDateTime now, ReserveStatus status);
 }

--- a/src/main/java/com/fithub/fithubbackend/global/component/Scheduler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/component/Scheduler.java
@@ -61,6 +61,12 @@ public class Scheduler {
         for (ReserveInfo reserveInfo : reserveInfoListStatusBefore) {
             reserveInfo.updateStatus(ReserveStatus.START);
         }
+
+        LocalDateTime timeToChangeComplete = reserveTime.minusHours(1);
+        List<ReserveInfo> reserveInfoListToChangeComplete = reserveInfoRepository.findByReserveDateTimeAndStatus(timeToChangeComplete, ReserveStatus.BEFORE);
+        for (ReserveInfo reserveInfo : reserveInfoListToChangeComplete) {
+            reserveInfo.updateStatus(ReserveStatus.COMPLETE);
+        }
     }
 
 }

--- a/src/main/java/com/fithub/fithubbackend/global/component/Scheduler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/component/Scheduler.java
@@ -1,7 +1,10 @@
 package com.fithub.fithubbackend.global.component;
 
 import com.fithub.fithubbackend.domain.Training.domain.AvailableDate;
+import com.fithub.fithubbackend.domain.Training.domain.ReserveInfo;
 import com.fithub.fithubbackend.domain.Training.domain.Training;
+import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
+import com.fithub.fithubbackend.domain.Training.repository.ReserveInfoRepository;
 import com.fithub.fithubbackend.domain.Training.repository.TrainingRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +26,7 @@ import java.util.List;
 public class Scheduler {
 
     private final TrainingRepository trainingRepository;
+    private final ReserveInfoRepository reserveInfoRepository;
 
     @Async
     @Scheduled(cron = "0 0 */1 * * *")
@@ -41,6 +45,21 @@ public class Scheduler {
 
             if (training.getEndDate().isEqual(date) && !training.getEndHour().isBefore(time)) continue;
             training.updateClosed(true);
+        }
+    }
+
+    @Async
+    @Scheduled(cron = "0 0 */1 * * *")
+    @Transactional
+    public void changeReservationStatusToStart() {
+        LocalDateTime now = LocalDateTime.now();
+        log.info("[SCHEDULE] - changeReservationStatusToStart 실행: {}", now);
+
+        LocalDateTime reserveTime = LocalDateTime.of(now.getYear(), now.getMonth(), now.getDayOfMonth(), now.getHour(), 0, 0);
+        List<ReserveInfo> reserveInfoListStatusBefore = reserveInfoRepository.findByReserveDateTimeAndStatus(reserveTime, ReserveStatus.BEFORE);
+
+        for (ReserveInfo reserveInfo : reserveInfoListStatusBefore) {
+            reserveInfo.updateStatus(ReserveStatus.START);
         }
     }
 

--- a/src/main/java/com/fithub/fithubbackend/global/component/Scheduler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/component/Scheduler.java
@@ -63,7 +63,7 @@ public class Scheduler {
         }
 
         LocalDateTime timeToChangeComplete = reserveTime.minusHours(1);
-        List<ReserveInfo> reserveInfoListToChangeComplete = reserveInfoRepository.findByReserveDateTimeAndStatus(timeToChangeComplete, ReserveStatus.BEFORE);
+        List<ReserveInfo> reserveInfoListToChangeComplete = reserveInfoRepository.findByReserveDateTimeAndStatus(timeToChangeComplete, ReserveStatus.START);
         for (ReserveInfo reserveInfo : reserveInfoListToChangeComplete) {
             reserveInfo.updateStatus(ReserveStatus.COMPLETE);
         }


### PR DESCRIPTION
## pr 유형
- 기능 추가

## 반영 브랜치
- feature/training -> main

## 변경 사항
1. 정각에 LocalDateTime.now에 잡힌 예약 리스트 중 취소가 되지 않은 예약의 상태를 진행중으로 변경
2. 정각에 LocalDateTime.now 에서 1시간 뺀 시간에 잡힌 예약 중 진행 중인 예약 (한 시간 전에 시작된 예약)을 완료 상태로 변경
3. 트레이너의 예약 노쇼 처리 기능 추가 (완료 상태인 예약만 변경 가능, 진행 전/진행 중/취소 상태인거는 변경 불가능)

## 테스트 결과
- 정각에 스케줄러 동작
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/9a7f3bdd-2905-4b9f-91c0-434532e041c8)

- 노쇼 처리
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/f7a6cb28-5e3d-48c1-a102-f060cafb26fa)
