### PR TITLE
update: 프로필 이미지 즉시 로딩(EAGER) 으로 수정

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/UserServiceImpl.java
@@ -26,11 +26,10 @@ public class UserServiceImpl implements UserService {
     private final DocumentRepository documentRepository;
     private final AwsS3Uploader awsS3Uploader;
 
-    private final RedisUtil redisUtil;
-
     @Override
     @Transactional(readOnly = true)
     public ProfileDto myProfile(User user) {
+        user = getUser(user.getEmail());
         return ProfileDto.builder()
                 .nickname(user.getNickname())
                 .email(user.getEmail())
@@ -45,6 +44,7 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional(rollbackFor = {Exception.class})
     public User updateProfile(MultipartFile profileImg, ProfileDto profileDto, User user) {
+        user = getUser(user.getEmail());
         if(profileDto != null)
             user.updateProfile(profileDto);
 
@@ -71,5 +71,9 @@ public class UserServiceImpl implements UserService {
             throw new CustomException(ErrorCode.DUPLICATE,ErrorCode.DUPLICATE.getMessage());
     }
 
+    @Transactional(readOnly = true)
+    public User getUser(String email) {
+        return userRepository.findByEmailFetch(email).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 회원"));
+    }
 
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/UserServiceImpl.java
@@ -14,8 +14,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import java.util.ArrayList;
-import java.util.List;
 
 
 @Service
@@ -29,7 +27,6 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional(readOnly = true)
     public ProfileDto myProfile(User user) {
-        user = getUser(user.getEmail());
         return ProfileDto.builder()
                 .nickname(user.getNickname())
                 .email(user.getEmail())
@@ -44,7 +41,6 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional(rollbackFor = {Exception.class})
     public User updateProfile(MultipartFile profileImg, ProfileDto profileDto, User user) {
-        user = getUser(user.getEmail());
         if(profileDto != null)
             user.updateProfile(profileDto);
 
@@ -69,11 +65,6 @@ public class UserServiceImpl implements UserService {
         if(userRepository.findByEmail(email).isPresent()
             || userRepository.findByNickname(nickname).isPresent())
             throw new CustomException(ErrorCode.DUPLICATE,ErrorCode.DUPLICATE.getMessage());
-    }
-
-    @Transactional(readOnly = true)
-    public User getUser(String email) {
-        return userRepository.findByEmailFetch(email).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 회원"));
     }
 
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/domain/User.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/domain/User.java
@@ -63,7 +63,7 @@ public class User extends BaseTimeEntity implements UserDetails {
 
     private String bio;
 
-    @ManyToOne(cascade = CascadeType.PERSIST, optional = false, fetch = FetchType.LAZY)
+    @ManyToOne(cascade = CascadeType.PERSIST, optional = false)
     @JoinColumn(name = "document_id")
     private Document profileImg;
 

--- a/src/main/java/com/fithub/fithubbackend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/repository/UserRepository.java
@@ -2,21 +2,12 @@ package com.fithub.fithubbackend.domain.user.repository;
 
 import com.fithub.fithubbackend.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByNickname(String nickname);
     Optional<User> findByEmail(String email);
-    @Query(value = "select u " +
-            "from User u " +
-            "join fetch u.profileImg profileImg " +
-            "where u.email = :email "
-    )
-    Optional<User> findByEmailFetch(@Param("email") String email);
-
     Optional<User> findByEmailAndProvider(String email, String provider);
     Optional<User> findByProviderId(String providerId);
 

--- a/src/main/java/com/fithub/fithubbackend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/repository/UserRepository.java
@@ -2,12 +2,20 @@ package com.fithub.fithubbackend.domain.user.repository;
 
 import com.fithub.fithubbackend.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByNickname(String nickname);
     Optional<User> findByEmail(String email);
+    @Query(value = "select u " +
+            "from User u " +
+            "join fetch u.profileImg profileImg " +
+            "where u.email = :email "
+    )
+    Optional<User> findByEmailFetch(@Param("email") String email);
 
     Optional<User> findByEmailAndProvider(String email, String provider);
     Optional<User> findByProviderId(String providerId);


### PR DESCRIPTION
## PR 유형
- 기능 수정

## 반영 브랜치
- main -> main

## 변경 사항
- UserDetailsServiceImpl의 `loadUserByUsername()` 까지 영속 상태이지만
JwtTokenProvider의 `getAuthentication()`에서 **준영속 상태**라 user.getProfileImg()으로 document를 가져오지 못하는 오류 발생
  - 해결: 프로필 이미지 즉시 로딩(EAGER)으로 수정

## 테스트 결과

> GET /users/profile

![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/56933846-ccf7-4ed7-8983-fdf5bc43a3ed)
