### PR TITLE
Feature/training: 엔티티 수정, 지정한 위치 2km 반경 트레이닝 검색 기능 추가, fix: 목록의 트레이닝 찜 여부 조회 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,8 @@ dependencies {
 	// portone (결제 api)
 	implementation 'com.github.iamport:iamport-rest-client-java:0.2.23'
 
+	implementation group: 'org.hibernate', name: 'hibernate-spatial', version: '5.6.14.Final'
+
 	// querydsl
 	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,8 @@ dependencies {
 	// portone (결제 api)
 	implementation 'com.github.iamport:iamport-rest-client-java:0.2.23'
 
-	implementation group: 'org.hibernate', name: 'hibernate-spatial', version: '5.6.14.Final'
+	// db에서 Geometry를 사용
+	implementation group: 'org.hibernate', name: 'hibernate-spatial', version: '6.4.1.Final'
 
 	// querydsl
 	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainerTrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainerTrainingController.java
@@ -57,6 +57,7 @@ public class TrainerTrainingController {
 
     @Operation(summary = "트레이닝 생성, swagger에서 테스트 불가능, 이미지는 모두 images로 주면 됨", responses = {
             @ApiResponse(responseCode = "200", description = "생성됨"),
+            @ApiResponse(responseCode = "400", description = "현재 재직중인 회사가 없어 트레이닝 생성 불가능(트레이닝에는 주소,위도,경도 필요)", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
             @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
             @ApiResponse(responseCode = "403", description = "해당 회원은 트레이너가 아님", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
             @ApiResponse(responseCode = "409", description = "예약 가능 날짜에 현재보다 이전 날짜가 들어있음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainingController.java
@@ -71,7 +71,7 @@ public class TrainingController {
     }
 
     @Operation(summary = "트레이닝 지정 위치로 검색", parameters = {
-            @Parameter(name = "pageable", description = "조회할 목록의 page, size, sort(기본은 id desc(최신 생성 순) 변경 안 할거면 sort 부분은 지우기, title, startDate, endDate, price 지정 가능)")
+            @Parameter(name = "location", description = "위도, 경도")
     }, responses = {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "500", description = "좌표 파싱중에 에러 발생. 좌표 다시 설정해서 보내주기"),

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainingController.java
@@ -1,6 +1,7 @@
 package com.fithub.fithubbackend.domain.Training.api;
 
 import com.fithub.fithubbackend.domain.Training.application.TrainingService;
+import com.fithub.fithubbackend.domain.Training.dto.Location;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingOutlineDto;
 import com.fithub.fithubbackend.domain.Training.dto.review.TrainingReviewDto;
@@ -67,5 +68,16 @@ public class TrainingController {
     public ResponseEntity<Page<TrainingOutlineDto>> searchTrainingByConditions(@RequestBody TrainingSearchConditionDto conditions
             , @PageableDefault(size = 9, sort = "id",  direction = Sort.Direction.DESC) Pageable pageable) {
         return ResponseEntity.ok(trainingService.searchTrainingByConditions(conditions, pageable));
+    }
+
+    @Operation(summary = "트레이닝 지정 위치로 검색", parameters = {
+            @Parameter(name = "pageable", description = "조회할 목록의 page, size, sort(기본은 id desc(최신 생성 순) 변경 안 할거면 sort 부분은 지우기, title, startDate, endDate, price 지정 가능)")
+    }, responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "500", description = "좌표 파싱중에 에러 발생. 좌표 다시 설정해서 보내주기"),
+    })
+    @PostMapping("/search/location")
+    public ResponseEntity<List<TrainingOutlineDto>> searchTrainingByConditions(@RequestBody Location location) {
+        return ResponseEntity.ok(trainingService.searchTrainingByLocation(location.getLatitude(), location.getLongitude()));
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/UserTrainingLikesController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/UserTrainingLikesController.java
@@ -46,7 +46,7 @@ public class UserTrainingLikesController {
             @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
             @ApiResponse(responseCode = "404", description = "찜 여부를 조회할 트레이닝이 존재하지 않음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
     })
-    @GetMapping("/check/list")
+    @PostMapping("/check/list")
     public ResponseEntity<List<Boolean>> checkGivenTrainingListIsLiked(@RequestBody List<Long> trainingIdList, @AuthUser User user) {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         return ResponseEntity.ok(userTrainingLikeService.checkGivenTrainingListIsLiked(trainingIdList, user));

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
@@ -65,6 +65,10 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
         Trainer trainer = findTrainerByUserId(user.getId());
         dateValidate(dto.getStartDate(), dto.getEndDate());
 
+        if (trainer.getPoint() == null) {
+            throw new CustomException(ErrorCode.BAD_REQUEST, "현재 트레이너가 근무지가 없어 생성이 불가능합니다.");
+        }
+
         Training training = Training.builder().dto(dto).trainer(trainer).build();
 
         List<LocalDate> availableDateList = getAvailableDateList(dto.getStartDate(), dto.getEndDate(), dto.getUnableDates());

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainingService.java
@@ -2,8 +2,8 @@ package com.fithub.fithubbackend.domain.Training.application;
 
 import com.fithub.fithubbackend.domain.Training.dto.TrainingInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingOutlineDto;
-import com.fithub.fithubbackend.domain.Training.dto.review.TrainingReviewDto;
 import com.fithub.fithubbackend.domain.Training.dto.TrainingSearchConditionDto;
+import com.fithub.fithubbackend.domain.Training.dto.review.TrainingReviewDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -15,5 +15,5 @@ public interface TrainingService {
     List<TrainingReviewDto> getTrainingReviews(Long id);
 
     Page<TrainingOutlineDto> searchTrainingByConditions(TrainingSearchConditionDto conditions, Pageable pageable);
-
+    List<TrainingOutlineDto> searchTrainingByLocation(Double latitude, Double longitude);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingReservationServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingReservationServiceImpl.java
@@ -45,7 +45,7 @@ public class UserTrainingReservationServiceImpl implements UserTrainingReservati
                 .reservationId(reserveInfo.getId())
                 .trainingId(training.getId())
                 .title(training.getTitle())
-                .location(training.getLocation())
+                .address(training.getAddress())
                 .reserveDateTime(reserveInfo.getReserveDateTime())
                 .price(reserveInfo.getPrice())
                 .impUid(reserveInfo.getImpUid())

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
@@ -56,12 +56,6 @@ public class Training extends BaseTimeEntity {
     private boolean closed;
 
     @NotNull
-    private String location;
-
-    @NotNull
-    private int participants;
-
-    @NotNull
     @ColumnDefault("0")
     private int price;
 
@@ -86,12 +80,10 @@ public class Training extends BaseTimeEntity {
     private boolean deleted;
 
     @Builder
-    public Training(TrainingCreateDto dto, Trainer trainer, Point point) {
+    public Training(TrainingCreateDto dto, Trainer trainer) {
         this.title = dto.getTitle();
         this.content = dto.getContent();
         this.closed = false;
-        this.location = dto.getLocation();
-        this.participants = 0;
         this.price = dto.getPrice();
         this.startDate = dto.getStartDate();
         this.endDate = dto.getEndDate();
@@ -99,7 +91,7 @@ public class Training extends BaseTimeEntity {
         this.endHour = dto.getEndHour();
         this.trainer = trainer;
         this.address = trainer.getAddress();
-        this.point = point;
+        this.point = trainer.getPoint();
         this.availableDates = new ArrayList<>();
         this.images = new ArrayList<>();
         this.deleted = false;

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
@@ -14,6 +14,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.locationtech.jts.geom.Point;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -32,6 +33,12 @@ public class Training extends BaseTimeEntity {
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JsonIgnore
     private Trainer trainer;
+
+    @NotNull
+    private String address;
+
+    @Column(columnDefinition = "point")
+    private Point point;
 
     @NotNull
     @Size(min = 2, max = 100)
@@ -79,7 +86,7 @@ public class Training extends BaseTimeEntity {
     private boolean deleted;
 
     @Builder
-    public Training(TrainingCreateDto dto, Trainer trainer) {
+    public Training(TrainingCreateDto dto, Trainer trainer, Point point) {
         this.title = dto.getTitle();
         this.content = dto.getContent();
         this.closed = false;
@@ -91,6 +98,8 @@ public class Training extends BaseTimeEntity {
         this.startHour = dto.getStartHour();
         this.endHour = dto.getEndHour();
         this.trainer = trainer;
+        this.address = trainer.getAddress();
+        this.point = point;
         this.availableDates = new ArrayList<>();
         this.images = new ArrayList<>();
         this.deleted = false;

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/Location.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/Location.java
@@ -1,10 +1,13 @@
 package com.fithub.fithubbackend.domain.Training.dto;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Location {
     private Double latitude;
     private Double longitude;

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/Location.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/Location.java
@@ -1,0 +1,11 @@
+package com.fithub.fithubbackend.domain.Training.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class Location {
+    private Double latitude;
+    private Double longitude;
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/Location.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/Location.java
@@ -1,5 +1,6 @@
 package com.fithub.fithubbackend.domain.Training.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,6 +10,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Location {
+    @Schema(description = "위도", example = "37.573319")
     private Double latitude;
+
+    @Schema(description = "경도", example = "126.915444")
     private Double longitude;
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainerInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainerInfoDto.java
@@ -12,14 +12,14 @@ public class TrainerInfoDto {
     private Long trainerId;
     private String name;
     private String trainerProfileImg;
-    private String location;
+    private String address;
 
     public static TrainerInfoDto toDto(Trainer trainer) {
         return TrainerInfoDto.builder()
                 .trainerId(trainer.getId())
                 .name(trainer.getName())
                 .trainerProfileImg(trainer.getProfileUrl())
-                .location(trainer.getLocation())
+                .address(trainer.getAddress())
                 .build();
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainersTrainingOutlineDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainersTrainingOutlineDto.java
@@ -14,7 +14,7 @@ public class TrainersTrainingOutlineDto {
     private Long trainingId;
     private String title;
     private int price;
-    private String location;
+    private String address;
 
     private int participants;
 
@@ -32,8 +32,7 @@ public class TrainersTrainingOutlineDto {
         this.trainingId = training.getId();
         this.title = training.getTitle();
         this.price = training.getPrice();
-        this.location = training.getLocation();
-        this.participants = training.getParticipants();
+        this.address = training.getAddress();
         this.startDate = training.getStartDate();
         this.endDate = training.getEndDate();
         this.closed = training.isClosed();

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainingInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainingInfoDto.java
@@ -19,7 +19,7 @@ public class TrainingInfoDto {
 
     private String title;
     private String content;
-    private String location;
+    private String address;
 
     private List<TrainingDocumentDto> images;
 
@@ -39,7 +39,7 @@ public class TrainingInfoDto {
                 .trainerInfoDto(TrainerInfoDto.toDto(training.getTrainer()))
                 .title(training.getTitle())
                 .content(training.getContent())
-                .location(training.getLocation())
+                .address(training.getAddress())
                 .price(training.getPrice())
                 .startDate(training.getStartDate())
                 .endDate(training.getEndDate())

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainingOutlineDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainingOutlineDto.java
@@ -15,7 +15,8 @@ public class TrainingOutlineDto {
     private TrainerInfoDto trainerInfoDto;
     private String title;
     private int price;
-    private String location;
+    private String address;
+    private Double dist;
 
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate startDate;
@@ -29,10 +30,14 @@ public class TrainingOutlineDto {
                 .trainerInfoDto(TrainerInfoDto.toDto(training.getTrainer()))
                 .title(training.getTitle())
                 .price(training.getPrice())
-                .location(training.getLocation())
+                .address(training.getAddress())
                 .startDate(training.getStartDate())
                 .endDate(training.getEndDate())
                 .closed(training.isClosed())
                 .build();
+    }
+
+    public void updateDist(Double dist) {
+        this.dist = dist;
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainingOutlineDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainingOutlineDto.java
@@ -2,6 +2,7 @@ package com.fithub.fithubbackend.domain.Training.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fithub.fithubbackend.domain.Training.domain.Training;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -16,6 +17,8 @@ public class TrainingOutlineDto {
     private String title;
     private int price;
     private String address;
+
+    @Schema(description = "보내준 위치와의 거리. 위치로 트레이닝 검색할 때만 값이 들어가있음")
     private Double dist;
 
     @JsonFormat(pattern = "yyyy-MM-dd")

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/UsersReserveInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/UsersReserveInfoDto.java
@@ -26,7 +26,7 @@ public class UsersReserveInfoDto {
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime reserveDateTime;
 
-    private String location;
+    private String address;
 
     private int price;
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/enums/Direction.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/enums/Direction.java
@@ -1,0 +1,21 @@
+package com.fithub.fithubbackend.domain.Training.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum Direction {
+    NORTH(0.0),
+    WEST(270.0),
+    SOUTH(180.0),
+    EAST(90.0),
+    NORTHWEST(315.0),
+    SOUTHWEST(225.0),
+    SOUTHEAST(135.0),
+    NORTHEAST(45.0);
+
+    private final Double bearing;
+
+    Direction(Double bearing) {
+        this.bearing = bearing;
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/CustomTrainingRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/CustomTrainingRepository.java
@@ -64,7 +64,7 @@ public class CustomTrainingRepository {
                                 reserveInfo.id,
                                 reserveInfo.training.id,
                                 reserveInfo.training.title,
-                                reserveInfo.training.location,
+                                reserveInfo.training.address,
                                 reserveInfo.reserveDateTime,
                                 reserveInfo.status,
                                 reserveInfo.createdDate,

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingRepository.java
@@ -16,6 +16,10 @@ public interface TrainingRepository extends JpaRepository<Training, Long> {
     Page<Training> findAllByDeletedFalseAndTrainerIdAndClosed(Long trainerId, boolean closed, Pageable pageable);
 
     List<Training> findByClosedFalseAndEndDateLessThanEqual(LocalDate now);
-    @Query(value = "SELECT t.title FROM Training t WHERE t.id = :id")
-    String findTitleById(@Param("id") Long id);
+
+    @Query(value = "SELECT * FROM Training AS t WHERE t.deleted = false AND t.closed = false AND MBRContains(ST_LINESTRINGFROMTEXT(:pointFormat), t.point)", nativeQuery = true)
+    List<Training> findByPoint(@Param("pointFormat")String pointFormat, Pageable pageable);
+
+    @Query(value = "SELECT ST_DISTANCE_SPHERE(POINT(:lon, :lat), t.point) AS dist FROM Training t WHERE t.id = :id", nativeQuery = true)
+    Double findDistByPoint(@Param("lon") Double lon, @Param("lat") Double lat, @Param("id") Long id);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/admin/application/AdminServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/admin/application/AdminServiceImpl.java
@@ -60,7 +60,7 @@ public class AdminServiceImpl implements AdminService {
         trainer.updateTrainerLicenseImg(trainerLicenseImgList);
 
         Optional<TrainerCareer> company = trainerCareerList.stream().filter(TrainerCareer::isWorking).findFirst();
-        company.ifPresent(trainerCareer -> trainer.updateLocation(trainerCareer.getCompany()));
+        company.ifPresent(trainerCareer -> trainer.updateAddress(trainerCareer.getAddress()));
 
         trainer.grantPermission();
         trainerRepository.save(trainer);

--- a/src/main/java/com/fithub/fithubbackend/domain/admin/application/AdminServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/admin/application/AdminServiceImpl.java
@@ -60,7 +60,7 @@ public class AdminServiceImpl implements AdminService {
         trainer.updateTrainerLicenseImg(trainerLicenseImgList);
 
         Optional<TrainerCareer> company = trainerCareerList.stream().filter(TrainerCareer::isWorking).findFirst();
-        company.ifPresent(trainerCareer -> trainer.updateAddress(trainerCareer.getAddress()));
+        company.ifPresent(trainer::updateAddress);
 
         trainer.grantPermission();
         trainerRepository.save(trainer);

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerAuthService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerAuthService.java
@@ -2,7 +2,8 @@ package com.fithub.fithubbackend.domain.trainer.application;
 
 import com.fithub.fithubbackend.domain.trainer.dto.TrainerCertificationRequestDto;
 import com.fithub.fithubbackend.domain.user.domain.User;
+import org.locationtech.jts.io.ParseException;
 
 public interface TrainerAuthService {
-    void saveTrainerCertificateRequest(TrainerCertificationRequestDto request, User user);
+    void saveTrainerCertificateRequest(TrainerCertificationRequestDto request, User user) throws ParseException;
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerAuthService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerAuthService.java
@@ -5,5 +5,5 @@ import com.fithub.fithubbackend.domain.user.domain.User;
 import org.locationtech.jts.io.ParseException;
 
 public interface TrainerAuthService {
-    void saveTrainerCertificateRequest(TrainerCertificationRequestDto request, User user) throws ParseException;
+    void saveTrainerCertificateRequest(TrainerCertificationRequestDto request, User user);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/Trainer.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/Trainer.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
+import org.locationtech.jts.geom.Point;
 
 import java.util.List;
 
@@ -39,6 +40,8 @@ public class Trainer extends BaseTimeEntity {
     @Comment("현재 일하는 장소")
     private String address;
 
+    private Point point;
+
     @OneToMany(mappedBy = "trainer", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<TrainerCareer> trainerCareerList;
 
@@ -53,8 +56,9 @@ public class Trainer extends BaseTimeEntity {
         this.profileUrl = user.getProfileImg().getUrl();
     }
 
-    public void updateAddress(String address) {
-        this.address = address;
+    public void updateAddress(TrainerCareer career) {
+        this.address = career.getAddress();
+        this.point = career.getPoint();
     }
     
     public void updateCareerList(List<TrainerCareer> trainerCareerList) {

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/Trainer.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/Trainer.java
@@ -37,7 +37,7 @@ public class Trainer extends BaseTimeEntity {
     private String profileUrl;
 
     @Comment("현재 일하는 장소")
-    private String location;
+    private String address;
 
     @OneToMany(mappedBy = "trainer", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<TrainerCareer> trainerCareerList;
@@ -53,8 +53,8 @@ public class Trainer extends BaseTimeEntity {
         this.profileUrl = user.getProfileImg().getUrl();
     }
 
-    public void updateLocation(String location) {
-        this.location = location;
+    public void updateAddress(String address) {
+        this.address = address;
     }
     
     public void updateCareerList(List<TrainerCareer> trainerCareerList) {

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCareer.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCareer.java
@@ -9,6 +9,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.locationtech.jts.geom.Point;
+
 
 import java.time.LocalDate;
 
@@ -26,13 +28,20 @@ public class TrainerCareer extends BaseTimeEntity {
     @NotNull
     @Size(min = 2)
     private String company;
+
+    @NotNull
+    private String address;
+
+    @Column(columnDefinition = "point")
+    private Point point;
+
     @NotNull
     @Size(min = 2)
     private String work;
 
     @NotNull
     private LocalDate startDate;
-    @NotNull
+
     private LocalDate endDate;
 
     @ColumnDefault("false")
@@ -43,9 +52,11 @@ public class TrainerCareer extends BaseTimeEntity {
     public TrainerCareer(Trainer trainer, TrainerCareerTemp trainerCareerTemp) {
         this.trainer = trainer;
         this.company = trainerCareerTemp.getCompany();
+        this.address = trainerCareerTemp.getAddress();
+        this.point = trainerCareerTemp.getPoint();
         this.work = trainerCareerTemp.getWork();
         this.startDate = trainerCareerTemp.getStartDate();
-        this.endDate = trainerCareerTemp.getEndDate();
+        this.endDate = trainerCareerTemp.getEndDate() != null ? trainerCareerTemp.getEndDate() : null;
         this.working = trainerCareerTemp.isWorking();
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCareerTemp.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCareerTemp.java
@@ -10,6 +10,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.locationtech.jts.geom.Point;
 
 import java.time.LocalDate;
 
@@ -28,13 +29,20 @@ public class TrainerCareerTemp extends BaseTimeEntity {
     @NotNull
     @Size(min = 2)
     private String company;
+
+    @NotNull
+    private String address;
+
+    @Column(columnDefinition = "point")
+    private Point point;
+
     @NotNull
     @Size(min = 2)
     private String work;
 
     @NotNull
     private LocalDate startDate;
-    @NotNull
+
     private LocalDate endDate;
 
     @ColumnDefault("false")
@@ -42,11 +50,13 @@ public class TrainerCareerTemp extends BaseTimeEntity {
     private boolean working;
 
     @Builder
-    public TrainerCareerTemp (TrainerCareerRequestDto dto) {
+    public TrainerCareerTemp (TrainerCareerRequestDto dto, Point point) {
         this.company = dto.getCompany();
+        this.address = dto.getAddress();
+        this.point = point;
         this.work = dto.getWork();
         this.startDate = dto.getStartDate();
-        this.endDate = dto.getEndDate();
+        this.endDate = dto.getEndDate() != null ? dto.getEndDate() : null;
         this.working = dto.isWorking();
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerCareerRequestDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerCareerRequestDto.java
@@ -14,9 +14,19 @@ import java.time.LocalDate;
 @Schema(description = "트레이너 인증 요청 시 작성하는 경력 사항")
 public class TrainerCareerRequestDto {
     @NotBlank
-    @Schema(description = "근무지")
+    @Schema(description = "회사명")
     private String company;
 
+    @NotNull
+    @Schema(description = "회사 주소")
+    private String address;
+
+    @Schema(description = "경도")
+    private Double longitude;
+
+    @Schema(description = "위도")
+    private Double latitude;
+    
     @NotBlank
     @Schema(description = "담당 업무")
     private String work;
@@ -26,7 +36,6 @@ public class TrainerCareerRequestDto {
     @Schema(description = "입사년월")
     private LocalDate startDate;
 
-    @NotNull
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     @Schema(description = "퇴사년월")
     private LocalDate endDate;

--- a/src/main/java/com/fithub/fithubbackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/fithub/fithubbackend/global/exception/ErrorCode.java
@@ -35,7 +35,8 @@ public enum ErrorCode {
     DATE_OR_TIME_ERROR(HttpStatus.BAD_REQUEST, "불가능한 날짜 또는 시간대입니다."),
     PERMISSION_DENIED(HttpStatus.FORBIDDEN, "해당 작업을 수행할 권한이 없습니다."),
 
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.");
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    POINT_PARSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "좌표 변환 중 에러가 발생했습니다. 좌표를 다시 설정해주세요");
     private final HttpStatus httpStatus;
     private final String message;
 }

--- a/src/main/java/com/fithub/fithubbackend/global/util/GeometryUtil.java
+++ b/src/main/java/com/fithub/fithubbackend/global/util/GeometryUtil.java
@@ -1,0 +1,43 @@
+package com.fithub.fithubbackend.global.util;
+
+import com.fithub.fithubbackend.domain.Training.dto.Location;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GeometryUtil {
+    public static Location calculate(Double baseLatitude, Double baseLongitude, Double distance,
+                                     Double bearing) {
+        Double radianLatitude = toRadian(baseLatitude);
+        Double radianLongitude = toRadian(baseLongitude);
+        Double radianAngle = toRadian(bearing);
+        Double distanceRadius = distance / 6371.01;
+
+        Double latitude = Math.asin(sin(radianLatitude) * cos(distanceRadius) +
+                cos(radianLatitude) * sin(distanceRadius) * cos(radianAngle));
+        Double longitude = radianLongitude + Math.atan2(sin(radianAngle) * sin(distanceRadius) *
+                cos(radianLatitude), cos(distanceRadius) - sin(radianLatitude) * sin(latitude));
+
+        longitude = normalizeLongitude(longitude);
+        return new Location(toDegree(latitude), toDegree(longitude));
+    }
+
+    private static Double toRadian(Double coordinate) {
+        return coordinate * Math.PI / 180.0;
+    }
+
+    private static Double toDegree(Double coordinate) {
+        return coordinate * 180.0 / Math.PI;
+    }
+
+    private static Double sin(Double coordinate) {
+        return Math.sin(coordinate);
+    }
+
+    private static Double cos(Double coordinate) {
+        return Math.cos(coordinate);
+    }
+
+    private static Double normalizeLongitude(Double longitude) {
+        return (longitude + 540) % 360 - 180;
+    }
+}


### PR DESCRIPTION
## pr 유형
- 엔티티 수정
- 기능 추가

## 변경사항
- 트레이너의 위치 -> 주소로 컬럼 수정
- db에서 geometry 사용을 위해 build에 hibernate-spatial 추가 (application.yml도 수정됨)
- 트레이너, 트레이너 경력, 트레이닝에 주소,좌표(경도,위도) 추가
- 트레이너 인증 요청,인증 승인 시 경도,위도 좌표 넣어주도록 수정
- 트레이닝 생성 시 트레이너의 현재 직장 좌표 사용
- 지정한 위치 2km 반경의 트레이닝 검색 기능 추가
- 주어진 목록의 트레이닝 찜 여부 조회 시 requestBody로 목록을 받아서 Get -> Post로 변경

## 테스트 결과
- 트레이너 인증 요청 시 위도,경도,주소 넣기
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/df322006-74cf-4d4a-a3ee-dd1df5164092)

- 트레이너 정보에 Point가 들어가있음
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/1ee2830c-9ab7-4ce8-88b9-0a5c87eccb1f)

- 경도, 위도 보내주면 2km 반경의 트레이닝 검색 기능
[
    {
        "id": 3,
        "trainerInfoDto": {
            "trainerId": 2,
            "name": "트레이너",
            "trainerProfileImg": "https://fithub-bucket.s3.ap-northeast-2.amazonaws.com/profiles/1590f5b4-12b8-4ef4-a19f-4bf838dd2c60",
            "address": "~"
        },
        "title": "작심삼일 타파2",
        "price": 10000,
        "address": "~",
        "dist": 857.1267042646435,
        "startDate": "2024-03-02",
        "endDate": "2024-03-05",
        "closed": false
    },
    {
        "id": 4,
        "trainerInfoDto": {
            "trainerId": 3,
            "name": "trainer",
            "trainerProfileImg": "https://fithub-bucket.s3.ap-northeast-2.amazonaws.com/profiles/default.jpg",
            "address": "~"
        },
        "title": "작심삼일 타파2",
        "price": 10000,
        "address": "~",
        "dist": 1036.7300840131552,
        "startDate": "2024-03-02",
        "endDate": "2024-03-05",
        "closed": false
    }
]

## 추가 변경 사항
- application.yml: spring.jpa.database-platform: org.hibernate.spatial.dialect.mariadb.MariaDB103SpatialDialect 추가