### PR TITLE
update: 소셜 로그인 실패 리다이렉트 주소 변경

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/global/auth/OAuthFailureHandler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/OAuthFailureHandler.java
@@ -4,6 +4,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
@@ -16,11 +17,14 @@ import java.io.IOException;
 @Component
 public class OAuthFailureHandler extends SimpleUrlAuthenticationFailureHandler {
 
+    @Value("${spring.security.registration.fail.redirect}")
+    private String url;
+
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
         log.error("소셜 로그인 실패: {} , endpoint: {}", exception.getMessage(), request.getServletPath());
 
-        String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:3000/oauth/fail")
+        String targetUrl = UriComponentsBuilder.fromUriString(url)
                 .queryParam("status", HttpStatus.BAD_REQUEST)
                 .queryParam("message", exception.getMessage())
                 .build()


### PR DESCRIPTION
## pr 유형
- 수정

## 반영 브랜치
- auth -> main

## 변경 사항
- 소셜 로그인 실패 시 원래는 /oauth/fail이었는데 프론트 요청으로 /login으로 변경
- url application.yml에서 가져오도록 수정

## 추가 변경 사항
- application.yml에 security.registration.fail.redirect 부분 추가