### PR TITLE
update/training: 트레이너가 예약 노쇼 처리 시 리뷰 존재하면 비공개 처리, 트레이닝 조회, 회원 예약 조회 수정

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/UserTrainingLikesController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/UserTrainingLikesController.java
@@ -44,7 +44,8 @@ public class UserTrainingLikesController {
     }, responses = {
             @ApiResponse(responseCode = "400", description = "트레이너는 자신의 트레이닝 찜 불가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
             @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
-            @ApiResponse(responseCode = "404", description = "해당 트레이닝이 존재하지 않음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
+            @ApiResponse(responseCode = "404", description = "해당 트레이닝이 존재하지 않음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "409", description = "마감된 트레이닝은 찜 불가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
     })
     @PostMapping
     public ResponseEntity<String> likes(@RequestParam Long trainingId, @AuthUser User user) {

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/UserTrainingReservationController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/UserTrainingReservationController.java
@@ -1,6 +1,7 @@
 package com.fithub.fithubbackend.domain.Training.api;
 
 import com.fithub.fithubbackend.domain.Training.application.UserTrainingReservationService;
+import com.fithub.fithubbackend.domain.Training.dto.reservation.UsersReserveCancelInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.UsersReserveInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.review.TrainingReviewReqDto;
 import com.fithub.fithubbackend.domain.Training.dto.review.UsersTrainingReviewDto;
@@ -32,7 +33,7 @@ import java.util.List;
 public class UserTrainingReservationController {
     private final UserTrainingReservationService userTrainingReservationService;
 
-    @Operation(summary = "회원의 트레이닝 예약 리스트", parameters = {
+    @Operation(summary = "회원의 트레이닝 예약(진행 전, 진행 중, 완료) 리스트", parameters = {
             @Parameter(name = "pageable", description = "조회할 목록의 page, size, sort(기본은 id desc(생성 순), 예약된 트레이닝 날짜 순은 reserveDateTime으로 주면 됨)")
     }, responses = {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
@@ -43,6 +44,19 @@ public class UserTrainingReservationController {
                                                                                      @PageableDefault(sort="id", direction = Sort.Direction.DESC) Pageable pageable) {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         return ResponseEntity.ok(userTrainingReservationService.getTrainingReservationList(user, pageable));
+    }
+
+    @Operation(summary = "회원의 트레이닝 예약 취소/환불, 노쇼 리스트", parameters = {
+            @Parameter(name = "pageable", description = "조회할 목록의 page, size, sort(기본은 id desc(생성 순), 예약된 트레이닝 날짜 순은 reserveDateTime으로 주면 됨)")
+    }, responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
+    })
+    @GetMapping("/all/cancel")
+    public ResponseEntity<Page<UsersReserveCancelInfoDto>> getTrainingReservationCancelList(@AuthUser User user,
+                                                                                            @PageableDefault(sort="id", direction = Sort.Direction.DESC) Pageable pageable) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        return ResponseEntity.ok(userTrainingReservationService.getTrainingReservationCancelAndNoShowList(user, pageable));
     }
 
     @Operation(summary = "회원이 남긴 트레이닝 예약 리뷰 전부 조회", description = "예약했던 모든 트레이닝 후기 조회",

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
@@ -133,14 +133,12 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
         permissionValidate(training.getTrainer(), email);
 
         if (reserveInfoRepository.existsByTrainingIdAndStatusNotIn(id,
-                new ReserveStatus[]{ReserveStatus.CANCEL, ReserveStatus.NOSHOW, ReserveStatus.COMPLETE})) {
+                List.of(ReserveStatus.CANCEL, ReserveStatus.NOSHOW, ReserveStatus.COMPLETE))) {
             throw new CustomException(ErrorCode.BAD_REQUEST, "해당 트레이닝에 완료 또는 취소되지 않은 예약이 존재해 삭제 작업이 불가능합니다.");
         }
 
         List<TrainingLikes> trainingLikesList = trainingLikesRepository.findByTrainingId(id);
-        for (TrainingLikes trainingLikes : trainingLikesList) {
-            trainingLikesRepository.delete(trainingLikes);
-        }
+        trainingLikesRepository.deleteAll(trainingLikesList);
 
         training.updateDeleted(true);
     }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
@@ -7,6 +7,7 @@ import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
 import com.fithub.fithubbackend.domain.Training.repository.ReserveInfoRepository;
 import com.fithub.fithubbackend.domain.Training.repository.TrainingLikesRepository;
 import com.fithub.fithubbackend.domain.Training.repository.TrainingRepository;
+import com.fithub.fithubbackend.domain.Training.repository.TrainingReviewRepository;
 import com.fithub.fithubbackend.domain.trainer.domain.Trainer;
 import com.fithub.fithubbackend.domain.trainer.repository.TrainerRepository;
 import com.fithub.fithubbackend.domain.user.domain.User;
@@ -29,6 +30,7 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -39,6 +41,7 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
     private final TrainingLikesRepository trainingLikesRepository;
 
     private final ReserveInfoRepository reserveInfoRepository;
+    private final TrainingReviewRepository trainingReviewRepository;
 
     private final AwsS3Uploader awsS3Uploader;
 
@@ -173,7 +176,7 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
 
     @Override
     @Transactional
-    // TODO: 노쇼 처리 시 예약 회원에게 알림
+    // TODO: 노쇼 처리 시, 리뷰 비공개 처리 시 예약 회원에게 알림
     public void updateReservationStatusNoShow(String email, Long reservationId) {
         ReserveInfo reserveInfo = reserveInfoRepository.findById(reservationId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "해당 예약은 존재하지 않습니다."));
 
@@ -181,6 +184,9 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
         permissionValidate(reserveInfo.getTrainer(), email);
 
         reserveInfo.updateStatus(ReserveStatus.NOSHOW);
+
+        Optional<TrainingReview> optionalTrainingReview = trainingReviewRepository.findByReserveInfoId(reserveInfo.getId());
+        optionalTrainingReview.ifPresent(TrainingReview::lock);
     }
 
     private void isReserveInfoStatusComplete(ReserveInfo reserveInfo) {

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingServiceImpl.java
@@ -27,7 +27,7 @@ public class TrainingServiceImpl implements TrainingService {
     @Override
     @Transactional(readOnly = true)
     public Page<TrainingOutlineDto> searchAll(Pageable pageable) {
-        Page<Training> trainingPage = trainingRepository.findAllByDeletedFalse(pageable);
+        Page<Training> trainingPage = trainingRepository.findAllByDeletedFalseAndClosedFalse(pageable);
         return trainingPage.map(TrainingOutlineDto::toDto);
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingServiceImpl.java
@@ -2,9 +2,14 @@ package com.fithub.fithubbackend.domain.Training.application;
 
 import com.fithub.fithubbackend.domain.Training.domain.Training;
 import com.fithub.fithubbackend.domain.Training.domain.TrainingReview;
-import com.fithub.fithubbackend.domain.Training.dto.*;
+import com.fithub.fithubbackend.domain.Training.dto.TrainingDocumentDto;
+import com.fithub.fithubbackend.domain.Training.dto.TrainingInfoDto;
+import com.fithub.fithubbackend.domain.Training.dto.TrainingOutlineDto;
+import com.fithub.fithubbackend.domain.Training.dto.TrainingSearchConditionDto;
 import com.fithub.fithubbackend.domain.Training.dto.review.TrainingReviewDto;
-import com.fithub.fithubbackend.domain.Training.repository.*;
+import com.fithub.fithubbackend.domain.Training.repository.CustomTrainingRepository;
+import com.fithub.fithubbackend.domain.Training.repository.TrainingRepository;
+import com.fithub.fithubbackend.domain.Training.repository.TrainingReviewRepository;
 import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingReservationService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingReservationService.java
@@ -1,5 +1,6 @@
 package com.fithub.fithubbackend.domain.Training.application;
 
+import com.fithub.fithubbackend.domain.Training.dto.reservation.UsersReserveCancelInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.UsersReserveInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.review.TrainingReviewReqDto;
 import com.fithub.fithubbackend.domain.Training.dto.review.UsersTrainingReviewDto;
@@ -10,11 +11,8 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface UserTrainingReservationService {
-
-
-
-
     Page<UsersReserveInfoDto> getTrainingReservationList(User user, Pageable pageable);
+    Page<UsersReserveCancelInfoDto> getTrainingReservationCancelAndNoShowList(User user, Pageable pageable);
 
     List<UsersTrainingReviewDto> getAllReviews(User user);
     UsersTrainingReviewDto getReviewForReservation(User user, Long reserveId);

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingReservationServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingReservationServiceImpl.java
@@ -2,8 +2,9 @@ package com.fithub.fithubbackend.domain.Training.application;
 
 import com.fithub.fithubbackend.domain.Training.domain.ReserveInfo;
 import com.fithub.fithubbackend.domain.Training.domain.TrainingReview;
-import com.fithub.fithubbackend.domain.Training.dto.review.TrainingReviewReqDto;
+import com.fithub.fithubbackend.domain.Training.dto.reservation.UsersReserveCancelInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.UsersReserveInfoDto;
+import com.fithub.fithubbackend.domain.Training.dto.review.TrainingReviewReqDto;
 import com.fithub.fithubbackend.domain.Training.dto.review.UsersTrainingReviewDto;
 import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
 import com.fithub.fithubbackend.domain.Training.repository.ReserveInfoRepository;
@@ -28,8 +29,16 @@ public class UserTrainingReservationServiceImpl implements UserTrainingReservati
 
     @Override
     public Page<UsersReserveInfoDto> getTrainingReservationList(User user, Pageable pageable) {
-        Page<ReserveInfo> page = reserveInfoRepository.findByUserId(user.getId(), pageable);
+        Page<ReserveInfo> page = reserveInfoRepository.findByUserIdAndStatusIn(user.getId(),
+                List.of(ReserveStatus.BEFORE, ReserveStatus.START, ReserveStatus.COMPLETE),pageable);
         return page.map(UsersReserveInfoDto::toDto);
+    }
+
+    @Override
+    public Page<UsersReserveCancelInfoDto> getTrainingReservationCancelAndNoShowList(User user, Pageable pageable) {
+        Page<ReserveInfo> page = reserveInfoRepository.findByUserIdAndStatusIn(user.getId(),
+                List.of(ReserveStatus.CANCEL, ReserveStatus.NOSHOW), pageable);
+        return page.map(UsersReserveCancelInfoDto::toDto);
     }
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/TrainingReview.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/TrainingReview.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fithub.fithubbackend.domain.Training.dto.review.TrainingReviewReqDto;
 import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.global.common.BaseTimeEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -36,6 +37,10 @@ public class TrainingReview extends BaseTimeEntity {
     @NotNull
     private int star;
 
+    @NotNull
+    @Schema(description = "비공개(잠금) 여부 (트레이너에 의해 / 관리자에 의해 잠금처리)")
+    private boolean locked;
+
     @Builder
     private TrainingReview(User user, ReserveInfo reserveInfo, TrainingReviewReqDto trainingReviewReqDto) {
         this.user = user;
@@ -43,10 +48,15 @@ public class TrainingReview extends BaseTimeEntity {
         this.training = reserveInfo.getTraining();
         this.content = trainingReviewReqDto.getContent();
         this.star = trainingReviewReqDto.getStar();
+        this.locked = false;
     }
 
     public void updateReview(String content, int star) {
         this.content = content;
         this.star = star;
+    }
+
+    public void lock() {
+        this.locked = true;
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/UsersReserveCancelInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/UsersReserveCancelInfoDto.java
@@ -1,0 +1,55 @@
+package com.fithub.fithubbackend.domain.Training.dto.reservation;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fithub.fithubbackend.domain.Training.domain.ReserveInfo;
+import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "회원의 트레이닝 예약 취소 정보 확인")
+public class UsersReserveCancelInfoDto {
+
+    @Schema(description = "트레이닝 예약 id")
+    private Long reservationId;
+
+    @Schema(description = "트레이닝 id")
+    private Long trainingId;
+
+    @Schema(description = "트레이닝 제목")
+    private String title;
+
+    @Schema(description = "예약한 트레이닝 날짜, 시간")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime reserveDateTime;
+
+    @Schema(description = "트레이닝 진행 상황(취소, 노쇼)")
+    private ReserveStatus status;
+
+    @Schema(description = "트레이닝 결제 금액")
+    private int price;
+
+    @Schema(description = "트레이닝 구매 번호")
+    private String merchantUid;
+
+    @Schema(description = "트레이닝을 취소한 날짜, 시간")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime cancelDateTime;
+
+    public static UsersReserveCancelInfoDto toDto(ReserveInfo reserveInfo) {
+        return UsersReserveCancelInfoDto.builder()
+                .reservationId(reserveInfo.getId())
+                .trainingId(reserveInfo.getTraining().getId())
+                .title(reserveInfo.getTraining().getTitle())
+                .reserveDateTime(reserveInfo.getReserveDateTime())
+                .status(reserveInfo.getStatus())
+                .price(reserveInfo.getPrice())
+                .merchantUid(reserveInfo.getMerchantUid())
+                .cancelDateTime(reserveInfo.getModifiedDate())
+                .build();
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/UsersReserveInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/UsersReserveInfoDto.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
-@Schema(description = "회원의 트레이닝 예약 정보 확인")
+@Schema(description = "회원의 트레이닝 예약, 진행,종료 정보 확인")
 public class UsersReserveInfoDto {
 
     @Schema(description = "트레이닝 예약 id")
@@ -23,18 +23,11 @@ public class UsersReserveInfoDto {
     @Schema(description = "트레이닝 제목")
     private String title;
 
-    @Schema(description = "트레이닝을 담당하는 트레이너 이름")
-    private String trainerName;
-
     @Schema(description = "예약한 트레이닝 날짜, 시간")
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-    private LocalDateTime trainingDateTime;
-
-    @Schema(description = "트레이닝을 예약한 날짜, 시간")
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime reserveDateTime;
 
-    @Schema(description = "트레이닝 진행 상황(진행 전, 진행중, 진행완료, 취소)")
+    @Schema(description = "트레이닝 진행 상황(진행 전, 진행중, 진행완료)")
     private ReserveStatus status;
 
     @Schema(description = "트레이닝 결제 금액")
@@ -43,18 +36,20 @@ public class UsersReserveInfoDto {
     @Schema(description = "트레이닝 구매 번호")
     private String merchantUid;
 
-    // TODO: 트레이너용 dto, 회원용 dto로 나누기 (트레이너한테는 자기 이름 필요없으니까 불필요한 trainer 조회 없이가도록)
+    @Schema(description = "트레이닝 결제(예약)한 날짜, 시간")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime paymentDateTime;
+
     public static UsersReserveInfoDto toDto(ReserveInfo reserveInfo) {
         return UsersReserveInfoDto.builder()
                 .reservationId(reserveInfo.getId())
                 .trainingId(reserveInfo.getTraining().getId())
                 .title(reserveInfo.getTraining().getTitle())
-                .trainerName(reserveInfo.getTrainer().getName())
-                .trainingDateTime(reserveInfo.getReserveDateTime())
-                .reserveDateTime(reserveInfo.getCreatedDate())
+                .reserveDateTime(reserveInfo.getReserveDateTime())
                 .status(reserveInfo.getStatus())
                 .price(reserveInfo.getPrice())
                 .merchantUid(reserveInfo.getMerchantUid())
+                .paymentDateTime(reserveInfo.getCreatedDate())
                 .build();
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
@@ -2,6 +2,7 @@ package com.fithub.fithubbackend.domain.Training.repository;
 
 import com.fithub.fithubbackend.domain.Training.domain.ReserveInfo;
 import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,8 +13,9 @@ import java.util.List;
 public interface ReserveInfoRepository extends JpaRepository<ReserveInfo, Long> {
     Page<ReserveInfo> findByTrainerId(Long trainerId, Pageable pageable);
     Page<ReserveInfo> findByUserId(Long userId, Pageable pageable);
+    Page<ReserveInfo> findByUserIdAndStatusIn(Long user_id, List<@NotNull ReserveStatus> status, Pageable pageable);
 
-    boolean existsByTrainingIdAndStatusNotIn(Long trainingId, ReserveStatus[] statuses);
+    boolean existsByTrainingIdAndStatusNotIn(Long training_id, List<@NotNull ReserveStatus> status);
 
     List<ReserveInfo> findByReserveDateTimeAndStatus(LocalDateTime now, ReserveStatus status);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingRepository.java
@@ -10,6 +10,6 @@ import java.util.List;
 
 public interface TrainingRepository extends JpaRepository<Training, Long> {
 
-    Page<Training> findAllByDeletedFalse(Pageable pageable);
+    Page<Training> findAllByDeletedFalseAndClosedFalse(Pageable pageable);
     List<Training> findByClosedFalseAndEndDateLessThanEqual(LocalDate now);
 }

--- a/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
@@ -102,7 +102,7 @@ public class SecurityConfig {
         corsConfiguration.setAllowCredentials(true);
         corsConfiguration.setAllowedHeaders(List.of("*"));
         corsConfiguration.setAllowedMethods(List.of("*"));
-        corsConfiguration.setExposedHeaders(List.of("X-AUTH-TOKEN"));
+        corsConfiguration.setExposedHeaders(List.of("Authorization"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", corsConfiguration);


### PR DESCRIPTION
## pr 유형
- 기능 추가, 수정

## 변경 사항
- 기존: 트레이니 전체 조회 시 삭제된 것만 제외했음 -> 변경: 마감된 트레이닝도 제외
- 트레이너가 예약을 노쇼 처리 했을 때 만약 그 전에 예약 회원이 리뷰를 작성했다면 비공개 처리
- 트레이닝 리뷰에 locked 추가
- 회원이 트레이닝 예약 전체 조회 시 피그마에 맞춰 진행전,진행,종료로 따로 조회 / 취소,노쇼 따로 조회로 분리
- 코드 에러 수정

## 테스트 결과
- 트레이닝 전체 조회 (closed 제외 들어감)
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/b00f7e05-5864-4c02-b920-a818ebc6ba52)

- 노쇼 처리 시 리뷰 존재하면 lock 설정
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/19f2d48d-0776-4731-b98c-b270ebd7a94d)
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/4b837d19-8164-47ca-91ab-03eeb582a7dd)
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/1046d96c-67e9-4022-8f03-d3916fd5ace8)

- 트레이닝 예약 조회 수정
진행중,진행,종료 조회
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/adf04f39-add0-4e08-94c8-830dc16ae45c)

취소,노쇼 조회
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/55cc751a-76b9-4110-8190-aca9603c8c57)
