### PR TITLE
feat: 회원이 작성한 게시글과 댓글 남긴 게시글 조회, 단일 게시글의 전체 좋아요 정보 조회 기능 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
@@ -1,11 +1,13 @@
 package com.fithub.fithubbackend.domain.board.api;
 
 import com.fithub.fithubbackend.domain.board.application.CommentService;
+import com.fithub.fithubbackend.domain.board.application.PostLikesService;
 import com.fithub.fithubbackend.domain.board.application.PostService;
 import com.fithub.fithubbackend.domain.board.dto.*;
 import com.fithub.fithubbackend.domain.board.dto.comment.CommentInfoDto;
 import com.fithub.fithubbackend.domain.board.dto.comment.ParentCommentInfoDto;
 import com.fithub.fithubbackend.domain.board.dto.likes.LikedUsersInfoDto;
+import com.fithub.fithubbackend.domain.board.dto.likes.LikesInfoDto;
 import com.fithub.fithubbackend.global.exception.ErrorResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -31,6 +33,7 @@ public class PostController {
 
     private final PostService postService;
     private final CommentService commentService;
+    private final PostLikesService postLikesService;
 
     @Operation(summary = "게시글 전체 조회, page 사용 (size = 9, sort = \"id\", desc 적용). 페이지 이동 시 page 값만 보내주면 됨. ex) \"page\" : 0 인 경우 1 페이지", responses = {
             @ApiResponse(responseCode = "200", description = "게시글 전체 조회 성공"),
@@ -51,8 +54,8 @@ public class PostController {
         return ResponseEntity.ok(postService.getPostDetail(postId));
     }
 
-    @Operation(summary = "세부 게시글 좋아요 리스트 조회", responses = {
-            @ApiResponse(responseCode = "200", description = "게시글 전체 조회 성공"),
+    @Operation(summary = "세부 게시글의 좋아요 정보 요약 조회 (개수와 최대 4개의 회원 정보)", responses = {
+            @ApiResponse(responseCode = "200", description = "세부 게시글 좋아요 정보 요약 조회 성공"),
     }, parameters = {
             @Parameter(name="postId", description = "게시글 id")
     })
@@ -61,8 +64,20 @@ public class PostController {
         return ResponseEntity.ok(postService.getLikedUsersForPostDetail(postId));
     }
 
-    @Operation(summary = "전체 게시글 좋아요 리스트 조회", responses = {
-            @ApiResponse(responseCode = "200", description = "게시글 전체 조회 성공"),
+    @Operation(summary = "세부 게시글의 전체 좋아요 조회. 페이징 사용", responses = {
+            @ApiResponse(responseCode = "200", description = "세부 게시글 좋아요 정보 조회 성공"),
+    }, parameters = {
+            @Parameter(name="postId", description = "게시글 id"),
+            @Parameter(name="pageable", description = "page (size = 20, sort = \"id\", desc 적용). 페이지 이동 시 page 값만 보내주면 됨. ex) \"page\" : 0 인 경우 1 페이지")
+    })
+    @GetMapping("/{postId}/likes/all")
+    public ResponseEntity<Page<LikesInfoDto>> getAllLikedUsersForPostDetail(@PageableDefault(size = 20, sort = "id", direction = Sort.Direction.ASC) Pageable pageable,
+                                                                            @PathVariable(value = "postId") Long postId) {
+        return ResponseEntity.ok(postLikesService.getAllLikedUsersForPostDetail(pageable, postId));
+    }
+
+    @Operation(summary = "전체 게시글의 좋아요 정보 요약 조회 (개수와 최대 4개의 회원 정보)", responses = {
+            @ApiResponse(responseCode = "200", description = "전체 게시글 좋아요 정보 요약 조회 성공"),
     }, parameters = {
             @Parameter(name="postRequestDtos", description = "전체 게시글 조회에서 받은 response body에서 postId을 추출하여 json 형식의 Request body로 전달")
     })

--- a/src/main/java/com/fithub/fithubbackend/domain/board/api/UserPostCommentController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/api/UserPostCommentController.java
@@ -64,7 +64,7 @@ public class UserPostCommentController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "회원이 작성한 댓글을 가진 게시글 조회. page 사용", responses = {
+    @Operation(summary = "회원이 댓글 남긴 게시글 조회. page 사용", responses = {
             @ApiResponse(responseCode = "200", description = "게시글 조회 성공")
     }, parameters = {
             @Parameter(name="pageable", description = "page (size = 9, sort = \"id\", desc 적용). 페이지 이동 시 page 값만 보내주면 됨. ex) \"page\" : 0 인 경우 1 페이지")

--- a/src/main/java/com/fithub/fithubbackend/domain/board/api/UserPostCommentController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/api/UserPostCommentController.java
@@ -1,6 +1,7 @@
 package com.fithub.fithubbackend.domain.board.api;
 
 import com.fithub.fithubbackend.domain.board.application.UserCommentService;
+import com.fithub.fithubbackend.domain.board.dto.PostInfoDto;
 import com.fithub.fithubbackend.domain.board.dto.comment.CommentCreateDto;
 import com.fithub.fithubbackend.domain.board.dto.comment.CommentUpdateDto;
 import com.fithub.fithubbackend.domain.user.domain.User;
@@ -9,12 +10,17 @@ import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
 import com.fithub.fithubbackend.global.exception.ErrorResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -56,5 +62,17 @@ public class UserPostCommentController {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         userCommentService.deleteComment(commentId, user);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "회원이 작성한 댓글을 가진 게시글 조회. page 사용", responses = {
+            @ApiResponse(responseCode = "200", description = "게시글 조회 성공")
+    }, parameters = {
+            @Parameter(name="pageable", description = "page (size = 9, sort = \"id\", desc 적용). 페이지 이동 시 page 값만 보내주면 됨. ex) \"page\" : 0 인 경우 1 페이지")
+    })
+    @GetMapping
+    public ResponseEntity<Page<PostInfoDto>> getPostsByUserAndComments(@PageableDefault(size = 9, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
+                                                            @AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        return ResponseEntity.ok(userCommentService.getPostsByUserAndComments(pageable, user));
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/api/UserPostController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/api/UserPostController.java
@@ -15,6 +15,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -70,7 +74,7 @@ public class UserPostController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "게시글 전체 조회 시 좋아요, 북마크 여부 체크 (로그인한 회원 ver)", responses = {
+    @Operation(summary = "게시글 전체 조회 시 좋아요, 북마크 여부 체크", responses = {
             @ApiResponse(responseCode = "200", description = "게시글 전체 조회 성공"),
     }, parameters = {
             @Parameter(name="postRequestDtos", description = "전체 게시글 조회에서 받은 response body에서 postId을 추출하여 json 형식의 Request body로 전달")
@@ -82,7 +86,7 @@ public class UserPostController {
         return ResponseEntity.ok(userPostService.checkPostsLikeAndBookmarkStatus(postRequestDtos, user));
     }
 
-    @Operation(summary = "게시글 세부 조회 시 좋아요, 북마크 여부 체크 (로그인한 회원 ver)", responses = {
+    @Operation(summary = "게시글 세부 조회 시 좋아요, 북마크 여부 체크", responses = {
             @ApiResponse(responseCode = "200", description = "게시글 전체 조회 성공"),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
@@ -91,5 +95,18 @@ public class UserPostController {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         return ResponseEntity.ok(userPostService.checkPostLikeAndBookmarkStatus(user, postId));
     }
+
+    @Operation(summary = "회원이 작성한 게시글 조회. page 사용", responses = {
+            @ApiResponse(responseCode = "200", description = "게시글 조회 성공")
+    }, parameters = {
+            @Parameter(name="pageable", description = "page (size = 9, sort = \"id\", desc 적용). 페이지 이동 시 page 값만 보내주면 됨. ex) \"page\" : 0 인 경우 1 페이지")
+    })
+    @GetMapping
+    public ResponseEntity<Page<PostInfoDto>> getPostsByUser(@PageableDefault(size = 9, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
+                                                              @AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        return ResponseEntity.ok(userPostService.getPostsByUser(pageable, user));
+    }
+
 
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostLikesService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostLikesService.java
@@ -1,0 +1,10 @@
+package com.fithub.fithubbackend.domain.board.application;
+
+import com.fithub.fithubbackend.domain.board.dto.likes.LikesInfoDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PostLikesService {
+
+    Page<LikesInfoDto> getAllLikedUsersForPostDetail(Pageable pageable, Long postId);
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostLikesServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostLikesServiceImpl.java
@@ -1,0 +1,27 @@
+package com.fithub.fithubbackend.domain.board.application;
+
+import com.fithub.fithubbackend.domain.board.dto.likes.LikesInfoDto;
+import com.fithub.fithubbackend.domain.board.post.domain.Likes;
+import com.fithub.fithubbackend.domain.board.repository.LikesRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostLikesServiceImpl implements PostLikesService {
+
+    private final LikesRepository likesRepository;
+
+    @Override
+    @Transactional
+    public Page<LikesInfoDto> getAllLikedUsersForPostDetail(Pageable pageable, Long postId) {
+
+        Page<Likes> likes = likesRepository.findByPostId(pageable, postId);
+        return likes.map(LikesInfoDto::toDto);
+    }
+
+
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/UserCommentService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/UserCommentService.java
@@ -1,8 +1,11 @@
 package com.fithub.fithubbackend.domain.board.application;
 
+import com.fithub.fithubbackend.domain.board.dto.PostInfoDto;
 import com.fithub.fithubbackend.domain.board.dto.comment.CommentCreateDto;
 import com.fithub.fithubbackend.domain.board.dto.comment.CommentUpdateDto;
 import com.fithub.fithubbackend.domain.user.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface UserCommentService {
 
@@ -11,4 +14,7 @@ public interface UserCommentService {
     void updateComment(CommentUpdateDto commentUpdateDto, User user);
 
     void deleteComment(long commentId, User user);
+
+    Page<PostInfoDto> getPostsByUserAndComments(Pageable pageable, User user);
+
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/UserCommentServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/UserCommentServiceImpl.java
@@ -1,6 +1,7 @@
 package com.fithub.fithubbackend.domain.board.application;
 
 import com.fithub.fithubbackend.domain.board.comment.domain.Comment;
+import com.fithub.fithubbackend.domain.board.dto.PostInfoDto;
 import com.fithub.fithubbackend.domain.board.dto.comment.CommentCreateDto;
 import com.fithub.fithubbackend.domain.board.dto.comment.CommentUpdateDto;
 import com.fithub.fithubbackend.domain.board.post.domain.Post;
@@ -9,6 +10,8 @@ import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -68,6 +71,13 @@ public class UserCommentServiceImpl implements UserCommentService {
         else {
             throw new CustomException(ErrorCode.NOT_FOUND, "해당 회원은 댓글 작성자가 아님");
         }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<PostInfoDto> getPostsByUserAndComments(Pageable pageable, User user) {
+        Page<Post> posts = commentRepository.findPostsByUserAndComments(pageable, user);
+        return posts.map(PostInfoDto::toDto);
     }
 
     @Transactional

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/UserPostService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/UserPostService.java
@@ -3,6 +3,8 @@ package com.fithub.fithubbackend.domain.board.application;
 import com.fithub.fithubbackend.domain.board.dto.*;
 import com.fithub.fithubbackend.domain.board.post.domain.Post;
 import com.fithub.fithubbackend.domain.user.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -18,4 +20,6 @@ public interface UserPostService {
     List<LikesBookmarkStatusDto> checkPostsLikeAndBookmarkStatus(List<PostRequestDto> postRequestDtos, User user);
 
     Post getPost(Long postId);
+
+    Page<PostInfoDto> getPostsByUser(Pageable pageable, User user);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/UserPostServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/UserPostServiceImpl.java
@@ -8,6 +8,8 @@ import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
 import com.fithub.fithubbackend.global.util.FileUtils;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -119,6 +121,13 @@ public class UserPostServiceImpl implements UserPostService {
     @Transactional
     public Post getPost(Long postId) {
         return postRepository.findById(postId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 게시글"));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<PostInfoDto> getPostsByUser(Pageable pageable, User user) {
+        Page<Post> posts = postRepository.findByUser(pageable, user);
+        return posts.map(PostInfoDto::toDto);
     }
 
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/repository/CommentRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/repository/CommentRepository.java
@@ -2,6 +2,7 @@ package com.fithub.fithubbackend.domain.board.repository;
 
 import com.fithub.fithubbackend.domain.board.comment.domain.Comment;
 import com.fithub.fithubbackend.domain.board.post.domain.Post;
+import com.fithub.fithubbackend.domain.user.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -19,4 +20,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     Page<Comment> findByPostIdAndParentIsNull(Pageable pageable, long postId);
 
     List<Comment> findByParent(Comment comment);
+
+    @Query(value = "SELECT distinct c.post " +
+            "FROM Comment c " +
+            "WHERE c.user = :user ")
+    Page<Post> findPostsByUserAndComments(Pageable pageable, @Param("user") User user);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/repository/LikesRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/repository/LikesRepository.java
@@ -3,9 +3,9 @@ package com.fithub.fithubbackend.domain.board.repository;
 import com.fithub.fithubbackend.domain.board.post.domain.Likes;
 import com.fithub.fithubbackend.domain.board.post.domain.Post;
 import com.fithub.fithubbackend.domain.user.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.*;
 
@@ -20,4 +20,6 @@ public interface LikesRepository extends JpaRepository<Likes, Long> {
     List<Likes> findByPostOrderByCreatedDateAsc(Post post);
 
     boolean existsByUserAndPostId(User user, Long postId);
+
+    Page<Likes> findByPostId(Pageable pageable, Long postId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/repository/PostRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/repository/PostRepository.java
@@ -1,9 +1,9 @@
 package com.fithub.fithubbackend.domain.board.repository;
 
 import com.fithub.fithubbackend.domain.board.post.domain.Post;
+import com.fithub.fithubbackend.domain.user.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,4 +17,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             "WHERE post.id = :postId")
     Post findByPostIdWithFetchJoin(@Param("postId") long postId);
 
+    Page<Post> findByUser(Pageable pageable, User user);
 }


### PR DESCRIPTION
## PR 유형
- 기능 추가

## 반영 브랜치
- main -> main

## 변경 사항
- 회원이 작성한 게시글 조회 및 댓글 남긴 게시글 조회 기능 추가
- 단일 게시글에 대한 전체 좋아요 정보 조회 기능 추가 (페이징 사용)


## 테스트 결과

1. 회원이 작성한 게시글 조회 (page 사용)

> GET /users/posts

![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/0e534708-1cd6-4d50-aa0d-48ce5d7e297d)

2. 회원이 댓글 남긴 게시글 조회 (page 사용)

> GET /users/posts/comments

![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/09869f36-0409-4e2a-abba-d38400c37c58)

3. 단일 게시글에 대한 전체 좋아요 정보 조회 (page 사용)

> GET /posts/{postId}/likes/all

![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/20466480-154e-4fde-b98b-ee89093374c1)



