### PR TITLE
feat: 로그인한 사용자의 게시글 좋아요, 북마크 여부 확인 기능 추가 / update: 게시글 조회 api 수정, 게시글 좋아요한 사용자 정보 최대 4개까지 가져오도록 수정

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
@@ -20,7 +20,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -39,7 +38,7 @@ public class PostController {
             @ApiResponse(responseCode = "409", description = "이미지가 아닌 파일 업로드 또는 이미지 확장자 검사 실패", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
     })
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Void> createPost(@Valid PostCreateDto postCreateDto, BindingResult bindingResult, @AuthUser User user) {
+    public ResponseEntity<Void> createPost(@Valid PostCreateDto postCreateDto, @AuthUser User user) {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
 
         postService.createPost(postCreateDto, user);

--- a/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
@@ -97,21 +97,25 @@ public class PostController {
     @GetMapping("/like-and-bookmark-status")
     public ResponseEntity<List<LikesBookmarkStatusDto>> getAllPostsWithLikesAndBookmark(@RequestBody List<PostOutlineDto> postOutlineDtos,
                                                                                         @AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         return ResponseEntity.ok(postService.checkPostsLikeAndBookmarkStatus(postOutlineDtos, user));
     }
 
     @Operation(summary = "게시글 세부 조회 시 좋아요, 북마크 여부 체크 (로그인한 회원 ver)", responses = {
             @ApiResponse(responseCode = "200", description = "게시글 전체 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
     @GetMapping("/{postId}/like-and-bookmark-status")
     public ResponseEntity<LikesBookmarkStatusDto> getAllPostsWithLikesAndBookmark(@AuthUser User user, @PathVariable("postId") long postId) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         return ResponseEntity.ok(postService.checkPostLikeAndBookmarkStatus(user, postId));
     }
 
 
     @Operation(summary = "게시글 좋아요", responses = {
             @ApiResponse(responseCode = "200", description = "게시글 좋아요 성공"),
-            @ApiResponse(responseCode = "409", description = "이미 좋아요한 게시글", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
+            @ApiResponse(responseCode = "409", description = "이미 좋아요한 게시글", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     }, parameters = {
             @Parameter(name = "postId", description = "좋아요한 게시글 id")
     })
@@ -124,6 +128,7 @@ public class PostController {
 
     @Operation(summary = "게시글 좋아요 취소", responses = {
             @ApiResponse(responseCode = "200", description = "게시글 좋아요 취소 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     }, parameters = {
             @Parameter(name = "postId", description = "좋아요 취소할 게시글 id")
     })
@@ -137,7 +142,8 @@ public class PostController {
 
     @Operation(summary = "게시글 북마크", responses = {
             @ApiResponse(responseCode = "200", description = "게시글 북마크 성공"),
-            @ApiResponse(responseCode = "409", description = "이미 북마크한 게시글", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
+            @ApiResponse(responseCode = "409", description = "이미 북마크한 게시글", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     }, parameters = {
             @Parameter(name = "postId", description = "북마크한 게시글 id")
     })
@@ -150,6 +156,7 @@ public class PostController {
 
     @Operation(summary = "게시글 북마크 삭제", responses = {
             @ApiResponse(responseCode = "200", description = "게시글 북마크 삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     }, parameters = {
             @Parameter(name = "postId", description = "북마크 삭제할 게시글 id")
     })

--- a/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
@@ -23,6 +23,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/posts")
@@ -74,7 +76,7 @@ public class PostController {
     @Operation(summary = "게시글 전체 조회", responses = {
             @ApiResponse(responseCode = "200", description = "게시글 전체 조회 성공"),
     })
-    @GetMapping
+    @GetMapping("/public")
     public ResponseEntity<Page<PostOutlineDto>> getAllPosts(@PageableDefault(size = 9, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
         return ResponseEntity.ok(postService.getAllPosts(pageable));
     }
@@ -82,9 +84,26 @@ public class PostController {
     @Operation(summary = "게시글 세부 조회", responses = {
             @ApiResponse(responseCode = "200", description = "게시글 세부 조회 성공"),
     })
-    @GetMapping("/{postId}")
+    @GetMapping("/public/{postId}")
     public ResponseEntity<PostDetailInfoDto> getPostDetail(@PathVariable("postId") long postId) {
         return ResponseEntity.ok(postService.getPostDetail(postId));
+    }
+
+    @Operation(summary = "게시글 전체 조회 시 좋아요, 북마크 여부 체크 (로그인한 회원 ver)", responses = {
+            @ApiResponse(responseCode = "200", description = "게시글 전체 조회 성공"),
+    })
+    @GetMapping("/like-and-bookmark-status")
+    public ResponseEntity<List<LikesBookmarkStatusDto>> getAllPostsWithLikesAndBookmark(@PageableDefault(size = 9, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
+                                                                                        @AuthUser User user) {
+        return ResponseEntity.ok(postService.checkPostsLikeAndBookmarkStatus(pageable, user));
+    }
+
+    @Operation(summary = "게시글 세부 조회 시 좋아요, 북마크 여부 체크 (로그인한 회원 ver)", responses = {
+            @ApiResponse(responseCode = "200", description = "게시글 전체 조회 성공"),
+    })
+    @GetMapping("/{postId}/like-and-bookmark-status")
+    public ResponseEntity<LikesBookmarkStatusDto> getAllPostsWithLikesAndBookmark(@AuthUser User user, @PathVariable("postId") long postId) {
+        return ResponseEntity.ok(postService.checkPostLikeAndBookmarkStatus(user, postId));
     }
 
 

--- a/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
@@ -90,11 +90,13 @@ public class PostController {
 
     @Operation(summary = "게시글 전체 조회 시 좋아요, 북마크 여부 체크 (로그인한 회원 ver)", responses = {
             @ApiResponse(responseCode = "200", description = "게시글 전체 조회 성공"),
+    }, parameters = {
+            @Parameter(name = "postOutlineDtos", description = "게시글 전체 조회하여 받은 response body의 content")
     })
     @GetMapping("/like-and-bookmark-status")
-    public ResponseEntity<List<LikesBookmarkStatusDto>> getAllPostsWithLikesAndBookmark(@PageableDefault(size = 9, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
+    public ResponseEntity<List<LikesBookmarkStatusDto>> getAllPostsWithLikesAndBookmark(@RequestBody List<PostOutlineDto> postOutlineDtos,
                                                                                         @AuthUser User user) {
-        return ResponseEntity.ok(postService.checkPostsLikeAndBookmarkStatus(pageable, user));
+        return ResponseEntity.ok(postService.checkPostsLikeAndBookmarkStatus(postOutlineDtos, user));
     }
 
     @Operation(summary = "게시글 세부 조회 시 좋아요, 북마크 여부 체크 (로그인한 회원 ver)", responses = {

--- a/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
@@ -82,6 +82,7 @@ public class PostController {
 
     @Operation(summary = "게시글 세부 조회", responses = {
             @ApiResponse(responseCode = "200", description = "게시글 세부 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
     @GetMapping("/public/{postId}")
     public ResponseEntity<PostDetailInfoDto> getPostDetail(@PathVariable("postId") long postId) {
@@ -110,7 +111,7 @@ public class PostController {
 
     @Operation(summary = "게시글 좋아요", responses = {
             @ApiResponse(responseCode = "200", description = "게시글 좋아요 성공"),
-            @ApiResponse(responseCode = "409", description = "이미 좋아요한 게시글"),
+            @ApiResponse(responseCode = "409", description = "이미 좋아요한 게시글", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
     }, parameters = {
             @Parameter(name = "postId", description = "좋아요한 게시글 id")
     })
@@ -136,7 +137,7 @@ public class PostController {
 
     @Operation(summary = "게시글 북마크", responses = {
             @ApiResponse(responseCode = "200", description = "게시글 북마크 성공"),
-            @ApiResponse(responseCode = "409", description = "이미 북마크한 게시글"),
+            @ApiResponse(responseCode = "409", description = "이미 북마크한 게시글", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
     }, parameters = {
             @Parameter(name = "postId", description = "북마크한 게시글 id")
     })

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/BookmarkService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/BookmarkService.java
@@ -12,4 +12,6 @@ public interface BookmarkService {
     void deleteBookmark(User user, Post post);
 
     List<Bookmark> getBookmarksByUser(User user);
+
+    boolean isBookmarked(User user, Long postId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/BookmarkServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/BookmarkServiceImpl.java
@@ -48,4 +48,11 @@ public class BookmarkServiceImpl implements BookmarkService {
     public List<Bookmark> getBookmarksByUser(User user) {
         return bookmarkRepository.findByUserOrderByCreatedDateDesc(user);
     }
+
+    @Override
+    public boolean isBookmarked(User user, Long postId) {
+        if (bookmarkRepository.existsByUserIdAndPostId(user.getId(), postId) == 1)
+            return true;
+        return false;
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/BookmarkServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/BookmarkServiceImpl.java
@@ -51,7 +51,7 @@ public class BookmarkServiceImpl implements BookmarkService {
 
     @Override
     public boolean isBookmarked(User user, Long postId) {
-        if (bookmarkRepository.existsByUserIdAndPostId(user.getId(), postId) == 1)
+        if (bookmarkRepository.existsByUserAndPostId(user, postId))
             return true;
         return false;
     }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/LikesService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/LikesService.java
@@ -14,4 +14,6 @@ public interface LikesService {
     List<Likes> getLikesByPost(Post post);
 
     List<Likes> getLikesByUser(User user);
+
+    boolean isLiked(User user, Long postId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/LikesServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/LikesServiceImpl.java
@@ -48,4 +48,11 @@ public class LikesServiceImpl implements LikesService {
     public List<Likes> getLikesByUser(User user) {
         return likesRepository.findByUserOrderByCreatedDateDesc(user);
     }
+
+    @Override
+    public boolean isLiked(User user, Long postId) {
+        if (likesRepository.existsByUserIdAndPostId(user.getId(), postId) == 1)
+            return true;
+        return false;
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/LikesServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/LikesServiceImpl.java
@@ -51,7 +51,7 @@ public class LikesServiceImpl implements LikesService {
 
     @Override
     public boolean isLiked(User user, Long postId) {
-        if (likesRepository.existsByUserIdAndPostId(user.getId(), postId) == 1)
+        if (likesRepository.existsByUserAndPostId(user, postId))
             return true;
         return false;
     }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostDocumentService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostDocumentService.java
@@ -12,5 +12,4 @@ public interface PostDocumentService {
 
     void updateDocument(List<PostDocumentUpdateDto> postDocumentUpdateDto, Post post);
 
-//    void isValidDocument(List<MultipartFile> images);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostDocumentServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostDocumentServiceImpl.java
@@ -79,22 +79,4 @@ public class PostDocumentServiceImpl implements PostDocumentService {
         );
 
     }
-
-//    @Override
-//    @Transactional
-//    public void isValidDocument(List<MultipartFile> images) {
-//
-//        for (MultipartFile image : images) {
-//            try (InputStream inputStream = image.getInputStream()) {
-//                boolean isValid = FileUtils.validImageFile(inputStream);
-//
-//                if (!isValid) {
-//                    throw new CustomException(ErrorCode.INVALID_IMAGE, "이미지 파일이 아닌 파일");
-//                }
-//            } catch (IOException e) {
-//                throw new CustomException(ErrorCode.INVALID_IMAGE, "이미지 확장자 검사 실패");
-//            }
-//        }
-//    }
-
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostService.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import com.fithub.fithubbackend.domain.user.domain.User;
 
+import java.util.*;
 
 public interface PostService {
     void createPost(PostCreateDto postCreateDto, User user);
@@ -24,4 +25,8 @@ public interface PostService {
     Page<PostOutlineDto> getAllPosts(Pageable pageable);
 
     PostDetailInfoDto getPostDetail(long postId);
+
+    LikesBookmarkStatusDto checkPostLikeAndBookmarkStatus(User user, long postId);
+
+    List<LikesBookmarkStatusDto> checkPostsLikeAndBookmarkStatus(Pageable pageable, User user);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostService.java
@@ -28,5 +28,5 @@ public interface PostService {
 
     LikesBookmarkStatusDto checkPostLikeAndBookmarkStatus(User user, long postId);
 
-    List<LikesBookmarkStatusDto> checkPostsLikeAndBookmarkStatus(Pageable pageable, User user);
+    List<LikesBookmarkStatusDto> checkPostsLikeAndBookmarkStatus(List<PostOutlineDto> postOutlineDtos, User user);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostServiceImpl.java
@@ -124,7 +124,11 @@ public class PostServiceImpl implements PostService {
     @Override
     @Transactional(readOnly = true)
     public PostDetailInfoDto getPostDetail(long postId) {
-        Post post = postRepository.findPostWithHashtags(postId);
+        Post post = postRepository.findByPostIdWithFetchJoin(postId);
+
+        if (post == null)
+            throw new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 게시글");
+
         PostDetailInfoDto postDetailInfoDto = PostDetailInfoDto.toDto(post);
 
         if (post.getComments() != null && !post.getComments().isEmpty())

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostServiceImpl.java
@@ -124,7 +124,7 @@ public class PostServiceImpl implements PostService {
     @Override
     @Transactional(readOnly = true)
     public PostDetailInfoDto getPostDetail(long postId) {
-        Post post = postRepository.findPostWithHashtags(postId);
+        Post post = postRepository.findByPostIdWithFetchJoin(postId);
         PostDetailInfoDto postDetailInfoDto = PostDetailInfoDto.toDto(post);
 
         if (post.getComments() != null && !post.getComments().isEmpty())

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostServiceImpl.java
@@ -140,7 +140,8 @@ public class PostServiceImpl implements PostService {
     @Override
     @Transactional(readOnly = true)
     public LikesBookmarkStatusDto checkPostLikeAndBookmarkStatus(User user, long postId) {
-        return checkLikeAndBookmarkStatus(user, postId);
+        Post post = getPost(postId);
+        return checkLikeAndBookmarkStatus(user, post.getId());
     }
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostServiceImpl.java
@@ -124,7 +124,7 @@ public class PostServiceImpl implements PostService {
     @Override
     @Transactional(readOnly = true)
     public PostDetailInfoDto getPostDetail(long postId) {
-        Post post = postRepository.findByPostIdWithFetchJoin(postId);
+        Post post = postRepository.findPostWithHashtags(postId);
         PostDetailInfoDto postDetailInfoDto = PostDetailInfoDto.toDto(post);
 
         if (post.getComments() != null && !post.getComments().isEmpty())

--- a/src/main/java/com/fithub/fithubbackend/domain/board/dto/LikedUsersInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/dto/LikedUsersInfoDto.java
@@ -30,7 +30,7 @@ public class LikedUsersInfoDto {
     public static LikedUsersInfoDto toDo(Post post) {
         return LikedUsersInfoDto.builder()
                 .likedCount((long) post.getLikes().size())
-                .likedUsers(post.getLikes().stream().limit(3).map(LikesInfoDto::toDto).collect(Collectors.toList()))
+                .likedUsers(post.getLikes().stream().limit(4).map(LikesInfoDto::toDto).collect(Collectors.toList()))
                 .build();
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/board/dto/LikesBookmarkStatusDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/dto/LikesBookmarkStatusDto.java
@@ -1,0 +1,32 @@
+package com.fithub.fithubbackend.domain.board.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LikesBookmarkStatusDto {
+
+    private long postId;
+
+    private boolean likesStatus;
+
+    private boolean bookmarkStatus;
+
+    @Builder
+    public LikesBookmarkStatusDto(long postId) {
+        this.postId = postId;
+        this.likesStatus = false;
+        this.bookmarkStatus = false;
+    }
+
+    public void updateLikesStatus(boolean likesStatus) {
+        this.likesStatus = likesStatus;
+    }
+
+    public void updateBookmarkStatus(boolean bookmarkStatus) {
+        this.bookmarkStatus = bookmarkStatus;
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/board/post/domain/Post.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/post/domain/Post.java
@@ -32,29 +32,20 @@ public class Post extends BaseTimeEntity {
     private User user;
 
 
-    @BatchSize(size = 100)
     @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY, orphanRemoval = true)
-    private Set<Comment> comments = new HashSet<>();
+    private List<Comment> comments = new ArrayList<>();
 
-    @BatchSize(size = 100)
-    @OrderBy("id asc")
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
-    private Set<Bookmark> bookmarks = new HashSet<>();
+    private List<Bookmark> bookmarks = new ArrayList<>();
 
-    @BatchSize(size = 100)
-    @OrderBy("id asc")
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
-    private Set<Likes> likes = new HashSet<>();
+    private List<Likes> likes = new ArrayList<>();
 
-    @BatchSize(size = 100)
-    @OrderBy("id asc")
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
-    private Set<PostHashtag> postHashtags = new HashSet<>();
+    private List<PostHashtag> postHashtags = new ArrayList<>();
 
-    @BatchSize(size = 100)
-    @OrderBy("id asc")
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
-    private Set<PostDocument> postDocuments = new HashSet<>();
+    private List<PostDocument> postDocuments = new ArrayList<>();
 
     public void setUser(User user) {
         this.user = user;

--- a/src/main/java/com/fithub/fithubbackend/domain/board/post/domain/Post.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/post/domain/Post.java
@@ -37,18 +37,22 @@ public class Post extends BaseTimeEntity {
     private Set<Comment> comments = new HashSet<>();
 
     @BatchSize(size = 100)
+    @OrderBy("id asc")
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     private Set<Bookmark> bookmarks = new HashSet<>();
 
     @BatchSize(size = 100)
+    @OrderBy("id asc")
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     private Set<Likes> likes = new HashSet<>();
 
     @BatchSize(size = 100)
+    @OrderBy("id asc")
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     private Set<PostHashtag> postHashtags = new HashSet<>();
 
     @BatchSize(size = 100)
+    @OrderBy("id asc")
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     private Set<PostDocument> postDocuments = new HashSet<>();
 

--- a/src/main/java/com/fithub/fithubbackend/domain/board/repository/BookmarkRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/repository/BookmarkRepository.java
@@ -4,6 +4,8 @@ import com.fithub.fithubbackend.domain.board.post.domain.Bookmark;
 import com.fithub.fithubbackend.domain.board.post.domain.Post;
 import com.fithub.fithubbackend.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.*;
 
@@ -15,5 +17,11 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     void deleteByUserAndPost(User user, Post post);
 
     List<Bookmark> findByUserOrderByCreatedDateDesc(User user);
+
+    @Query(value = "SELECT EXISTS (" +
+            "SELECT *" +
+            "FROM bookmark b " +
+            "WHERE b.post_id = :postId AND b.user_id = :userId );", nativeQuery = true)
+    Integer existsByUserIdAndPostId(@Param("userId") long userId, @Param("postId") long postId);
 
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/repository/BookmarkRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/repository/BookmarkRepository.java
@@ -18,10 +18,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     List<Bookmark> findByUserOrderByCreatedDateDesc(User user);
 
-    @Query(value = "SELECT EXISTS (" +
-            "SELECT *" +
-            "FROM bookmark b " +
-            "WHERE b.post_id = :postId AND b.user_id = :userId );", nativeQuery = true)
-    Integer existsByUserIdAndPostId(@Param("userId") long userId, @Param("postId") long postId);
+    boolean existsByUserAndPostId(User user, Long postId);
 
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/repository/LikesRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/repository/LikesRepository.java
@@ -4,6 +4,8 @@ import com.fithub.fithubbackend.domain.board.post.domain.Likes;
 import com.fithub.fithubbackend.domain.board.post.domain.Post;
 import com.fithub.fithubbackend.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.*;
 
@@ -16,4 +18,10 @@ public interface LikesRepository extends JpaRepository<Likes, Long> {
     List<Likes> findByUserOrderByCreatedDateDesc(User user);
 
     List<Likes> findByPostOrderByCreatedDateAsc(Post post);
+
+    @Query(value = "SELECT EXISTS (" +
+            "SELECT *" +
+            "FROM likes l " +
+            "WHERE l.post_id = :postId AND l.user_id = :userId );", nativeQuery = true)
+    Integer existsByUserIdAndPostId(@Param("userId") long userId, @Param("postId") long postId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/repository/LikesRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/repository/LikesRepository.java
@@ -19,9 +19,5 @@ public interface LikesRepository extends JpaRepository<Likes, Long> {
 
     List<Likes> findByPostOrderByCreatedDateAsc(Post post);
 
-    @Query(value = "SELECT EXISTS (" +
-            "SELECT *" +
-            "FROM likes l " +
-            "WHERE l.post_id = :postId AND l.user_id = :userId );", nativeQuery = true)
-    Integer existsByUserIdAndPostId(@Param("userId") long userId, @Param("postId") long postId);
+    boolean existsByUserAndPostId(User user, Long postId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/repository/PostRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/repository/PostRepository.java
@@ -9,10 +9,12 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-
-    @EntityGraph(attributePaths = {"user", "user.profileImg", "likes", "postHashtags", "postDocuments", "postHashtags.hashtag", "comments"})
     @Query(value = "SELECT post " +
             "FROM Post post " +
+            "JOIN FETCH post.user user " +
+            "JOIN FETCH user.profileImg profileImg " +
+            "JOIN FETCH post.postDocuments postDocuments " +
             "WHERE post.id = :postId")
-    Post findPostWithHashtags(@Param("postId") long postId);
+    Post findByPostIdWithFetchJoin(@Param("postId") long postId);
+
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/repository/PostRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/repository/PostRepository.java
@@ -1,18 +1,24 @@
 package com.fithub.fithubbackend.domain.board.repository;
 
 import com.fithub.fithubbackend.domain.board.post.domain.Post;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    @EntityGraph(attributePaths = {"user", "user.profileImg", "likes", "postHashtags", "postDocuments", "postHashtags.hashtag", "comments"})
+//    @EntityGraph(attributePaths = {"user", "user.profileImg", "likes", "postHashtags", "postDocuments", "postHashtags.hashtag", "comments"})
+//    @Query(value = "SELECT post " +
+//            "FROM Post post " +
+//            "WHERE post.id = :postId")
+//    Post findPostWithHashtags(@Param("postId") long postId);
+
     @Query(value = "SELECT post " +
             "FROM Post post " +
+            "JOIN FETCH post.user user " +
+            "JOIN FETCH user.profileImg document " +
+            "JOIN FETCH post.postHashtags postHashtag " +
+            "JOIN FETCH postHashtag.hashtag hashtag " +
             "WHERE post.id = :postId")
-    Post findPostWithHashtags(@Param("postId") long postId);
+    Post findByPostIdWithFetchJoin(@Param("postId") long postId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/repository/PostRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/repository/PostRepository.java
@@ -1,24 +1,18 @@
 package com.fithub.fithubbackend.domain.board.repository;
 
 import com.fithub.fithubbackend.domain.board.post.domain.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-//    @EntityGraph(attributePaths = {"user", "user.profileImg", "likes", "postHashtags", "postDocuments", "postHashtags.hashtag", "comments"})
-//    @Query(value = "SELECT post " +
-//            "FROM Post post " +
-//            "WHERE post.id = :postId")
-//    Post findPostWithHashtags(@Param("postId") long postId);
-
+    @EntityGraph(attributePaths = {"user", "user.profileImg", "likes", "postHashtags", "postDocuments", "postHashtags.hashtag", "comments"})
     @Query(value = "SELECT post " +
             "FROM Post post " +
-            "JOIN FETCH post.user user " +
-            "JOIN FETCH user.profileImg document " +
-            "JOIN FETCH post.postHashtags postHashtag " +
-            "JOIN FETCH postHashtag.hashtag hashtag " +
             "WHERE post.id = :postId")
-    Post findByPostIdWithFetchJoin(@Param("postId") long postId);
+    Post findPostWithHashtags(@Param("postId") long postId);
 }

--- a/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
@@ -37,7 +37,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     };
 
     private static final String[] SHOULD_NOT_FILTER_GET_URI_LIST = new String[] {
-            "/users/training", "/users/training/all", "/auth/oauth/login", "/posts/**"
+            "/users/training", "/users/training/all", "/auth/oauth/login", "/posts/public/**"
     };
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig {
     };
 
     private static final String[] PERMIT_ALL_GET_PATTERNS = new String[] {
-        "/users/training/all", "/users/training", "/posts/**"
+        "/users/training/all", "/users/training", "/posts/public/**"
     };
 
     @Bean


### PR DESCRIPTION
## PR 유형
- 기능 추가, 수정

## 반영 브랜치
- feature/auth -> main

## 변경사항
- 로그인한 사용자의 **게시글 좋아요, 북마크 여부** 확인 기능 추가
- 게시글 조회 api 수정
   - **게시글 전체 조회 api** 
       - GET /posts -> /posts/public 
   - **게시글 세부 조회 api** 
       - GET /posts/{postId} -> /posts/public/{postId}
- 게시글 좋아요한 사용자 정보 최대 4개까지 가져오도록 수정
   - 좋아요한 사용자 리스트에 로그인한 사용자가 포함될 수 있어 **3개에서 4개로 수정**

## 테스트 결과

**1. 로그인한 사용자의 게시글 좋아요, 북마크 여부 확인** 


1-1. 게시글 전체 조회

> GET /posts/like-and-bookmark-status

![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/bbf2f435-1eb8-45e8-8598-1802b7988df7)

1-2. 게시글 세부 조회

> GET /posts/{postId}/like-and-bookmark-status

![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/345f93ea-e9b7-4176-8e36-b0d0a8b444e7)


