### PR TITLE
 feat/training: 트레이닝 날짜에 해당하는 예약 수 가져오는 기능 추가, 트레이닝 날짜 수정 기능 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/PaymentController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/PaymentController.java
@@ -36,7 +36,7 @@ public class PaymentController {
     @Operation(summary = "결제 전 예약 시간이 예약 가능한지 확인, 저장 api", responses = {
             @ApiResponse(responseCode = "200", description = "예약하려던 시간이 예약 가능해서 예약 정보가 저장됨, 임시로 저장된 예약 정보 id 반환"),
             @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
-            @ApiResponse(responseCode = "400", description = "DATE_OR_TIME_ERROR: 결제한 트레이닝의 시간대가 예약 불가능해짐, BAD_REQUEST: 마감한 트레이닝은 예약 불가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "DATE_OR_TIME_ERROR: 결제한 트레이닝의 시간대가 예약 불가능해짐 / 예약 하려는 날짜에 해당하는 시간이 아닙니다, BAD_REQUEST: 마감한 트레이닝은 예약 불가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
             @ApiResponse(responseCode = "404", description = "예약할 트레이닝이 존재하지 않는 트레이닝", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
     })
     @PostMapping("/order")

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainerTrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainerTrainingController.java
@@ -3,6 +3,7 @@ package com.fithub.fithubbackend.domain.Training.api;
 import com.fithub.fithubbackend.domain.Training.application.TrainerTrainingService;
 import com.fithub.fithubbackend.domain.Training.dto.TrainersTrainingOutlineDto;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.TrainersReserveInfoDto;
+import com.fithub.fithubbackend.domain.Training.dto.reservation.TrainingDateReservationNumDto;
 import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.TrainingContentUpdateDto;
 import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.TrainingCreateDto;
 import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
@@ -26,6 +27,8 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "trainer's training (트레이너의 트레이닝)", description = "트레이너가 사용하는 트레이닝 관련 api (트레이너 권한 필요)")
 @RestController
@@ -51,7 +54,6 @@ public class TrainerTrainingController {
         return ResponseEntity.ok(trainerTrainingService.getTrainersTrainingList(user.getId(), closed, pageable));
     }
 
-
     @Operation(summary = "트레이닝 생성, swagger에서 테스트 불가능, 이미지는 모두 images로 주면 됨", responses = {
             @ApiResponse(responseCode = "200", description = "생성됨"),
             @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
@@ -71,10 +73,20 @@ public class TrainerTrainingController {
             @ApiResponse(responseCode = "500", description = "이미지 업로드 에러", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
     @PutMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Long> updateTraining(@Valid TrainingContentUpdateDto dto, @RequestParam Long trainingId, @AuthUser User user) {
+    public ResponseEntity<Long> updateTrainingContent(@Valid TrainingContentUpdateDto dto, @RequestParam Long trainingId, @AuthUser User user) {
         // TODO: 예약 관련 기능 끝난 후 수정 필요
         if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         return ResponseEntity.ok(trainerTrainingService.updateTrainingContent(dto, trainingId, user.getEmail()));
+    }
+
+    @Operation(summary = "트레이닝 날짜, 시간 수정을 위해 그 날짜들에 있는 예약 수 받아오기", responses = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+    })
+    @GetMapping("/reservations/count")
+    public ResponseEntity<List<TrainingDateReservationNumDto>> getNumberOfReservations(@RequestParam Long trainingId, @AuthUser User user) {
+        if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        return ResponseEntity.ok(trainerTrainingService.getNumberOfReservations(trainingId));
     }
 
     @Operation(summary = "트레이닝 삭제 (soft delete)", parameters = {

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainerTrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainerTrainingController.java
@@ -6,6 +6,7 @@ import com.fithub.fithubbackend.domain.Training.dto.reservation.TrainersReserveI
 import com.fithub.fithubbackend.domain.Training.dto.reservation.TrainingDateReservationNumDto;
 import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.TrainingContentUpdateDto;
 import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.TrainingCreateDto;
+import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.TrainingDateUpdateDto;
 import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
 import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.global.domain.AuthUser;
@@ -79,7 +80,7 @@ public class TrainerTrainingController {
         return ResponseEntity.ok(trainerTrainingService.updateTrainingContent(dto, trainingId, user.getEmail()));
     }
 
-    @Operation(summary = "트레이닝 날짜, 시간 수정을 위해 그 날짜들에 있는 예약 수 받아오기", responses = {
+    @Operation(summary = "트레이닝 날짜, 시간 수정을 위해 그 날짜들에 있는 진행 전 예약 수 받아오기", responses = {
             @ApiResponse(responseCode = "200", description = "성공"),
             @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })
@@ -87,6 +88,18 @@ public class TrainerTrainingController {
     public ResponseEntity<List<TrainingDateReservationNumDto>> getNumberOfReservations(@RequestParam Long trainingId, @AuthUser User user) {
         if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         return ResponseEntity.ok(trainerTrainingService.getNumberOfReservations(trainingId));
+    }
+
+    @Operation(summary = "트레이닝 날짜 수정", responses = {
+            @ApiResponse(responseCode = "200", description = "성공. 다시 /reservations/count 조회하거나 트레이닝으로 돌아가기"),
+            @ApiResponse(responseCode = "400", description = "수정하려는 날짜 중에(date.getDate()) 일에 진행 전 예약이 존재하여 수정할 수 없습니다.", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+    })
+    @PutMapping("/update/date")
+    public ResponseEntity<Long> updateTrainingDates(@RequestParam Long trainingId, @RequestBody TrainingDateUpdateDto dto,
+                                                                              @AuthUser User user) {
+        if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        return ResponseEntity.ok(trainerTrainingService.updateTrainingDate(user.getEmail(), trainingId, dto));
     }
 
     @Operation(summary = "트레이닝 삭제 (soft delete)", parameters = {

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/PaymentServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/PaymentServiceImpl.java
@@ -70,6 +70,10 @@ public class PaymentServiceImpl implements PaymentService {
             throw new CustomException(ErrorCode.DATE_OR_TIME_ERROR, "해당 시간은 이미 예약되었습니다.");
         }
 
+        if (!availableTime.getAvailableDate().equals(availableDate)) {
+            throw new CustomException(ErrorCode.DATE_OR_TIME_ERROR, "예약 하려는 날짜에 해당하는 시간이 아닙니다.");
+        }
+
         closeReservationDateTime(availableTime, availableDate);
         updateTrainingStatus(training, availableDate.getId());
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingService.java
@@ -2,6 +2,7 @@ package com.fithub.fithubbackend.domain.Training.application;
 
 import com.fithub.fithubbackend.domain.Training.dto.TrainersTrainingOutlineDto;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.TrainersReserveInfoDto;
+import com.fithub.fithubbackend.domain.Training.dto.reservation.TrainingDateReservationNumDto;
 import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.TrainingContentUpdateDto;
 import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.TrainingCreateDto;
 import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
@@ -9,11 +10,16 @@ import com.fithub.fithubbackend.domain.user.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface TrainerTrainingService {
 
     Page<TrainersTrainingOutlineDto> getTrainersTrainingList(Long userId, boolean closed, Pageable pageable);
     Long createTraining(TrainingCreateDto dto, User user);
     Long updateTrainingContent(TrainingContentUpdateDto dto, Long trainingId, String email);
+
+    List<TrainingDateReservationNumDto> getNumberOfReservations(Long trainingId);
+
     void deleteTraining(Long id, String email);
 
     void closeTraining(Long id, User user);

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingService.java
@@ -5,6 +5,8 @@ import com.fithub.fithubbackend.domain.Training.dto.reservation.TrainersReserveI
 import com.fithub.fithubbackend.domain.Training.dto.reservation.TrainingDateReservationNumDto;
 import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.TrainingContentUpdateDto;
 import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.TrainingCreateDto;
+import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.TrainingDateUpdateDto;
+import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.TrainingTimeUpdateDto;
 import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
 import com.fithub.fithubbackend.domain.user.domain.User;
 import org.springframework.data.domain.Page;
@@ -19,6 +21,9 @@ public interface TrainerTrainingService {
     Long updateTrainingContent(TrainingContentUpdateDto dto, Long trainingId, String email);
 
     List<TrainingDateReservationNumDto> getNumberOfReservations(Long trainingId);
+
+    Long updateTrainingDate(String email, Long trainingId, TrainingDateUpdateDto dto);
+    Long updateTrainingTime(String email, Long trainingId, TrainingTimeUpdateDto dto);
 
     void deleteTraining(Long id, String email);
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
@@ -2,10 +2,10 @@ package com.fithub.fithubbackend.domain.Training.application;
 
 import com.fithub.fithubbackend.domain.Training.domain.*;
 import com.fithub.fithubbackend.domain.Training.dto.TrainersTrainingOutlineDto;
+import com.fithub.fithubbackend.domain.Training.dto.TrainingAvailableTimeDto;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.TrainersReserveInfoDto;
-import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.TrainingContentUpdateDto;
-import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.TrainingCreateDto;
-import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.TrainingImgUpdateDto;
+import com.fithub.fithubbackend.domain.Training.dto.reservation.TrainingDateReservationNumDto;
+import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.*;
 import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
 import com.fithub.fithubbackend.domain.Training.repository.*;
 import com.fithub.fithubbackend.domain.trainer.domain.Trainer;
@@ -119,6 +119,28 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
         }
 
         return training.getId();
+    }
+
+    @Override
+    public List<TrainingDateReservationNumDto> getNumberOfReservations(Long trainingId) {
+        Training training = findTrainingById(trainingId);
+        List<AvailableDate> availableDates = training.getAvailableDates();
+
+        List<TrainingDateReservationNumDto> list = new ArrayList<>();
+        for (AvailableDate date : availableDates) {
+            Long reservationNum = reserveInfoRepository.countByAvailableDateIdAndStatus(date.getId(), ReserveStatus.BEFORE);
+            list.add(createTrainingDateReservationNumDto(date, reservationNum));
+        }
+        return list;
+    }
+
+    private TrainingDateReservationNumDto createTrainingDateReservationNumDto(AvailableDate date, Long reservationNum) {
+        return TrainingDateReservationNumDto.builder()
+                .id(date.getId())
+                .date(date.getDate())
+                .availableTimes(date.getAvailableTimes().stream().map(TrainingAvailableTimeDto::toDto).toList())
+                .reservationNum(reservationNum)
+                .build();
     }
 
     private void deleteOrAddImage(TrainingImgUpdateDto dto, Training training) {

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
@@ -176,6 +176,12 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
         List<TrainingLikes> trainingLikesList = trainingLikesRepository.findByTrainingId(id);
         trainingLikesRepository.deleteAll(trainingLikesList);
 
+        List<TrainingDocument> trainingImgList = trainingDocumentRepository.findByTrainingId(id);
+        for (TrainingDocument trainingImg : trainingImgList) {
+            awsS3Uploader.deleteS3(trainingImg.getDocument().getPath());
+        }
+        trainingDocumentRepository.deleteAll(trainingImgList);
+
         training.updateDeleted(true);
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
@@ -42,6 +42,8 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
     private final TrainerRepository trainerRepository;
     private final TrainingLikesRepository trainingLikesRepository;
 
+    private final AvailableDateRepository availableDateRepository;
+
     private final ReserveInfoRepository reserveInfoRepository;
     private final TrainingReviewRepository trainingReviewRepository;
     private final CustomReserveInfoRepository customReserveInfoRepository;
@@ -141,6 +143,59 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
                 .availableTimes(date.getAvailableTimes().stream().map(TrainingAvailableTimeDto::toDto).toList())
                 .reservationNum(reservationNum)
                 .build();
+    }
+
+    @Override
+    @Transactional
+    public Long updateTrainingDate(String email, Long trainingId, TrainingDateUpdateDto dto) {
+        Training training = findTrainingById(trainingId);
+        permissionValidate(training.getTrainer(), email);
+
+        List<LocalDate> newAvailableDateList = getAvailableDateList(dto.getStartDate(), dto.getEndDate(), dto.getUnableDates());
+        List<LocalTime> localTimeList = getAvailableTimeList(training.getStartHour(), training.getEndHour());
+
+        List<AvailableDate> currentDateList = training.getAvailableDates();
+
+        updateCurrentDates(currentDateList, newAvailableDateList, training);
+        saveTrainingDateTime(newAvailableDateList, localTimeList, training);
+
+        training.updateStartAndEndDate(dto.getStartDate(), dto.getEndDate());
+        return trainingId;
+    }
+
+    public void updateCurrentDates(List<AvailableDate> currentDateList, List<LocalDate> newAvailableDateList, Training training) {
+        List<AvailableDate> datesToRemove = new ArrayList<>();
+
+        for (AvailableDate date : currentDateList) {
+            if (newAvailableDateList.contains(date.getDate())) {
+                newAvailableDateList.remove(date.getDate());
+            } else {
+                datesToRemove.add(date);
+            }
+        }
+
+        for (AvailableDate date : datesToRemove) {
+            handleDeleteData(date, training);
+        }
+    }
+
+    public void handleDeleteData(AvailableDate date, Training training) {
+        ReserveStatus status = reserveInfoRepository.findStatusByAvailableDateId(date.getId());
+        if (status == ReserveStatus.BEFORE) {
+            throw new CustomException(ErrorCode.BAD_REQUEST, date.getDate() + "일에 진행 전 예약이 존재하여 수정할 수 없습니다.");
+        }
+
+        if (status == null) {
+            training.removeDate(date);
+            availableDateRepository.delete(date);
+        } else {
+            date.deleteDate();
+        }
+    }
+
+    @Override
+    public Long updateTrainingTime(String email, Long trainingId, TrainingTimeUpdateDto dto) {
+        return null;
     }
 
     private void deleteOrAddImage(TrainingImgUpdateDto dto, Training training) {

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/AvailableDate.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/AvailableDate.java
@@ -33,7 +33,7 @@ public class AvailableDate {
     @ColumnDefault("true")
     private boolean enabled;
 
-    @OneToMany(mappedBy = "availableDate", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "availableDate", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonIgnoreProperties({"availableDate"})
     private List<AvailableTime> availableTimes;
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/AvailableDate.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/AvailableDate.java
@@ -9,12 +9,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Where;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
 @Entity
+@Where(clause = "deleted = false")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AvailableDate {
@@ -36,6 +38,8 @@ public class AvailableDate {
     @OneToMany(mappedBy = "availableDate", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonIgnoreProperties({"availableDate"})
     private List<AvailableTime> availableTimes;
+
+    private boolean deleted;
 
     @Builder
     public AvailableDate (LocalDate date, boolean enabled) {
@@ -74,5 +78,10 @@ public class AvailableDate {
 
     public void openDate() {
         this.enabled = true;
+    }
+
+    public void deleteDate() {
+        this.deleted = true;
+        this.availableTimes.forEach(AvailableTime::deleteTime);
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/AvailableTime.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/AvailableTime.java
@@ -7,10 +7,12 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Where;
 
 import java.time.LocalTime;
 
 @Entity
+@Where(clause = "deleted = false")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AvailableTime {
@@ -29,6 +31,8 @@ public class AvailableTime {
     @ColumnDefault("true")
     private boolean enabled;
 
+    private boolean deleted;
+
     @Builder
     public AvailableTime (LocalTime time, AvailableDate date, boolean enabled) {
         this.time = time;
@@ -42,5 +46,9 @@ public class AvailableTime {
 
     public void openTime() {
         this.enabled = true;
+    }
+
+    public void deleteTime() {
+        this.deleted = true;
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
@@ -125,4 +125,13 @@ public class Training extends BaseTimeEntity {
     public void removeImage(TrainingDocument document) {
         this.images.remove(document);
     }
+
+    public void removeDate(AvailableDate date) {
+        this.availableDates.remove(date);
+    }
+
+    public void updateStartAndEndDate(LocalDate startDate, LocalDate endDate) {
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
@@ -78,6 +78,7 @@ public class Training extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "training", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @JsonIgnoreProperties({"training"})
+    @OrderBy(value = "date")
     private List<AvailableDate> availableDates;
 
     @NotNull

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/TrainingDateReservationNumDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/TrainingDateReservationNumDto.java
@@ -1,0 +1,24 @@
+package com.fithub.fithubbackend.domain.Training.dto.reservation;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fithub.fithubbackend.domain.Training.dto.TrainingAvailableTimeDto;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class TrainingDateReservationNumDto {
+    private Long id;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate date;
+
+    private Long reservationNum;
+
+    private List<TrainingAvailableTimeDto> availableTimes = new ArrayList<>();
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/trainersTraining/TrainingDateUpdateDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/trainersTraining/TrainingDateUpdateDto.java
@@ -1,0 +1,26 @@
+ package com.fithub.fithubbackend.domain.Training.dto.trainersTraining;
+
+ import io.swagger.v3.oas.annotations.media.Schema;
+ import jakarta.validation.constraints.NotNull;
+ import lombok.Getter;
+ import lombok.Setter;
+
+ import java.time.LocalDate;
+ import java.util.ArrayList;
+ import java.util.List;
+
+@Getter
+@Setter
+public class TrainingDateUpdateDto {
+
+    @NotNull
+    @Schema(description = "트레이닝 시작 날짜")
+    private LocalDate startDate;
+    
+    @NotNull
+    @Schema(description = "트레이닝 마지막 날짜")
+    private LocalDate endDate;
+
+    @Schema(description = "트레이닝 불가 날짜", example = "[\"2024-03-02\",\"2024-03-05\"]")
+    private List<LocalDate> unableDates = new ArrayList<>();
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
@@ -15,4 +15,6 @@ public interface ReserveInfoRepository extends JpaRepository<ReserveInfo, Long> 
     boolean existsByTrainingIdAndStatusNotIn(Long training_id, List<@NotNull ReserveStatus> status);
 
     List<ReserveInfo> findByReserveDateTimeAndStatus(LocalDateTime now, ReserveStatus status);
+
+    Long countByAvailableDateIdAndStatus(Long availableDateId, ReserveStatus status);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
@@ -6,6 +6,8 @@ import jakarta.validation.constraints.NotNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,4 +19,7 @@ public interface ReserveInfoRepository extends JpaRepository<ReserveInfo, Long> 
     List<ReserveInfo> findByReserveDateTimeAndStatus(LocalDateTime now, ReserveStatus status);
 
     Long countByAvailableDateIdAndStatus(Long availableDateId, ReserveStatus status);
+
+    @Query("SELECT r.status FROM ReserveInfo r WHERE r.availableDate.id = :availableDateId")
+    ReserveStatus findStatusByAvailableDateId(@Param("availableDateId") Long availableDateId);
 }


### PR DESCRIPTION
## pr 유형
- 기능 추가

## 변경 사항
- 트레이닝 날짜 수정 시 해당 날짜에 예약이 있는지 확인 필요 -> 예약 수 가져오는 api 추가
- 트레이너의 트레이닝 날짜 수정 기능 추가
  - 수정하려는 날짜에 진행 전 예약이 존재하면 400 에러 발생
  - 예약 완료/취소가 존재하는 트레이닝 날짜가 있으면 soft delete
  - startDate와 endDate를 받아서 삭제해야 되는 날짜는 삭제, 새로 추가할 날짜는 새로 추가
- 트레이닝 삭제 시 트레이닝 이미지도 삭제되도록 수정

## 테스트 결과
- 트레이닝 날짜에 해당하는 예약 수 가져오는 api
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/ce5c1567-2df5-434f-b3c0-0c52e8b84df0)

- 트레이닝 날짜 수정
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/3fe5a060-6108-4148-8cc3-ad4f1730ce59)

