### PR TITLE
update: Token Dto 에서 Refresh Token 제외, 댓글 및 좋아요 알림 TODO 추가, 일부 api HTTP 메소드 수정 / fix: 임시 비밀번호 401 에러 수정

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
@@ -72,7 +72,7 @@ public class PostController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "게시글 전체 조회", responses = {
+    @Operation(summary = "게시글 전체 조회, page 사용 (size = 9, sort = \"id\", desc 적용). 페이지 이동 시 page 값만 보내주면 됨. ex) \"page\" : 0 인 경우 1 페이지", responses = {
             @ApiResponse(responseCode = "200", description = "게시글 전체 조회 성공"),
     })
     @GetMapping("/public")
@@ -89,12 +89,10 @@ public class PostController {
         return ResponseEntity.ok(postService.getPostDetail(postId));
     }
 
-    @Operation(summary = "게시글 전체 조회 시 좋아요, 북마크 여부 체크 (로그인한 회원 ver)", responses = {
+    @Operation(summary = "게시글 전체 조회 시 좋아요, 북마크 여부 체크 (로그인한 회원 ver), 게시글 전체 조회하여 받은 response body의 content을 Request body로 전달", responses = {
             @ApiResponse(responseCode = "200", description = "게시글 전체 조회 성공"),
-    }, parameters = {
-            @Parameter(name = "postOutlineDtos", description = "게시글 전체 조회하여 받은 response body의 content")
     })
-    @GetMapping("/like-and-bookmark-status")
+    @PostMapping("/like-and-bookmark-status")
     public ResponseEntity<List<LikesBookmarkStatusDto>> getAllPostsWithLikesAndBookmark(@RequestBody List<PostOutlineDto> postOutlineDtos,
                                                                                         @AuthUser User user) {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/CommentServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/CommentServiceImpl.java
@@ -24,6 +24,7 @@ public class CommentServiceImpl implements CommentService {
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
 
+    // TODO 댓글 작성 시, 게시글 작성자(+부모 댓글 작성자)에게 알림 전송
     @Override
     @Transactional
     public void createComment(CommentCreateDto commentCreateDto, User user) {

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/LikesServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/LikesServiceImpl.java
@@ -18,6 +18,8 @@ import java.util.Optional;
 public class LikesServiceImpl implements LikesService {
 
     private final LikesRepository likesRepository;
+
+    // TODO 게시글 좋아요 시, 게시글 작성자에게 알림 전송
     @Override
     @Transactional
     public void addLikes(User user, Post post) {

--- a/src/main/java/com/fithub/fithubbackend/domain/user/api/EmailController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/api/EmailController.java
@@ -39,7 +39,7 @@ public class EmailController {
             @ApiResponse(responseCode = "404", description = "가입되지 않는 이메일", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
             @ApiResponse(responseCode = "409", description = "소셜 로그인으로 가입된 이메일", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
     })
-    @PostMapping("/send/temporary-password")
+    @PatchMapping("/send/temporary-password")
     public ResponseEntity<Void> sendEmailWithTemporaryPassword(@RequestBody EmailDto emailDto) throws MessagingException {
         emailService.sendEmailWithTemporaryPassword(emailDto);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/EmailServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/EmailServiceImpl.java
@@ -77,7 +77,7 @@ public class EmailServiceImpl implements EmailService {
     @Transactional
     public void sendEmailWithTemporaryPassword(EmailDto emailDto) throws MessagingException {
         User user = userRepository.findByEmail(emailDto.getTo()).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 회원"));
-        if (! user.getProvider().isEmpty() && user.getProvider() != null )
+        if (user.getProvider() != null && ! user.getProvider().isEmpty())
             throw new CustomException(ErrorCode.DUPLICATE, user.getProvider() + "로 가입된 이메일");
 
         boolean useLetters = true;

--- a/src/main/java/com/fithub/fithubbackend/global/auth/TokenInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/TokenInfoDto.java
@@ -1,5 +1,6 @@
 package com.fithub.fithubbackend.global.auth;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +12,9 @@ public class TokenInfoDto {
 
     private String grantType;
     private String accessToken;
+    @JsonIgnore
     private String refreshToken;
+    @JsonIgnore
     private Long refreshTokenExpirationTime;
 
     @Builder


### PR DESCRIPTION
## PR 유형
- 기능 수정, 버그 수정

## 반영 브랜치
- main -> main

## 변경 사항
- 로그인 성공 시, Refresh Token 정보 제외한 Token Dto 전달
- 댓글 및 좋아요 알림 TODO 추가
- 임시 비밀번호 발급 HTTP 메소드 수정 (POST -> PATCH)
- 임시 비밀번호 발급 401 에러 수정
   - 사용자의 provider가 null인 상태에서 isEmpty() 사용하면 NullPointerException 발생하므로 순서 변경
- 전체 게시글의 좋아요, 북마크 여부 체크 HTTP 메소드 수정 (GET -> POST)

## 테스트 결과

1. 로그인 

> POST /auth/sign-in

![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/c0f11134-55ea-42bc-a594-84ff619dd1d1)
