### PR TITLE
fix: 프로필 코드 에러 수정, 트레이너,트레이닝 코드 에러 수정 및 업데이트

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
@@ -199,11 +199,11 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
     }
 
     private void deleteOrAddImage(TrainingImgUpdateDto dto, Training training) {
-        if (dto.isImgAdded() && !dto.getNewImgList().isEmpty()) {
-            saveTrainingImages(dto.getNewImgList(), training);
-        }
         if (dto.isImgDeleted() && !dto.getUnModifiedImgList().isEmpty()) {
             deleteOriginalImage(dto.getUnModifiedImgList(), training);
+        }
+        if (dto.isImgAdded() && !dto.getNewImgList().isEmpty()) {
+            saveTrainingImages(dto.getNewImgList(), training);
         }
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
@@ -239,7 +239,11 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
         }
         trainingDocumentRepository.deleteAll(trainingImgList);
 
-        training.updateDeleted(true);
+        if (reserveInfoRepository.existsByTrainingId(id)) {
+            training.executeDelete();
+        } else {
+            trainingRepository.delete(training);
+        }
     }
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
@@ -180,12 +180,14 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
     }
 
     public void handleDeleteData(AvailableDate date, Training training) {
-        ReserveStatus status = reserveInfoRepository.findStatusByAvailableDateId(date.getId());
-        if (status == ReserveStatus.BEFORE) {
-            throw new CustomException(ErrorCode.BAD_REQUEST, date.getDate() + "일에 진행 전 예약이 존재하여 수정할 수 없습니다.");
+        List<ReserveStatus> statusList = reserveInfoRepository.findStatusByAvailableDateId(date.getId());
+        for (ReserveStatus status : statusList) {
+            if (status == ReserveStatus.BEFORE) {
+                throw new CustomException(ErrorCode.BAD_REQUEST, date.getDate() + "일에 진행 전 예약이 존재하여 수정할 수 없습니다.");
+            }
         }
 
-        if (status == null) {
+        if (statusList.isEmpty()) {
             training.removeDate(date);
             availableDateRepository.delete(date);
         } else {

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/AvailableDate.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/AvailableDate.java
@@ -81,7 +81,11 @@ public class AvailableDate {
     }
 
     public void deleteDate() {
+        closeDate();
         this.deleted = true;
-        this.availableTimes.forEach(AvailableTime::deleteTime);
+        this.availableTimes.forEach(a -> {
+            a.closeTime();
+            a.deleteTime();
+        });
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/ReserveInfo.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/ReserveInfo.java
@@ -40,7 +40,7 @@ public class ReserveInfo extends BaseTimeEntity {
     @OrderBy(value = "date")
     private AvailableDate availableDate;
 
-    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @OneToOne(fetch = FetchType.LAZY)
     @OrderBy(value = "time")
     private AvailableTime availableTime;
 
@@ -92,5 +92,6 @@ public class ReserveInfo extends BaseTimeEntity {
     public void openDateTime() {
         this.getAvailableTime().openTime();
         this.getAvailableDate().openDate();
+        this.availableTime = null;
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
@@ -76,7 +76,7 @@ public class Training extends BaseTimeEntity {
     @NotNull
     private LocalTime endHour;
 
-    @OneToMany(mappedBy = "training", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "training", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     @JsonIgnoreProperties({"training"})
     @OrderBy(value = "date")
     private List<AvailableDate> availableDates;
@@ -114,8 +114,10 @@ public class Training extends BaseTimeEntity {
         this.closed = closed;
     }
 
-    public void updateDeleted(boolean deleted) {
-        this.deleted = deleted;
+    public void executeDelete() {
+        this.deleted = true;
+        this.closed = true;
+        this.getAvailableDates().forEach(AvailableDate::deleteDate);
     }
 
     public void addImages(TrainingDocument document) {

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/trainersTraining/TrainingCreateDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/trainersTraining/TrainingCreateDto.java
@@ -28,7 +28,7 @@ public class TrainingCreateDto {
     @Schema(description = "트레이닝 소개글")
     private String content;
 
-    private List<MultipartFile> images;
+    private List<MultipartFile> images = new ArrayList<>();
 
     @NotBlank
     @Schema(description = "트레이닝이 진행 장소")

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
@@ -14,7 +14,8 @@ import java.util.List;
 
 public interface ReserveInfoRepository extends JpaRepository<ReserveInfo, Long> {
     Page<ReserveInfo> findByTrainerId(Long trainerId, Pageable pageable);
-    boolean existsByTrainingIdAndStatusNotIn(Long training_id, List<@NotNull ReserveStatus> status);
+    boolean existsByTrainingIdAndStatusNotIn(Long trainingId, List<@NotNull ReserveStatus> status);
+    boolean existsByTrainingId(Long trainingId);
 
     List<ReserveInfo> findByReserveDateTimeAndStatus(LocalDateTime now, ReserveStatus status);
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
@@ -21,5 +21,5 @@ public interface ReserveInfoRepository extends JpaRepository<ReserveInfo, Long> 
     Long countByAvailableDateIdAndStatus(Long availableDateId, ReserveStatus status);
 
     @Query("SELECT r.status FROM ReserveInfo r WHERE r.availableDate.id = :availableDateId")
-    ReserveStatus findStatusByAvailableDateId(@Param("availableDateId") Long availableDateId);
+    List<ReserveStatus> findStatusByAvailableDateId(@Param("availableDateId") Long availableDateId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/admin/application/AdminServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/admin/application/AdminServiceImpl.java
@@ -2,19 +2,21 @@ package com.fithub.fithubbackend.domain.admin.application;
 
 import com.fithub.fithubbackend.domain.admin.domain.TrainerCertificationRejectLog;
 import com.fithub.fithubbackend.domain.admin.dto.CertRejectDto;
+import com.fithub.fithubbackend.domain.admin.repository.TrainerCareerTempRepository;
 import com.fithub.fithubbackend.domain.admin.repository.TrainerCertificationRejectLogRepository;
-import com.fithub.fithubbackend.domain.trainer.domain.Trainer;
-import com.fithub.fithubbackend.domain.trainer.domain.TrainerCareer;
-import com.fithub.fithubbackend.domain.trainer.domain.TrainerCertificationRequest;
-import com.fithub.fithubbackend.domain.trainer.domain.TrainerLicenseImg;
+import com.fithub.fithubbackend.domain.admin.repository.TrainerLicenseTempImgRepository;
+import com.fithub.fithubbackend.domain.trainer.domain.*;
 import com.fithub.fithubbackend.domain.trainer.repository.TrainerCertificationRequestRepository;
 import com.fithub.fithubbackend.domain.trainer.repository.TrainerRepository;
+import com.fithub.fithubbackend.domain.user.repository.DocumentRepository;
+import com.fithub.fithubbackend.global.domain.Document;
 import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -22,6 +24,10 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class AdminServiceImpl implements AdminService {
     private final TrainerCertificationRequestRepository trainerCertificationRequestRepository;
+    private final TrainerCareerTempRepository trainerCareerTempRepository;
+    private final TrainerLicenseTempImgRepository trainerLicenseTempImgRepository;
+    private final DocumentRepository documentRepository;
+
     private final TrainerRepository trainerRepository;
 
     private final TrainerCertificationRejectLogRepository rejectLogRepository;
@@ -62,8 +68,20 @@ public class AdminServiceImpl implements AdminService {
     @Transactional
     // TODO: 반려됐다는 알림 보내기?
     public void rejectTrainerCertificateRequest(Long requestId, CertRejectDto dto) {
-        TrainerCertificationRequest trainerCertificationRequest = trainerCertificationRequestRepository.findById(requestId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "트레이너 인증 요청을 찾을 수 없습니다."));
+        TrainerCertificationRequest trainerCertificationRequest = trainerCertificationRequestRepository.findById(requestId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "트레이너 인증 요청을 찾을 수 없습니다."));//
+        List<TrainerLicenseTempImg> licenseTempImgList = trainerCertificationRequest.getLicenseTempImgList();
+
+        List<Document> documentToDeleted = new ArrayList<>();
+        for (TrainerLicenseTempImg trainerLicenseTempImg : licenseTempImgList) {
+            documentToDeleted.add(trainerLicenseTempImg.getDocument());
+        }
+        trainerCareerTempRepository.deleteAll(trainerCertificationRequest.getCareerTempList());
+        trainerLicenseTempImgRepository.deleteAll(trainerCertificationRequest.getLicenseTempImgList());
+        documentRepository.deleteAll(documentToDeleted);
+
         trainerCertificationRequest.requestReject();
+
+        trainerCertificationRequestRepository.saveAndFlush(trainerCertificationRequest);
 
         TrainerCertificationRejectLog rejectLog = TrainerCertificationRejectLog.builder()
                 .trainerCertificationRequest(trainerCertificationRequest)

--- a/src/main/java/com/fithub/fithubbackend/domain/admin/application/AdminServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/admin/application/AdminServiceImpl.java
@@ -9,6 +9,7 @@ import com.fithub.fithubbackend.domain.trainer.domain.*;
 import com.fithub.fithubbackend.domain.trainer.repository.TrainerCertificationRequestRepository;
 import com.fithub.fithubbackend.domain.trainer.repository.TrainerRepository;
 import com.fithub.fithubbackend.domain.user.repository.DocumentRepository;
+import com.fithub.fithubbackend.global.config.s3.AwsS3Uploader;
 import com.fithub.fithubbackend.global.domain.Document;
 import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
@@ -31,6 +32,8 @@ public class AdminServiceImpl implements AdminService {
     private final TrainerRepository trainerRepository;
 
     private final TrainerCertificationRejectLogRepository rejectLogRepository;
+
+    private final AwsS3Uploader awsS3Uploader;
 
     @Override
     @Transactional
@@ -73,8 +76,11 @@ public class AdminServiceImpl implements AdminService {
 
         List<Document> documentToDeleted = new ArrayList<>();
         for (TrainerLicenseTempImg trainerLicenseTempImg : licenseTempImgList) {
-            documentToDeleted.add(trainerLicenseTempImg.getDocument());
+            Document document = trainerLicenseTempImg.getDocument();
+            documentToDeleted.add(document);
+            awsS3Uploader.deleteS3(document.getPath());
         }
+
         trainerCareerTempRepository.deleteAll(trainerCertificationRequest.getCareerTempList());
         trainerLicenseTempImgRepository.deleteAll(trainerCertificationRequest.getLicenseTempImgList());
         documentRepository.deleteAll(documentToDeleted);

--- a/src/main/java/com/fithub/fithubbackend/domain/admin/repository/TrainerCareerTempRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/admin/repository/TrainerCareerTempRepository.java
@@ -1,0 +1,8 @@
+package com.fithub.fithubbackend.domain.admin.repository;
+
+import com.fithub.fithubbackend.domain.trainer.domain.TrainerCareerTemp;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TrainerCareerTempRepository extends JpaRepository<TrainerCareerTemp, Long> {
+
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/admin/repository/TrainerLicenseTempImgRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/admin/repository/TrainerLicenseTempImgRepository.java
@@ -1,0 +1,7 @@
+package com.fithub.fithubbackend.domain.admin.repository;
+
+import com.fithub.fithubbackend.domain.trainer.domain.TrainerLicenseTempImg;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TrainerLicenseTempImgRepository extends JpaRepository<TrainerLicenseTempImg, Long> {
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCertificationRequest.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCertificationRequest.java
@@ -49,5 +49,12 @@ public class TrainerCertificationRequest extends BaseTimeEntity {
 
     public void requestReject() {
         this.rejected = true;
+        clearCareerAndImg();
     }
+
+    public void clearCareerAndImg() {
+        this.careerTempList.clear();
+        this.licenseTempImgList.clear();
+    }
+
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/api/UserController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/api/UserController.java
@@ -7,11 +7,8 @@ import com.fithub.fithubbackend.domain.user.dto.ProfileUpdateDto;
 import com.fithub.fithubbackend.global.domain.AuthUser;
 import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
-import com.fithub.fithubbackend.global.exception.ErrorResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -35,7 +32,6 @@ public class UserController {
 
     @Operation(summary = "프로필 수정", responses = {
             @ApiResponse(responseCode = "200", description = "수정 성공"),
-            @ApiResponse(responseCode = "409", description = "닉네임 중복", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     }, parameters = {
             @Parameter(name="profileUpdateDto", description = "프로필내역")
     })
@@ -47,7 +43,7 @@ public class UserController {
     }
 
 
-    @Operation(summary = "이미지 수정, swagger에서 사용 불가능. postman으로 테스트 가능 (multipart/form-data)", responses = {
+    @Operation(summary = "이미지 수정", responses = {
             @ApiResponse(responseCode = "200", description = "수정 성공"),
     }, parameters = {
             @Parameter(name="image", description = "프로필 이미지 변경 시")

--- a/src/main/java/com/fithub/fithubbackend/domain/user/api/UserController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/api/UserController.java
@@ -4,9 +4,6 @@ import com.fithub.fithubbackend.domain.user.application.UserService;
 import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.domain.user.dto.ProfileDto;
 import com.fithub.fithubbackend.domain.user.dto.ProfileUpdateDto;
-import com.fithub.fithubbackend.domain.user.dto.SignUpDto;
-import com.fithub.fithubbackend.domain.user.dto.SignUpResponseDto;
-import com.fithub.fithubbackend.domain.user.enums.Gender;
 import com.fithub.fithubbackend.global.domain.AuthUser;
 import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
@@ -16,15 +13,10 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
 
 @RestController
 @RequestMapping("/users")
@@ -48,9 +40,10 @@ public class UserController {
             @Parameter(name="profileUpdateDto", description = "프로필내역")
     })
     @PutMapping("/profile/update")
-    public ResponseEntity<ProfileDto> updateProfile(@RequestPart(value = "profileUpdateDto") ProfileUpdateDto profileUpdateDto, @AuthUser User user){
+    public ResponseEntity<String> updateProfile(@RequestBody ProfileUpdateDto profileUpdateDto, @AuthUser User user){
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
-        return ResponseEntity.ok(userService.updateProfile(profileUpdateDto, user));
+        userService.updateProfile(profileUpdateDto, user);
+        return ResponseEntity.ok().body("완료");
     }
 
 
@@ -60,9 +53,10 @@ public class UserController {
             @Parameter(name="image", description = "프로필 이미지 변경 시")
     })
     @PutMapping("/image/update")
-    public ResponseEntity<ProfileDto> updateImage(@RequestPart(value = "image") MultipartFile multipartFile, @AuthUser User user){
+    public ResponseEntity<String> updateImage(@RequestPart(value = "image") MultipartFile multipartFile, @AuthUser User user){
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
-        return ResponseEntity.ok(userService.updateImage(multipartFile, user));
+        userService.updateImage(multipartFile, user);
+        return ResponseEntity.ok().body("완료");
     }
 
 

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/UserService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/UserService.java
@@ -3,13 +3,10 @@ package com.fithub.fithubbackend.domain.user.application;
 import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.domain.user.dto.ProfileDto;
 import com.fithub.fithubbackend.domain.user.dto.ProfileUpdateDto;
-import com.fithub.fithubbackend.domain.user.enums.Gender;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 public interface UserService {
     ProfileDto myProfile(User user);
-    ProfileDto updateProfile(ProfileUpdateDto profileUpdateDto, User user);
-    ProfileDto updateImage(MultipartFile profileImg, User user);
+    void updateProfile(ProfileUpdateDto profileUpdateDto, User user);
+    void updateImage(MultipartFile profileImg, User user);
 }


### PR DESCRIPTION
## pr 유형
- 에러 수정

## 변경 사항
- 프로필 업데이트 수정 (401 에러 난다고 해서 수정)
  - detached된 유저여서 수정사항이 반영되지 않는 문제 save로 수정
  - api 메서드를 사용하는 것 보다 put은 put의 역할만 하고 조회는 GET 메서드를 사용해 하도록 수정
- 트레이너 인증 요청 반려 시 temp 정보 (career, img) 삭제
- 트레이닝 수정: 이미지 추가 후 repo에서 이미지 찾고 없는 이미지 삭제하다보니 추가된 이미지도 삭제됨. 두 개를 바꿔서 먼저 기존에 없는 이미지 삭제 후 새로운 이미지 추가로 수정
- 트레이닝 날짜 수정: 기존에 있던 날짜를 삭제할 때 예약이 있는지 확인하는 코드에서 여러 개를 받아오는 find문인데 하나만 받아오도록 되어있어 에러 발생. List로 가져오도록 수정
- 트레이닝 삭제: soft delete로 하도록 했는데 트레이닝 삭제 시 예약이 아예 없었다면 아예 db에서 삭제 + soft delete 시에는 availableDate, Time도 close, delete 처리하도록 수정

## 테스트 결과
1. 프로필 업데이트
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/e7d4f993-02ff-450d-8d3c-44dcd697a1dc)