### PR TITLE
feat: 게시글 검색 기능 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
@@ -108,4 +108,18 @@ public class PostController {
         return ResponseEntity.ok().body(commentService.getDetailComments(commentId));
     }
 
+    @Operation(summary = "게시글 검색", parameters = {
+            @Parameter(name = "keyword", description = "검색 키워드"),
+            @Parameter(name = "scope", description = " 검색 범위 ex) content(기본), writer, hashtags"),
+            @Parameter(name = "page", description = "페이지 번호 (기본 0 : 가장 첫 페이지), 필수 값"),
+            @Parameter(name = "size", description = "한 페이지에 노출할 데이터 건수 (기본 9, 생략 가능)"),
+            @Parameter(name = "sort", description = "페이지 정렬 방식 (기본 id desc : 최신순, 생략 가능) ex) likes(좋아요 순), comments(댓글 순) 지정 가능"),
+    }, responses = {
+            @ApiResponse(responseCode = "200", description = "검색 완료"),
+    })
+    @PostMapping("/search")
+    public ResponseEntity<Page<PostInfoDto>> searchPostsByKeyword(@RequestBody PostSearchFilterDto filter) {
+        return ResponseEntity.ok().body(postService.searchPostsByKeyword(filter));
+    }
+
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostService.java
@@ -20,4 +20,5 @@ public interface PostService {
 
     List<LikedUsersInfoDto> getLikedUsersForPosts(List<PostRequestDto> postRequestDtos);
 
+    Page<PostInfoDto> searchPostsByKeyword(PostSearchFilterDto filter);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostServiceImpl.java
@@ -62,6 +62,13 @@ public class PostServiceImpl implements PostService {
         return likedUsersInfoDtos;
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public Page<PostInfoDto> searchPostsByKeyword(PostSearchFilterDto filter) {
+        Page<Post> posts = postRepository.searchPostsByKeyword(filter);
+        return posts.map(PostInfoDto::toDto);
+    }
+
     @Transactional
     public Post getPost(Long postId) {
         return postRepository.findById(postId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 게시글"));

--- a/src/main/java/com/fithub/fithubbackend/domain/board/dto/PageableDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/dto/PageableDto.java
@@ -1,0 +1,23 @@
+package com.fithub.fithubbackend.domain.board.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.util.List;
+
+@Getter @Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PageableDto {
+
+    @Schema(defaultValue = "0", description = "페이지 번호", required = true)
+    private int page = 0;
+
+    @Schema(defaultValue = "9", description = "페이지 크기")
+    private int size = 9;
+
+    @Schema(description = "정렬 방식", example = "[\"id\"]")
+    private List<String> sort;
+
+
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostSearchFilterDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostSearchFilterDto.java
@@ -1,0 +1,21 @@
+package com.fithub.fithubbackend.domain.board.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter @Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Schema(description = "게시글 검색 필터 dto")
+public class PostSearchFilterDto {
+
+    @Schema(description = "검색 키워드", example = "검색 키워드")
+    private String keyword;
+
+    @Schema(description = "검색 범위 (내용, 작성자, 해시태그)", example = "content")
+    private String scope = "content";
+
+    @Schema(description = "페이징")
+    private PageableDto pageable;
+
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostWriterInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostWriterInfoDto.java
@@ -12,17 +12,22 @@ public class PostWriterInfoDto {
     @Schema(description = "작성자 닉네임")
     private String nickname;
 
+    @Schema(description = "작성자 이메일")
+    private String email;
+
     @Schema(description = "게시글 작성자 프로필 url")
     private String profileUrl;
 
     @Builder
-    public PostWriterInfoDto(String nickname, String profileUrl) {
+    public PostWriterInfoDto(String nickname, String email, String profileUrl) {
         this.nickname = nickname;
+        this.email = email;
         this.profileUrl = profileUrl;
     }
 
     public static PostWriterInfoDto toDto(User user) {
         return PostWriterInfoDto.builder()
+                .email(user.getEmail())
                 .nickname(user.getNickname())
                 .profileUrl(user.getProfileImg().getUrl())
                 .build();

--- a/src/main/java/com/fithub/fithubbackend/domain/board/repository/CustomPostRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/repository/CustomPostRepository.java
@@ -1,0 +1,11 @@
+package com.fithub.fithubbackend.domain.board.repository;
+
+import com.fithub.fithubbackend.domain.board.dto.PostSearchFilterDto;
+import com.fithub.fithubbackend.domain.board.post.domain.Post;
+import org.springframework.data.domain.Page;
+
+public interface CustomPostRepository {
+
+    Page<Post> searchPostsByKeyword(PostSearchFilterDto postSearchFilterDTO);
+
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/board/repository/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/repository/CustomPostRepositoryImpl.java
@@ -1,0 +1,86 @@
+package com.fithub.fithubbackend.domain.board.repository;
+
+import com.fithub.fithubbackend.domain.board.dto.PageableDto;
+import com.fithub.fithubbackend.domain.board.dto.PostSearchFilterDto;
+import com.fithub.fithubbackend.domain.board.post.domain.Post;
+import com.querydsl.core.QueryResults;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.fithub.fithubbackend.domain.board.post.domain.QPost.post;
+import static com.fithub.fithubbackend.domain.user.domain.QUser.user;
+
+import java.util.*;
+
+@Repository
+@Slf4j
+public class CustomPostRepositoryImpl implements CustomPostRepository {
+
+    private JPAQueryFactory jpaQueryFactory;
+
+    public CustomPostRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<Post> searchPostsByKeyword(PostSearchFilterDto filter) {
+         QueryResults<Post> posts = jpaQueryFactory.selectFrom(post)
+                .where(scopeEq(filter))
+                 .join(post.user, user).fetchJoin()
+                .orderBy(getOrderSpecifier(filter.getPageable()).toArray(OrderSpecifier[]::new))
+                .offset(filter.getPageable().getPage() * filter.getPageable().getSize())
+                .limit(filter.getPageable().getSize())
+                .fetchResults();
+
+        return new PageImpl<>(posts.getResults(), PageRequest.of(filter.getPageable().getPage(), filter.getPageable().getSize()), posts.getTotal());
+    }
+
+    private BooleanExpression scopeEq(PostSearchFilterDto filter) {
+        if (filter.getScope().equals("content"))
+            return post.content.containsIgnoreCase(filter.getKeyword());
+        else if (filter.getScope().equals("writer"))
+            return post.user.nickname.containsIgnoreCase(filter.getKeyword());
+        else
+            return post.postHashtags.any().hashtag.content.containsIgnoreCase(filter.getKeyword());
+    }
+
+
+    private List<OrderSpecifier> getOrderSpecifier(PageableDto pageable) {
+
+        List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
+
+
+        if (pageable == null || pageable.getSort() == null || pageable.getSort().isEmpty()) {
+            orderSpecifiers.add(post.id.desc());
+            return orderSpecifiers;
+        }
+
+        for (String sortProperty : pageable.getSort()) {
+            Sort.Order order = Sort.Order.by(sortProperty);
+
+            switch (order.getProperty()) {
+                case "likes":
+                    orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, post.likes.size()));
+                    break;
+                case "comments":
+                    orderSpecifiers.add(new OrderSpecifier<>(Order.DESC,
+                            JPAExpressions.select(post.comments.size())
+                                    .from(post)
+                                    .where(post.comments.any().deleted.eq(false))));
+                    break;
+            }
+        }
+        return orderSpecifiers;
+    }
+
+
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/board/repository/PostRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/repository/PostRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, CustomPostRepository {
     @Query(value = "SELECT post " +
             "FROM Post post " +
             "JOIN FETCH post.user user " +


### PR DESCRIPTION
## PR 유형
- 기능 추가

## 반영 브랜치
- main -> main

## 변경 사항
- 게시글 검색 기능 추가
- 게시글 정보 dto에 작성자 이메일 (식별자 ) 추가

## 테스트 결과

### 1. 게시글 검색

> POST /posts/search

#### 1-1. request body 
![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/a3662c0f-5056-472d-b6de-d9f81ef41fc8)

- keyword: 검색 키워드
- scope :  검색 범위 ex) content(기본), writer, hashtags
- page : 페이지 번호 (기본 0 : 가장 첫 페이지), 필수 값
- size :한 페이지에 노출할 데이터 건수 (기본 9, 생략 가능)
- sort : 페이지 정렬 방식 (기본 id desc : 최신순, 생략 가능) ex) likes(좋아요 순), comments(댓글 순) 지정 가능

