### PR TITLE
update: user와 document 연관 관계 수정 (1:1에서 N:1)

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/user/domain/User.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/domain/User.java
@@ -63,7 +63,7 @@ public class User extends BaseTimeEntity implements UserDetails {
 
     private String bio;
 
-    @ManyToOne(cascade = CascadeType.PERSIST, optional = false)
+    @ManyToOne(cascade = CascadeType.PERSIST, optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "document_id")
     private Document profileImg;
 

--- a/src/main/java/com/fithub/fithubbackend/domain/user/domain/User.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/domain/User.java
@@ -63,7 +63,7 @@ public class User extends BaseTimeEntity implements UserDetails {
 
     private String bio;
 
-    @OneToOne(cascade = CascadeType.PERSIST)
+    @ManyToOne(cascade = CascadeType.PERSIST, optional = false)
     @JoinColumn(name = "document_id")
     private Document profileImg;
 


### PR DESCRIPTION
## PR 유형
- 수정

## 반영 브랜치
- main -> main

## 변경 사항
- user와 document 연관 관계 수정
- 회원 가입 시 프로필 이미지 업로드하지 않는 경우, DB에 저장된 디폴트 이미지로 등록 (Document 테이블의 Id가 1인 인스턴스)

## 테스트 결과
![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/488b79b0-c17f-4ffe-b3b9-575e8ac0ea85)
