### PR TITLE
Update: 결제 관련 전부 수정, 리팩토링 / refactor: 스케줄러 리팩토링/ feat: 트레이너의 트레이닝 목록 조회, 예약 리스트 조회

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,5 @@ out/
 
 ### VS Code ###
 .vscode/
-
-/src/main/resources/application.yml
 /src/main/generated/
+/src/test/

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/PaymentController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/PaymentController.java
@@ -3,7 +3,6 @@ package com.fithub.fithubbackend.domain.Training.api;
 import com.fithub.fithubbackend.domain.Training.application.PaymentService;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.CancelReqDto;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.PaymentReqDto;
-import com.fithub.fithubbackend.domain.Training.dto.reservation.PaymentResDto;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.ReserveReqDto;
 import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.global.domain.AuthUser;
@@ -19,7 +18,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
 
@@ -50,20 +52,21 @@ public class PaymentController {
     })
     @PostMapping("/validation")
     //TODO: 예약 완료 후 찜에 있는 트레이닝이면 삭제할거냐고 물어보거나 바로 삭제?
-    public ResponseEntity<PaymentResDto> validate(@RequestBody @Valid PaymentReqDto dto) throws IamportResponseException, IOException {
+    public ResponseEntity<Long> validate(@RequestBody @Valid PaymentReqDto dto) throws IamportResponseException, IOException {
         return ResponseEntity.ok(paymentService.validate(dto));
     }
 
     @Operation(summary = "결제,예약 취소(환불)", responses = {
             @ApiResponse(responseCode = "200", description = "취소 성공"),
             @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "403", description = "예약한 회원이 아니어서 취소 권한 없음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 예약 내역", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
             @ApiResponse(responseCode = "409", description = "진행 전 예약이 아니거나 이미 취소된 예약이므로 취소 불가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
     })
     @PostMapping("/cancel")
     public ResponseEntity<String> cancelPayment(@RequestBody @Valid CancelReqDto dto, @AuthUser User user) throws IamportResponseException, IOException {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
-        paymentService.cancelPayment(dto, user.getEmail());
+        paymentService.cancelPayment(user.getId(), dto);
         return ResponseEntity.ok().body("완료");
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/PaymentController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/PaymentController.java
@@ -36,7 +36,7 @@ public class PaymentController {
     @Operation(summary = "결제 전 예약 시간이 예약 가능한지 확인, 저장 api", responses = {
             @ApiResponse(responseCode = "200", description = "예약하려던 시간이 예약 가능해서 예약 정보가 저장됨, 임시로 저장된 예약 정보 id 반환"),
             @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
-            @ApiResponse(responseCode = "400", description = "결제한 트레이닝의 시간대가 예약 불가능해짐", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "DATE_OR_TIME_ERROR: 결제한 트레이닝의 시간대가 예약 불가능해짐, BAD_REQUEST: 마감한 트레이닝은 예약 불가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
             @ApiResponse(responseCode = "404", description = "예약할 트레이닝이 존재하지 않는 트레이닝", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
     })
     @PostMapping("/order")

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainerTrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainerTrainingController.java
@@ -5,6 +5,7 @@ import com.fithub.fithubbackend.domain.Training.dto.TrainersTrainingOutlineDto;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.TrainersReserveInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.TrainingContentUpdateDto;
 import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.TrainingCreateDto;
+import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
 import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.global.domain.AuthUser;
 import com.fithub.fithubbackend.global.exception.CustomException;
@@ -124,17 +125,36 @@ public class TrainerTrainingController {
     }
 
     @Operation(summary = "트레이너의 예약 리스트 조회", parameters = {
+            @Parameter(name = "status", description = "예약 상태, 진행전,중을 불러올 때는 없어야 됨", example = "COMPLETE, CANCEL, NOSHOW"),
             @Parameter(name = "pageable", description = "조회할 목록의 page, size, sort(기본은 id (생성 순), 예약된 트레이닝 날짜 순은 reserveDateTime으로 주면 됨)")
     }, responses = {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
-            @ApiResponse(responseCode = "404", description = "해당 회원은 트레이너가 아님", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "403", description = "해당 회원은 트레이너가 아님", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
-    @GetMapping("/reservations")
+    @GetMapping("/reservations/all")
     public ResponseEntity<Page<TrainersReserveInfoDto>> getReservationList(@AuthUser User user,
+                                                                           @RequestParam(required = false) ReserveStatus status,
                                                                            @PageableDefault(sort="id", direction = Sort.Direction.DESC) Pageable pageable) {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
-        return ResponseEntity.ok(trainerTrainingService.getReservationList(user, pageable));
+        return ResponseEntity.ok(trainerTrainingService.getReservationList(user.getId(), status, pageable));
+    }
+
+    @Operation(summary = "트레이너의 트레이닝 하나에 대한 예약 리스트 조회", parameters = {
+            @Parameter(name = "status", description = "예약 상태, 진행전,중을 불러올 때는 없어야 됨", example = "COMPLETE, CANCEL, NOSHOW"),
+            @Parameter(name = "pageable", description = "조회할 목록의 page, size, sort(기본은 id (생성 순), 예약된 트레이닝 날짜 순은 reserveDateTime으로 주면 됨)")
+    }, responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "403", description = "해당 회원은 트레이너가 아님", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+    })
+    @GetMapping("/reservations")
+    public ResponseEntity<Page<TrainersReserveInfoDto>> getReservationListForTrainingId(@AuthUser User user,
+                                                                           @RequestParam Long trainingId,
+                                                                           @RequestParam(required = false) ReserveStatus status,
+                                                                           @PageableDefault(sort="id", direction = Sort.Direction.DESC) Pageable pageable) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        return ResponseEntity.ok(trainerTrainingService.getReservationListForTrainingId(user.getId(), trainingId, status, pageable));
     }
 
     @Operation(summary = "트레이너의 예약 노쇼 처리", parameters = {

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainerTrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainerTrainingController.java
@@ -1,6 +1,7 @@
 package com.fithub.fithubbackend.domain.Training.api;
 
 import com.fithub.fithubbackend.domain.Training.application.TrainerTrainingService;
+import com.fithub.fithubbackend.domain.Training.dto.TrainersTrainingOutlineDto;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.TrainersReserveInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.TrainingContentUpdateDto;
 import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.TrainingCreateDto;
@@ -33,9 +34,27 @@ public class TrainerTrainingController {
 
     private final TrainerTrainingService trainerTrainingService;
 
+    @Operation(summary = "트레이너의 트레이닝 목록 (page)", parameters = {
+            @Parameter(name = "closed", description = "마감된 트레이닝 목록 조회 원하면 true로 주기"),
+            @Parameter(name = "pageable", description = "기본 정렬은 id desc, size = 9 / 정렬 값 변경은 응답 dto 값 중 하나로 가능")
+    }, responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "403", description = "해당 회원은 트레이너가 아님", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+    })
+    @GetMapping
+    public ResponseEntity<Page<TrainersTrainingOutlineDto>> getTrainersTrainingList(@AuthUser User user,
+                                                                                    @RequestParam(required = false) boolean closed,
+                                                                                    @PageableDefault(sort="id", size = 9, direction = Sort.Direction.DESC) Pageable pageable) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        return ResponseEntity.ok(trainerTrainingService.getTrainersTrainingList(user.getId(), closed, pageable));
+    }
+
+
     @Operation(summary = "트레이닝 생성, swagger에서 테스트 불가능, 이미지는 모두 images로 주면 됨", responses = {
             @ApiResponse(responseCode = "200", description = "생성됨"),
             @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "403", description = "해당 회원은 트레이너가 아님", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
             @ApiResponse(responseCode = "409", description = "예약 가능 날짜에 현재보다 이전 날짜가 들어있음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/UserTrainingLikesController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/UserTrainingLikesController.java
@@ -45,7 +45,7 @@ public class UserTrainingLikesController {
             @ApiResponse(responseCode = "400", description = "트레이너는 자신의 트레이닝 찜 불가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
             @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
             @ApiResponse(responseCode = "404", description = "해당 트레이닝이 존재하지 않음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
-            @ApiResponse(responseCode = "409", description = "마감된 트레이닝은 찜 불가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
+            @ApiResponse(responseCode = "409", description = "UNCORRECTABLE_DATA: 마감된 트레이닝은 찜 불가능 / DUPLICATE: 이미 찜 설정되어있음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
     })
     @PostMapping
     public ResponseEntity<String> likes(@RequestParam Long trainingId, @AuthUser User user) {
@@ -57,9 +57,8 @@ public class UserTrainingLikesController {
     @Operation(summary = "트레이닝 찜 취소", parameters = {
             @Parameter(name = "trainingId", description = "조회할 트레이닝의 primary key(id)")
     }, responses = {
-            @ApiResponse(responseCode = "404", description = "해당 트레이닝이 존재하지 않음"),
             @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
-            @ApiResponse(responseCode = "409", description = "해당 트레이닝을 찜하지 않아 찜 취소 불가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 트레이닝 / 찜 하지 않아서 취소 불가능"),
     })
     @DeleteMapping
     public ResponseEntity<String> cancelTrainingLikes(@RequestParam Long trainingId, @AuthUser User user) {

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/PaymentService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/PaymentService.java
@@ -2,7 +2,6 @@ package com.fithub.fithubbackend.domain.Training.application;
 
 import com.fithub.fithubbackend.domain.Training.dto.reservation.CancelReqDto;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.PaymentReqDto;
-import com.fithub.fithubbackend.domain.Training.dto.reservation.PaymentResDto;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.ReserveReqDto;
 import com.fithub.fithubbackend.domain.user.domain.User;
 import com.siot.IamportRestClient.exception.IamportResponseException;
@@ -12,7 +11,7 @@ import java.io.IOException;
 public interface PaymentService {
     Long saveOrder(ReserveReqDto dto, User user);
 
-    PaymentResDto validate(PaymentReqDto dto) throws IamportResponseException, IOException;
+    Long validate(PaymentReqDto dto) throws IamportResponseException, IOException;
 
-    void cancelPayment(CancelReqDto dto, String email) throws IamportResponseException, IOException;
+    void cancelPayment(Long userId, CancelReqDto dto) throws IamportResponseException, IOException;
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/PaymentServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/PaymentServiceImpl.java
@@ -57,6 +57,10 @@ public class PaymentServiceImpl implements PaymentService {
     public Long saveOrder(ReserveReqDto dto, User user) {
         Training training = trainingRepository.findById(dto.getTrainingId()).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 트레이닝입니다."));
 
+        if (training.isClosed()) {
+            throw new CustomException(ErrorCode.BAD_REQUEST, "마감된 트레이닝은 예약할 수 없습니다.");
+        }
+
         AvailableDate availableDate = availableDateRepository.findById(dto.getReservationDateId()).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "해당 예약 날짜는 존재하지 않습니다."));
         if (!availableDate.isEnabled()) {
             throw new CustomException(ErrorCode.DATE_OR_TIME_ERROR, "해당 날짜에 예약 가능한 시간대가 없습니다.");

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/PaymentServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/PaymentServiceImpl.java
@@ -1,12 +1,15 @@
 package com.fithub.fithubbackend.domain.Training.application;
 
+import com.fithub.fithubbackend.domain.Training.domain.AvailableDate;
+import com.fithub.fithubbackend.domain.Training.domain.AvailableTime;
 import com.fithub.fithubbackend.domain.Training.domain.ReserveInfo;
 import com.fithub.fithubbackend.domain.Training.domain.Training;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.CancelReqDto;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.PaymentReqDto;
-import com.fithub.fithubbackend.domain.Training.dto.reservation.PaymentResDto;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.ReserveReqDto;
 import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
+import com.fithub.fithubbackend.domain.Training.repository.AvailableDateRepository;
+import com.fithub.fithubbackend.domain.Training.repository.AvailableTimeRepository;
 import com.fithub.fithubbackend.domain.Training.repository.ReserveInfoRepository;
 import com.fithub.fithubbackend.domain.Training.repository.TrainingRepository;
 import com.fithub.fithubbackend.domain.user.domain.User;
@@ -24,6 +27,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -32,6 +36,9 @@ public class PaymentServiceImpl implements PaymentService {
     private IamportClient iamportClient;
 
     private final TrainingRepository trainingRepository;
+    private final AvailableDateRepository availableDateRepository;
+    private final AvailableTimeRepository availableTimeRepository;
+
     private final ReserveInfoRepository reserveInfoRepository;
 
     @Value("${imp.api.key}")
@@ -49,74 +56,106 @@ public class PaymentServiceImpl implements PaymentService {
     @Transactional
     public Long saveOrder(ReserveReqDto dto, User user) {
         Training training = trainingRepository.findById(dto.getTrainingId()).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 트레이닝입니다."));
-        if (!training.removeAvailableDateTime(dto.getReserveDateTime())) {
-            log.error("예약 실패 - 예약 가능한 시간대가 없음: {}", dto.getReserveDateTime());
-            throw new CustomException(ErrorCode.DATE_OR_TIME_ERROR, "현재 예약 가능한 시간대가 아닙니다.");
+
+        AvailableDate availableDate = availableDateRepository.findById(dto.getReservationDateId()).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "해당 예약 날짜는 존재하지 않습니다."));
+        if (!availableDate.isEnabled()) {
+            throw new CustomException(ErrorCode.DATE_OR_TIME_ERROR, "해당 날짜에 예약 가능한 시간대가 없습니다.");
+        }
+        AvailableTime availableTime = availableTimeRepository.findById(dto.getReservationTimeId()).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "해당 예약 시간은 존재하지 않습니다."));
+        if (!availableTime.isEnabled()) {
+            throw new CustomException(ErrorCode.DATE_OR_TIME_ERROR, "해당 시간은 이미 예약되었습니다.");
         }
 
-        // TODO: 모집이 전부 다 차서 마감되었다는 알림 전송
-        if (training.isAllClosed()) {
-            training.updateClosed(true);
-        }
-        ReserveInfo reserveInfo = ReserveInfo.builder().user(user).training(training).dto(dto).build();
+        closeReservationDateTime(availableTime, availableDate);
+        updateTrainingStatus(training, availableDate.getId());
+
+        ReserveInfo reserveInfo = createReserveInfo(user, training, availableDate, availableTime);
+
         return reserveInfoRepository.save(reserveInfo).getId();
     }
 
-    @Override
-    @Transactional(readOnly = true)
-    public PaymentResDto validate(PaymentReqDto dto) throws IamportResponseException, IOException {
-        ReserveInfo reserveInfo = reserveInfoRepository.findById(dto.getReservationId()).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "예약 내역이 없습니다. 다시 진행해주세요."));
-
-        Payment response = iamportClient.paymentByImpUid(dto.getImpUid()).getResponse();
-        int paidAmount = response.getAmount().intValue();
-        if (reserveInfo.getPrice() != paidAmount) {
-            log.error("결제 금액 상이: 결제 금액 - {}, 트레이닝 금액 - {}", paidAmount, reserveInfo.getPrice());
-            iamportClient.cancelPaymentByImpUid(createCancelData(response));
-            reserveInfoRepository.delete(reserveInfo);
-            throw new CustomException(ErrorCode.IAMPORT_PRICE_ERROR);
+    private void closeReservationDateTime(AvailableTime availableTime, AvailableDate availableDate) {
+        availableTime.closeTime();
+        if (!availableTimeRepository.existsByEnabledTrueAndAvailableDateIdAndIdNot(availableDate.getId(), availableTime.getId())) {
+            availableDate.closeDate();
         }
+    }
 
-        reserveInfo.updatePaymentInfo(dto);
-        String trainingTitle = trainingRepository.findTitleById(dto.getTrainingId());
+    private void updateTrainingStatus(Training training, Long availableDateId) {
+        if (!availableDateRepository.existsByEnabledTrueAndTrainingIdAndIdNot(training.getId(), availableDateId)) {
+            training.updateClosed(true);
+        }
+    }
 
-        log.info("결제 내역 - 구매 번호: {}", response.getMerchantUid());
-        return PaymentResDto.builder()
-                .impUid(response.getImpUid())
-                .merchantUid(response.getMerchantUid())
-                .payMethod(response.getPayMethod())
-                .amount(response.getAmount().intValue())
-                .trainingId(dto.getTrainingId())
-                .title(trainingTitle)
-                .reservationDateTime(reserveInfo.getReserveDateTime())
-                .paymentDateTime(reserveInfo.getModifiedDate())
+    private ReserveInfo createReserveInfo(User user, Training training, AvailableDate availableDate, AvailableTime availableTime) {
+        return ReserveInfo.builder()
+                .user(user)
+                .training(training)
+                .date(availableDate)
+                .time(availableTime)
                 .build();
     }
 
     @Override
+    @Transactional(noRollbackFor = {CustomException.class})
+    public Long validate(PaymentReqDto dto) throws IamportResponseException, IOException {
+        ReserveInfo reserveInfo = reserveInfoRepository.findById(dto.getReservationId()).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "예약 내역이 없습니다. 다시 진행해주세요."));
+
+        Payment response = iamportClient.paymentByImpUid(dto.getImpUid()).getResponse();
+        validateAmount(response, reserveInfo);
+
+        reserveInfo.updatePaymentInfo(dto);
+
+        log.info("결제 내역 - imp_uid: {}, merchant_uid: {}", response.getImpUid(), response.getMerchantUid());
+        return reserveInfo.getId();
+    }
+
+    private void validateAmount(Payment response, ReserveInfo reserveInfo) throws IamportResponseException, IOException {
+        int paidAmount = response.getAmount().intValue();
+        if (reserveInfo.getPrice() != paidAmount) {
+            log.error("결제 금액 상이: imp_uid- {}, 결제 금액 - {}, 트레이닝 금액 - {}", response.getImpUid(), paidAmount, reserveInfo.getPrice());
+            iamportClient.cancelPaymentByImpUid(createCancelData(response));
+
+            openTrainingAndDateTime(reserveInfo.getTraining(), reserveInfo);
+            reserveInfoRepository.delete(reserveInfo);
+            throw new CustomException(ErrorCode.IAMPORT_PRICE_ERROR);
+        }
+    }
+
+    @Override
     @Transactional
-    public void cancelPayment(CancelReqDto dto, String email) throws IamportResponseException, IOException {
-        cancelComplete(email, dto);
+    public void cancelPayment(Long userId, CancelReqDto dto) throws IamportResponseException, IOException {
+        cancelComplete(userId, dto);
 
         Payment response = iamportClient.paymentByImpUid(dto.getImpUid()).getResponse();
         iamportClient.cancelPaymentByImpUid(createCancelData(response));
     }
 
     // TODO: 예약 취소시 예약 취소됐다는 알림 트레이너에게 전달
-    private void cancelComplete(String email, CancelReqDto dto) {
+    private void cancelComplete(Long userId, CancelReqDto dto) {
         ReserveInfo reserveInfo = reserveInfoRepository.findById(dto.getReservationId()).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 결제내역입니다."));
-        if (!reserveInfo.getStatus().equals(ReserveStatus.BEFORE)) {
+        if (!Objects.equals(reserveInfo.getUser().getId(), userId)) {
+            throw new CustomException(ErrorCode.PERMISSION_DENIED, "예약한 회원이 아니므로 예약 취소 권한이 없습니다.");
+        }
+
+        checkReserveStatusIsCancelable(reserveInfo.getStatus());
+
+        reserveInfo.updateStatus(ReserveStatus.CANCEL);
+        openTrainingAndDateTime(reserveInfo.getTraining(), reserveInfo);
+    }
+
+    private void checkReserveStatusIsCancelable(ReserveStatus status) {
+        if (!status.equals(ReserveStatus.BEFORE)) {
             String message = "진행 전 예약만 취소가 가능합니다.";
-            if (reserveInfo.getStatus().equals(ReserveStatus.CANCEL)) {
+            if (status.equals(ReserveStatus.CANCEL)) {
                 message = "이미 취소된 예약입니다.";
             }
             throw new CustomException(ErrorCode.INVALID_FORM_DATA, message);
         }
-        reserveInfo.updateStatus(ReserveStatus.CANCEL);
+    }
 
-        // 예약 내역에서 예약 시간 가져와서 트레이닝에 그 시간 다시 예약 가능하도록 변경
-        Training training = reserveInfo.getTraining();
-        training.addAvailableDateTime(reserveInfo.getReserveDateTime());
-        
+    private void openTrainingAndDateTime(Training training, ReserveInfo reserveInfo) {
+        reserveInfo.openDateTime();
         // TODO: 예약이 취소돼서 모집 마감 -> 오픈되었다는 알림
         if (training.isClosed()) {
             training.updateClosed(false);

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingService.java
@@ -4,6 +4,7 @@ import com.fithub.fithubbackend.domain.Training.dto.TrainersTrainingOutlineDto;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.TrainersReserveInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.TrainingContentUpdateDto;
 import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.TrainingCreateDto;
+import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
 import com.fithub.fithubbackend.domain.user.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -18,7 +19,8 @@ public interface TrainerTrainingService {
     void closeTraining(Long id, User user);
     void openTraining(Long id, User user);
 
-    Page<TrainersReserveInfoDto> getReservationList(User user, Pageable pageable);
+    Page<TrainersReserveInfoDto> getReservationList(Long userId, ReserveStatus status, Pageable pageable);
+    Page<TrainersReserveInfoDto> getReservationListForTrainingId(Long userId, Long trainingId, ReserveStatus status, Pageable pageable);
 
     void updateReservationStatusNoShow(String email, Long reservationId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingService.java
@@ -1,5 +1,6 @@
 package com.fithub.fithubbackend.domain.Training.application;
 
+import com.fithub.fithubbackend.domain.Training.dto.TrainersTrainingOutlineDto;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.TrainersReserveInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.TrainingContentUpdateDto;
 import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.TrainingCreateDto;
@@ -8,6 +9,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface TrainerTrainingService {
+
+    Page<TrainersTrainingOutlineDto> getTrainersTrainingList(Long userId, boolean closed, Pageable pageable);
     Long createTraining(TrainingCreateDto dto, User user);
     Long updateTrainingContent(TrainingContentUpdateDto dto, Long trainingId, String email);
     void deleteTraining(Long id, String email);

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
@@ -44,6 +44,7 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
 
     private final ReserveInfoRepository reserveInfoRepository;
     private final TrainingReviewRepository trainingReviewRepository;
+    private final CustomReserveInfoRepository customReserveInfoRepository;
 
     private final AwsS3Uploader awsS3Uploader;
 
@@ -75,11 +76,6 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
 
         trainingRepository.save(training);
         return training.getId();
-    }
-
-    private Trainer findTrainerByUserId (Long userId) {
-        return trainerRepository.findByUserId(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.PERMISSION_DENIED, "해당 회원은 트레이너가 아님"));
     }
 
     private void saveTrainingDateTime(List<LocalDate> availableDateList, List<LocalTime> localTimeList, Training training) {
@@ -114,7 +110,7 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
     @Override
     @Transactional
     public Long updateTrainingContent(TrainingContentUpdateDto dto, Long trainingId, String email) {
-        Training training = trainingRepository.findById(trainingId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 트레이닝입니다."));
+        Training training = findTrainingById(trainingId);
         permissionValidate(training.getTrainer(), email);
 
         training.updateTraining(dto);
@@ -147,7 +143,7 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
     @Override
     @Transactional
     public void deleteTraining(Long id, String email) {
-        Training training = trainingRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 트레이닝입니다."));
+        Training training = findTrainingById(id);
         permissionValidate(training.getTrainer(), email);
 
         if (reserveInfoRepository.existsByTrainingIdAndStatusNotIn(id,
@@ -164,7 +160,7 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
     @Override
     @Transactional
     public void closeTraining(Long id, User user) {
-        Training training = trainingRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "해당하는 트레이닝을 찾을 수 없습니다."));
+        Training training = findTrainingById(id);
         permissionValidate(training.getTrainer(), user.getEmail());
         training.updateClosed(true);
     }
@@ -172,7 +168,7 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
     @Override
     @Transactional
     public void openTraining(Long id, User user) {
-        Training training = trainingRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "해당하는 트레이닝을 찾을 수 없습니다."));
+        Training training = findTrainingById(id);
         permissionValidate(training.getTrainer(), user.getEmail());
         // 트레이닝 예약 가능한 마지막 날이 현재보다 이전이면 오픈 불가능
         if (!training.getEndDate().isAfter(LocalDate.now())) {
@@ -183,11 +179,15 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<TrainersReserveInfoDto> getReservationList(User user, Pageable pageable) {
-        Trainer trainer = trainerRepository.findByUserId(user.getId()).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "해당 회원은 트레이너가 아닙니다."));
+    public Page<TrainersReserveInfoDto> getReservationList(Long userId, ReserveStatus status, Pageable pageable) {
+        Trainer trainer = findTrainerByUserId(userId);
+        return customReserveInfoRepository.searchTrainersReserveInfo(trainer.getId(), status, pageable);
+    }
 
-        Page<ReserveInfo> reserveInfoPage = reserveInfoRepository.findByTrainerId(trainer.getId(), pageable);
-        return reserveInfoPage.map(TrainersReserveInfoDto::toDto);
+    @Override
+    public Page<TrainersReserveInfoDto> getReservationListForTrainingId(Long userId, Long trainingId, ReserveStatus status, Pageable pageable) {
+        Trainer trainer = findTrainerByUserId(userId);
+        return customReserveInfoRepository.searchTrainersReserveInfo(trainer.getId(), trainingId, status, pageable);
     }
 
     @Override
@@ -209,6 +209,16 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
         if (!reserveInfo.getStatus().equals(ReserveStatus.COMPLETE)) {
             throw new CustomException(ErrorCode.BAD_REQUEST, "해당 예약은 진행 전 / 진행 중 / 취소 상태이므로 노쇼 처리할 수 없습니다. 완료 처리된 예약만 노쇼 처리가 가능합니다.");
         }
+    }
+
+    private Trainer findTrainerByUserId (Long userId) {
+        return trainerRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PERMISSION_DENIED, "해당 회원은 트레이너가 아님"));
+    }
+
+    private Training findTrainingById(Long trainingId) {
+        return trainingRepository.findById(trainingId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "해당하는 트레이닝을 찾을 수 없습니다."));
     }
 
     private List<LocalDate> getAvailableDateList(LocalDate startLocalDate, LocalDate endLocalDate, List<LocalDate> unableDates) {

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingServiceImpl.java
@@ -54,7 +54,7 @@ public class TrainingServiceImpl implements TrainingService {
 
     @Override
     public List<TrainingReviewDto> getTrainingReviews(Long id) {
-        List<TrainingReview> trainingReviewList = trainingReviewRepository.findByTrainingId(id);
+        List<TrainingReview> trainingReviewList = trainingReviewRepository.findByLockedFalseAndTrainingId(id);
         return trainingReviewList.stream().map(TrainingReviewDto::toDto).toList();
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingLikeServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingLikeServiceImpl.java
@@ -37,6 +37,10 @@ public class UserTrainingLikeServiceImpl implements UserTrainingLikeService {
         Training training = trainingRepository.findById(trainingId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 트레이닝입니다."));
         checkClosed(training.isClosed());
 
+        if (trainingLikesRepository.existsByTrainingIdAndUserId(trainingId, user.getId())) {
+            throw new CustomException(ErrorCode.DUPLICATE, "이미 찜 설정이 되어있습니다.");
+        }
+
         if (user.getId().equals(training.getTrainer().getUser().getId())) {
             throw new CustomException(ErrorCode.UNKNOWN_ERROR, "트레이너는 자신의 트레이닝을 찜할 수 없습니다.");
         }
@@ -57,7 +61,8 @@ public class UserTrainingLikeServiceImpl implements UserTrainingLikeService {
         if (!trainingRepository.existsById(trainingId)) {
             throw new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 트레이닝입니다.");
         }
-        TrainingLikes trainingLikes = trainingLikesRepository.findByTrainingIdAndUserId(trainingId, user.getId()).orElseThrow(() -> new CustomException(ErrorCode.UNCORRECTABLE_DATA, "트레이닝을 찜하지 않았습니다."));
+        TrainingLikes trainingLikes = trainingLikesRepository.findByTrainingIdAndUserId(trainingId, user.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "해당 트레이닝을 찜하지 않았습니다."));
         trainingLikesRepository.delete(trainingLikes);
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/AvailableDate.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/AvailableDate.java
@@ -52,28 +52,6 @@ public class AvailableDate {
         training.getAvailableDates().add(this);
     }
 
-    public boolean removeTime(LocalTime time) {
-        for (AvailableTime availableTime : this.getAvailableTimes()) {
-            if (availableTime.getTime().equals(time)) {
-                if (!availableTime.isEnabled()) return false;
-                availableTime.closeTime();
-                long enabledCnt = this.getAvailableTimes().stream().filter(AvailableTime::isEnabled).count();
-                if (enabledCnt == 0) closeDate();
-                return true;
-            }
-        }
-        return false;
-    }
-
-    public void addTime(LocalTime time) {
-        for (AvailableTime availableTime : this.getAvailableTimes()) {
-            if (availableTime.getTime().equals(time)) {
-                availableTime.openTime();
-                return;
-            }
-        }
-    }
-
     public void closeCurrentTime(LocalTime now) {
         for (AvailableTime time : this.getAvailableTimes()) {
             if (time.isEnabled() && time.getTime().getHour() == now.getHour()) {

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/ReserveInfo.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/ReserveInfo.java
@@ -2,7 +2,6 @@ package com.fithub.fithubbackend.domain.Training.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.PaymentReqDto;
-import com.fithub.fithubbackend.domain.Training.dto.reservation.ReserveReqDto;
 import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
 import com.fithub.fithubbackend.domain.trainer.domain.Trainer;
 import com.fithub.fithubbackend.domain.user.domain.User;
@@ -37,6 +36,14 @@ public class ReserveInfo extends BaseTimeEntity {
     @JsonIgnoreProperties({"trainer"})
     private Training training;
 
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @OrderBy(value = "date")
+    private AvailableDate availableDate;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @OrderBy(value = "time")
+    private AvailableTime availableTime;
+
     @NotNull
     private LocalDateTime reserveDateTime;
 
@@ -61,11 +68,13 @@ public class ReserveInfo extends BaseTimeEntity {
     private int price;
 
     @Builder
-    public ReserveInfo(User user, Training training, ReserveReqDto dto) {
+    public ReserveInfo(User user, Training training, AvailableDate date, AvailableTime time) {
         this.user = user;
         this.trainer = training.getTrainer();
         this.training = training;
-        this.reserveDateTime = dto.getReserveDateTime();
+        this.availableDate = date;
+        this.availableTime = time;
+        this.reserveDateTime = LocalDateTime.of(availableDate.getDate(), availableTime.getTime());
         this.status = ReserveStatus.BEFORE;
         this.price = training.getPrice();
     }
@@ -78,5 +87,10 @@ public class ReserveInfo extends BaseTimeEntity {
 
     public void updateStatus(ReserveStatus status) {
         this.status = status;
+    }
+
+    public void openDateTime() {
+        this.getAvailableTime().openTime();
+        this.getAvailableDate().openDate();
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/ReserveInfo.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/ReserveInfo.java
@@ -36,11 +36,11 @@ public class ReserveInfo extends BaseTimeEntity {
     @JsonIgnoreProperties({"trainer"})
     private Training training;
 
-    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @OrderBy(value = "date")
     private AvailableDate availableDate;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
     @OrderBy(value = "time")
     private AvailableTime availableTime;
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
@@ -17,7 +17,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -120,43 +119,5 @@ public class Training extends BaseTimeEntity {
 
     public void removeImage(TrainingDocument document) {
         this.images.remove(document);
-    }
-    
-    public boolean removeAvailableDateTime(LocalDateTime dateTime) {
-        LocalDate reserveDate = dateTime.toLocalDate();
-        LocalTime reserveTime = dateTime.toLocalTime();
-        for (AvailableDate availableDate : this.getAvailableDates()) {
-            if (availableDate.getDate().equals(reserveDate)) {
-                if (!availableDate.isEnabled()) return false;
-                return availableDate.removeTime(reserveTime);
-            }
-        }
-        return false;
-    }
-
-    public void addAvailableDateTime(LocalDateTime dateTime) {
-        LocalDate reserveDate = dateTime.toLocalDate();
-        LocalTime reserveTime = dateTime.toLocalTime();
-        for (AvailableDate availableDate : this.getAvailableDates()) {
-            if (availableDate.getDate().equals(reserveDate)) {
-                availableDate.addTime(reserveTime);
-                if (!availableDate.isEnabled()) availableDate.openDate();
-                return;
-            }
-        }
-    }
-
-    public boolean isAllClosed() {
-        for (AvailableDate availableDate : this.getAvailableDates()) {
-            if (availableDate.isEnabled()) return false;
-        }
-        return true;
-    }
-
-    public AvailableDate getToday(LocalDate today) {
-        for (AvailableDate date : this.getAvailableDates()) {
-            if (date.getDate().equals(today)) return date;
-        }
-        return null;
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
@@ -53,6 +53,9 @@ public class Training extends BaseTimeEntity {
     private String location;
 
     @NotNull
+    private int participants;
+
+    @NotNull
     @ColumnDefault("1")
     @Min(1)
     private int quota;
@@ -86,6 +89,7 @@ public class Training extends BaseTimeEntity {
         this.content = dto.getContent();
         this.closed = false;
         this.location = dto.getLocation();
+        this.participants = 0;
         this.quota = dto.getQuota();
         this.price = dto.getPrice();
         this.startDate = dto.getStartDate();

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainersTrainingOutlineDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainersTrainingOutlineDto.java
@@ -1,0 +1,45 @@
+package com.fithub.fithubbackend.domain.Training.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fithub.fithubbackend.domain.Training.domain.Training;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrainersTrainingOutlineDto {
+    private Long trainingId;
+    private String title;
+    private int price;
+    private String location;
+
+    private int participants;
+    private int quota;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
+    private boolean closed;
+
+    private LocalDateTime createdDate;
+    private LocalDateTime modifiedDate;
+
+    @Builder
+    public TrainersTrainingOutlineDto (Training training) {
+        this.trainingId = training.getId();
+        this.title = training.getTitle();
+        this.price = training.getPrice();
+        this.location = training.getLocation();
+        this.participants = training.getParticipants();
+        this.quota = training.getQuota();
+        this.startDate = training.getStartDate();
+        this.endDate = training.getEndDate();
+        this.closed = training.isClosed();
+        this.createdDate = training.getCreatedDate();
+        this.modifiedDate = training.getModifiedDate();
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/CancelReqDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/CancelReqDto.java
@@ -9,9 +9,6 @@ import lombok.Setter;
 @Setter
 @Schema(description = "결제 취소 dto")
 public class CancelReqDto {
-    @NotNull
-    @Schema(description = "결제했던 트레이닝 id")
-    private Long trainingId;
 
     @NotNull
     @Schema(description = "결제 내역 id")
@@ -20,8 +17,4 @@ public class CancelReqDto {
     @NotNull
     @Schema(description = "포트원 거래고유번호")
     private String impUid;
-
-    @NotNull
-    @Schema(description = "결제했던 금액(환불 금액)")
-    private String amount;
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/PaymentReqDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/PaymentReqDto.java
@@ -14,14 +14,6 @@ public class PaymentReqDto {
     private Long reservationId;
 
     @NotNull
-    @Schema(description = "예약한 트레이닝 id")
-    private Long trainingId;
-
-    @NotNull
-    @Schema(description = "상점 id kc는 html5_inicis 아니면 inicis")
-    private String pg;
-
-    @NotNull
     @Schema(description = "결제 방법")
     private String payMethod;
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/ReserveReqDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/ReserveReqDto.java
@@ -1,12 +1,9 @@
 package com.fithub.fithubbackend.domain.Training.dto.reservation;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
-
-import java.time.LocalDateTime;
 
 @Getter
 @Setter
@@ -17,7 +14,10 @@ public class ReserveReqDto {
     private Long trainingId;
 
     @NotNull
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-    @Schema(description = "예약한 날짜, 시간")
-    private LocalDateTime reserveDateTime;
+    @Schema(description = "예약한 날짜 id")
+    private Long reservationDateId;
+
+    @NotNull
+    @Schema(description = "예약한 시간 id")
+    private Long reservationTimeId;
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/TrainersReserveInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/TrainersReserveInfoDto.java
@@ -1,23 +1,27 @@
 package com.fithub.fithubbackend.domain.Training.dto.reservation;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fithub.fithubbackend.domain.Training.domain.ReserveInfo;
 import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
+import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Builder
 @Schema(description = "트레이너의 트레이닝 예약 정보 확인")
 public class TrainersReserveInfoDto {
     @Schema(description = "트레이닝 id")
-    private Long id;
+    private Long trainingId;
 
     @Schema(description = "트레이닝 제목")
     private String title;
+
+    @Schema(description = "트레이닝 예약자 primary key id")
+    private Long userId;
 
     @Schema(description = "트레이닝 예약자 이름")
     private String userName;
@@ -35,16 +39,18 @@ public class TrainersReserveInfoDto {
 
     @Schema(description = "트레이닝 결제 금액")
     private int price;
-    
-   public static TrainersReserveInfoDto toDto(ReserveInfo reserveInfo) {
-            return TrainersReserveInfoDto.builder()
-                    .id(reserveInfo.getId())
-                    .title(reserveInfo.getTraining().getTitle())
-                    .userName(reserveInfo.getUser().getName())
-                    .trainingDateTime(reserveInfo.getReserveDateTime())
-                    .createdDateTime(reserveInfo.getCreatedDate())
-                    .status(reserveInfo.getStatus())
-                    .price(reserveInfo.getPrice())
-                    .build();
+
+    @QueryProjection
+    public TrainersReserveInfoDto(Long trainingId, String title, Long userId, String userName,
+                                  ReserveStatus status, int price,
+                                  LocalDateTime trainingDateTime, LocalDateTime createdDateTime) {
+        this.trainingId = trainingId;
+        this.title = title;
+        this.userId = userId;
+        this.userName = userName;
+        this.trainingDateTime = trainingDateTime;
+        this.status = status;
+        this.price = price;
+        this.createdDateTime = createdDateTime;
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/AvailableDateRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/AvailableDateRepository.java
@@ -3,10 +3,13 @@ package com.fithub.fithubbackend.domain.Training.repository;
 import com.fithub.fithubbackend.domain.Training.domain.AvailableDate;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 public interface AvailableDateRepository extends JpaRepository<AvailableDate, Long> {
     List<AvailableDate> findByTrainingIdOrderByDate(Long trainingId);
-    Optional<AvailableDate> findFirstByTrainingIdOrderByDateDesc(Long trainingId);
+    Optional<AvailableDate> findByTrainingIdAndDate(Long trainingId, LocalDate date);
+
+    boolean existsByEnabledTrueAndTrainingIdAndIdNot(Long trainingId, Long id);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/AvailableDateRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/AvailableDateRepository.java
@@ -1,13 +1,24 @@
 package com.fithub.fithubbackend.domain.Training.repository;
 
 import com.fithub.fithubbackend.domain.Training.domain.AvailableDate;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.QueryHints;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 public interface AvailableDateRepository extends JpaRepository<AvailableDate, Long> {
+    @NotNull
+    @Override
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000")})
+    Optional<AvailableDate> findById(@NotNull Long aLong);
+
     List<AvailableDate> findByTrainingIdOrderByDate(Long trainingId);
     Optional<AvailableDate> findByTrainingIdAndDate(Long trainingId, LocalDate date);
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/AvailableTimeRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/AvailableTimeRepository.java
@@ -4,9 +4,8 @@ import com.fithub.fithubbackend.domain.Training.domain.AvailableTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface AvailableTimeRepository extends JpaRepository<AvailableTime, Long> {
     List<AvailableTime> findByAvailableDateIdOrderByTime(Long availableDateId);
-    Optional<AvailableTime> findFirstByAvailableDateIdOrderByTimeDesc(Long availableDateId);
+    boolean existsByEnabledTrueAndAvailableDateIdAndIdNot(Long availableDateId, Long id);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/CustomReserveInfoRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/CustomReserveInfoRepository.java
@@ -1,0 +1,117 @@
+package com.fithub.fithubbackend.domain.Training.repository;
+
+import com.fithub.fithubbackend.domain.Training.dto.reservation.QTrainersReserveInfoDto;
+import com.fithub.fithubbackend.domain.Training.dto.reservation.TrainersReserveInfoDto;
+import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.fithub.fithubbackend.domain.Training.domain.QReserveInfo.reserveInfo;
+import static com.fithub.fithubbackend.domain.Training.domain.QTraining.training;
+import static com.fithub.fithubbackend.domain.trainer.domain.QTrainer.trainer;
+
+@Repository
+public class CustomReserveInfoRepository {
+    private JPAQueryFactory jpaQueryFactory;
+
+    public CustomReserveInfoRepository(JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+    public Page<TrainersReserveInfoDto> searchTrainersReserveInfo(Long trainerId, ReserveStatus status, Pageable pageable) {
+        List<TrainersReserveInfoDto> content = jpaQueryFactory.select(
+                        new QTrainersReserveInfoDto(
+                                reserveInfo.training.id,
+                                reserveInfo.training.title,
+                                reserveInfo.user.id,
+                                reserveInfo.user.name,
+                                reserveInfo.status,
+                                reserveInfo.price,
+                                reserveInfo.reserveDateTime,
+                                reserveInfo.createdDate
+                        )
+                ).from(reserveInfo)
+                .where(reserveInfo.trainer.id.eq(trainerId),
+                        statusCondition(status))
+                .join(reserveInfo.trainer, trainer)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(reserveInfoSort(status, pageable).toArray(OrderSpecifier[]::new))
+                .fetch();
+
+        Long count = jpaQueryFactory.select(reserveInfo.count())
+                .from(reserveInfo)
+                .where(reserveInfo.trainer.id.eq(trainerId),
+                        statusCondition(status))
+                .join(reserveInfo.trainer, trainer)
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, count);
+    }
+
+    public Page<TrainersReserveInfoDto> searchTrainersReserveInfo(Long trainerId, Long trainingId, ReserveStatus status, Pageable pageable) {
+        List<TrainersReserveInfoDto> content = jpaQueryFactory.select(
+                        new QTrainersReserveInfoDto(
+                                reserveInfo.training.id,
+                                reserveInfo.training.title,
+                                reserveInfo.user.id,
+                                reserveInfo.user.name,
+                                reserveInfo.status,
+                                reserveInfo.price,
+                                reserveInfo.reserveDateTime,
+                                reserveInfo.createdDate
+                        )
+                ).from(reserveInfo)
+                .where(reserveInfo.trainer.id.eq(trainerId),
+                        reserveInfo.training.id.eq(trainingId),
+                        statusCondition(status))
+                .join(reserveInfo.trainer, trainer)
+                .join(reserveInfo.training, training)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(reserveInfoSort(status, pageable).toArray(OrderSpecifier[]::new))
+                .fetch();
+
+        Long count = jpaQueryFactory.select(reserveInfo.count())
+                .from(reserveInfo)
+                .where(reserveInfo.trainer.id.eq(trainerId),
+                        reserveInfo.training.id.eq(trainingId),
+                        statusCondition(status))
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, count);
+    }
+
+    private BooleanExpression statusCondition(ReserveStatus status) {
+        return status != null ? reserveInfo.status.eq(status) : reserveInfo.status.in(ReserveStatus.START, ReserveStatus.BEFORE);
+    }
+
+    private List<OrderSpecifier> reserveInfoSort(ReserveStatus status, Pageable pageable) {
+        List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
+
+        if (status == null) {
+            orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, reserveInfo.status));
+        }
+
+        if (pageable.getSort().isEmpty()) return orderSpecifiers;
+
+        for (Sort.Order order : pageable.getSort()) {
+            Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+            switch (order.getProperty()) {
+                case "id" -> orderSpecifiers.add(new OrderSpecifier<>(direction, reserveInfo.id));
+                case "trainingDateTime" -> orderSpecifiers.add(new OrderSpecifier<>(direction, reserveInfo.reserveDateTime));
+            }
+        }
+        return orderSpecifiers;
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/CustomTrainingRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/CustomTrainingRepository.java
@@ -71,7 +71,8 @@ public class CustomTrainingRepository {
                                 reserveInfo.modifiedDate
                         )
                 ).from(reserveInfo)
-                .where(statusCondition(status))
+                .where(user.id.eq(userId),
+                        statusCondition(status))
                 .join(reserveInfo.user, user)
                 .join(reserveInfo.training, training)
                 .offset(pageable.getOffset())

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/CustomTrainingRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/CustomTrainingRepository.java
@@ -82,7 +82,8 @@ public class CustomTrainingRepository {
 
         Long count = jpaQueryFactory.select(reserveInfo.count())
                 .from(reserveInfo)
-                .where(statusCondition(status))
+                .where(user.id.eq(userId),
+                        statusCondition(status))
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, count);

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingRepository.java
@@ -13,6 +13,8 @@ import java.util.List;
 public interface TrainingRepository extends JpaRepository<Training, Long> {
 
     Page<Training> findAllByDeletedFalseAndClosedFalse(Pageable pageable);
+    Page<Training> findAllByDeletedFalseAndTrainerIdAndClosed(Long trainerId, boolean closed, Pageable pageable);
+
     List<Training> findByClosedFalseAndEndDateLessThanEqual(LocalDate now);
     @Query(value = "SELECT t.title FROM Training t WHERE t.id = :id")
     String findTitleById(@Param("id") Long id);

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingReviewRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingReviewRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public interface TrainingReviewRepository extends JpaRepository<TrainingReview, Long> {
     List<TrainingReview> findByUserIdOrderByIdDesc(Long userId);
-    List<TrainingReview> findByTrainingId(Long trainingId);
+    List<TrainingReview> findByLockedFalseAndTrainingId(Long trainingId);
 
     Optional<TrainingReview> findByReserveInfoId(Long reserveInfoId);
 }

--- a/src/main/java/com/fithub/fithubbackend/global/component/Scheduler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/component/Scheduler.java
@@ -4,6 +4,7 @@ import com.fithub.fithubbackend.domain.Training.domain.AvailableDate;
 import com.fithub.fithubbackend.domain.Training.domain.ReserveInfo;
 import com.fithub.fithubbackend.domain.Training.domain.Training;
 import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
+import com.fithub.fithubbackend.domain.Training.repository.AvailableDateRepository;
 import com.fithub.fithubbackend.domain.Training.repository.ReserveInfoRepository;
 import com.fithub.fithubbackend.domain.Training.repository.TrainingRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Component
@@ -27,26 +29,44 @@ public class Scheduler {
 
     private final TrainingRepository trainingRepository;
     private final ReserveInfoRepository reserveInfoRepository;
+    private final AvailableDateRepository availableDateRepository;
 
     @Async
     @Scheduled(cron = "0 0 */1 * * *")
     @Transactional
     public void checkTrainingDateTimeValidation() {
         log.info("[SCHEDULE] - checkTrainingDateTimeValidation 실행: {}", LocalDateTime.now());
-        List<Training> openTrainingList = trainingRepository.findByClosedFalseAndEndDateLessThanEqual(LocalDate.now());
         LocalDate date = LocalDate.now();
         LocalTime time = LocalTime.now();
-        for (Training training : openTrainingList) {
-            AvailableDate today = training.getToday(date);
-            if (today != null && today.isEnabled()) {
-                today.closeCurrentTime(time);
-                if (today.isAllClosed()) today.closeDate();
-            }
 
-            if (training.getEndDate().isEqual(date) && !training.getEndHour().isBefore(time)) continue;
-            training.updateClosed(true);
+        List<Training> openTrainingList = trainingRepository.findByClosedFalseAndEndDateLessThanEqual(LocalDate.now());
+        for (Training training : openTrainingList) {
+            checkTraining(training, date, time);
         }
     }
+
+    private void checkTraining(Training training, LocalDate date, LocalTime time) {
+        closeAvailableTimeAndDate(training, date, time);
+        closeTraining(training, date, time);
+    }
+
+    private void closeAvailableTimeAndDate(Training training, LocalDate date, LocalTime time) {
+        Optional<AvailableDate> today = availableDateRepository.findByTrainingIdAndDate(training.getId(), date);
+        today.ifPresent(availableDate -> {
+            if (availableDate.isEnabled()) {
+                availableDate.closeCurrentTime(time);
+                if (availableDate.isAllClosed()) {
+                    availableDate.closeDate();
+                }
+            }
+        });
+    }
+
+    private void closeTraining(Training training, LocalDate date, LocalTime time) {
+        if (training.getEndDate().isEqual(date) && !training.getEndHour().isBefore(time)) return;
+        training.updateClosed(true);
+    }
+
 
     @Async
     @Scheduled(cron = "0 0 */1 * * *")
@@ -56,16 +76,25 @@ public class Scheduler {
         log.info("[SCHEDULE] - changeReservationStatusToStart 실행: {}", now);
 
         LocalDateTime reserveTime = LocalDateTime.of(now.getYear(), now.getMonth(), now.getDayOfMonth(), now.getHour(), 0, 0);
-        List<ReserveInfo> reserveInfoListStatusBefore = reserveInfoRepository.findByReserveDateTimeAndStatus(reserveTime, ReserveStatus.BEFORE);
-
-        for (ReserveInfo reserveInfo : reserveInfoListStatusBefore) {
-            reserveInfo.updateStatus(ReserveStatus.START);
-        }
+        changeReservationStatusToStart(reserveTime);
 
         LocalDateTime timeToChangeComplete = reserveTime.minusHours(1);
+        changeReservationStatusToComplete(timeToChangeComplete);
+    }
+
+    private void changeReservationStatusToStart(LocalDateTime reserveTime) {
+        List<ReserveInfo> reserveInfoListStatusBefore = reserveInfoRepository.findByReserveDateTimeAndStatus(reserveTime, ReserveStatus.BEFORE);
+        updateReserveInfoStatus(reserveInfoListStatusBefore, ReserveStatus.START);
+    }
+
+    private void changeReservationStatusToComplete(LocalDateTime timeToChangeComplete) {
         List<ReserveInfo> reserveInfoListToChangeComplete = reserveInfoRepository.findByReserveDateTimeAndStatus(timeToChangeComplete, ReserveStatus.START);
-        for (ReserveInfo reserveInfo : reserveInfoListToChangeComplete) {
-            reserveInfo.updateStatus(ReserveStatus.COMPLETE);
+        updateReserveInfoStatus(reserveInfoListToChangeComplete, ReserveStatus.COMPLETE);
+    }
+
+    private void updateReserveInfoStatus(List<ReserveInfo> reserveInfoList, ReserveStatus newStatus) {
+        for (ReserveInfo reserveInfo : reserveInfoList) {
+            reserveInfo.updateStatus(newStatus);
         }
     }
 

--- a/src/main/java/com/fithub/fithubbackend/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/exception/CustomExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.fithub.fithubbackend.global.exception;
 
+import com.siot.IamportRestClient.exception.IamportResponseException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mapping.PropertyReferenceException;
 import org.springframework.http.ResponseEntity;
@@ -31,5 +32,19 @@ public class CustomExceptionHandler {
         log.info("[CustomExceptionHandler] - PropertyReferenceException 에러 {}", exception.getMessage());
         return ErrorResponseDto.toResponseEntity(ErrorCode.INVALID_FORM_DATA, exception.getMessage());
     }
+
+    @ExceptionHandler(IamportResponseException.class)
+    public ResponseEntity<ErrorResponseDto> handleIamportResponseException(IamportResponseException exception) {
+        log.info("[CustomExceptionHandler] - IamportResponseException 에러 {}", exception.getMessage());
+        return ResponseEntity
+                .status(exception.getHttpStatusCode())
+                .body(ErrorResponseDto.builder()
+                        .status(exception.getHttpStatusCode())
+                        .code("IAMPORT_ERROR")
+                        .message(exception.getMessage())
+                        .build()
+                );
+    }
+
 }
 

--- a/src/main/java/com/fithub/fithubbackend/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/exception/CustomExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.data.mapping.PropertyReferenceException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -45,6 +46,20 @@ public class CustomExceptionHandler {
                         .build()
                 );
     }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponseDto> handleMissingServletRequestParameterException(MissingServletRequestParameterException exception) {
+        log.info("[CustomExceptionHandler] - MissingServletRequestParameterException 에러 {}", exception.getMessage());
+        return ResponseEntity
+                .status(exception.getStatusCode())
+                .body(ErrorResponseDto.builder()
+                        .status(exception.getStatusCode().value())
+                        .code("BAD_REQUEST")
+                        .message(exception.getMessage())
+                        .build()
+                );
+    }
+
 
 }
 


### PR DESCRIPTION
## pr 유형
- 기능 수정, 리팩토링

## 변경 사항
### 회원의 트레이닝
- 예약 리스트 조회 시 자기것만 가지고 오도록 수정
- 찜 설정 시 이미 찜한거면 에러 반환

### 회원 결제(예약)
- reserveInfo 엔티티가 availableDate, Time (예약 날짜, 시간)이랑 관계를 맺지 않았었음 -> 수정
- 결제 코드에서 불필요한 for문을 통해 데이터를 전부 찾아서 하나만 변경하게 되는 코드 대신 db에 접근하는 코드로 변경
- 결제 - 금액 검증 시 검증 실패하면 예약 취소하며 예약 시간을 enabled로 수정하지 않았었음 -> 수정하도록 변경 + CustomException 롤백 제외로 해서 검증 실패하면 변경 사항 업데이트 + reserveInfo 삭제하도록
- 결제 - 금액 검증 시 성공하면 결제 내역 대신 예약 id 반환으로 변경

### 트레이너의 트레이닝
- 트레이너의 트레이닝 목록 조회 기능 추가 (오픈 / 마감)

### 트레이너의 예약 리스트 조회
- 트레이너의 예약 리스트 조회 시 예약 상태에 따라 조회 하도록 수정 (진행중+진행전 / 완료 / 취소 / 노쇼)
- 트레이너가 트레이닝 하나에 대한 예약 리스트 조회 기능 추가 (예약 상태에 따라 조회,  진행중+진행전 / 완료 / 취소 / 노쇼)

### 기타
- 결제 api 에러 핸들러, api에 필요한 파라미터가 없을 시 처리하는 핸들러 추가

## 병합 후 필요한 작업
- Q파일 수정 및 추가로 compileJava 필요

## 테스트 결과
- 금액 검증 실패하면 (결제 금액과 트레이닝 금액이 다르면) 시간 예약 가능 상태 수정, reserveInfo 삭제
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/e03d44eb-4b47-46b8-8171-61c9afd1c2fa)


- impUid로 결제 정보 조회 실패
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/796a9576-8738-4546-87a4-26dbee4e76b2)


- 트레이너의 트레이닝 목록 조회
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/be07675f-b8ee-4beb-9daa-34358114cda2)


- 트레이너의 모든 예약 목록 조회 (status 없이 주면 BEFORE, START만 가져옴)
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/fbcadd7c-a030-493f-8dda-ba7bbe41bd1e)


- 트레이너의 트레이닝 하나에 대한 예약 리스트 조회
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/85b70cdd-e5cd-4694-ad6b-c28d2f9200a8)
