### PR TITLE
feat: 트레이너 경력, 자격증 관련 작업 기능 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainerTrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainerTrainingController.java
@@ -33,7 +33,7 @@ import java.util.List;
 
 @Tag(name = "trainer's training (트레이너의 트레이닝)", description = "트레이너가 사용하는 트레이닝 관련 api (트레이너 권한 필요)")
 @RestController
-@RequestMapping("/trainer/training")
+@RequestMapping("/trainers/training")
 @RequiredArgsConstructor
 public class TrainerTrainingController {
 

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerController.java
@@ -9,11 +9,19 @@ import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.global.domain.AuthUser;
 import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
+import com.fithub.fithubbackend.global.exception.ErrorResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+@Tag(name = "trainers (트레이너 경력, 자격증 작업)", description = "트레이너의 트레이닝 외의 작업")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/trainers")
@@ -21,36 +29,65 @@ public class TrainerController {
 
     private final TrainerService trainerService;
 
+    @Operation(summary = "트레이너의 경력, 자격증 이미지 조회", responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
+    })
     @GetMapping("/spec")
     public ResponseEntity<TrainerSpecDto> getTrainersSpec(@AuthUser User user) {
         if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         return ResponseEntity.ok(trainerService.getTrainersSpec(user.getId()));
     }
 
+    @Operation(summary = "트레이너 경력 하나 조회", responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
+    }, parameters = {
+            @Parameter(name="careerId", description = "/spec 조회로 얻은 careerList에 있는 careerId")
+    })
     @GetMapping("/careers")
     public ResponseEntity<TrainerCareerDto> getTrainerCareer(@AuthUser User user, @RequestParam Long careerId) {
         if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         return ResponseEntity.ok(trainerService.getTrainerCareer(careerId));
     }
 
+    @Operation(summary = "트레이너 자격증 하나 조회", responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
+    })
     @GetMapping("/licenses")
     public ResponseEntity<TrainerLicenseDto> getTrainerLicenseImg(@AuthUser User user, @RequestParam Long licenseId) {
         if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         return ResponseEntity.ok(trainerService.getTrainerLicenseImg(licenseId));
     }
 
+    @Operation(summary = "트레이너 경력 추가", responses = {
+            @ApiResponse(responseCode = "200", description = "추가 완료"),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
+    })
     @PostMapping("/careers")
     public ResponseEntity<Long> createTrainerCareer(@AuthUser User user, @RequestBody TrainerCareerRequestDto dto) {
         if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         return ResponseEntity.ok(trainerService.createTrainerCareer(user.getId(), dto));
     }
 
+    @Operation(summary = "트레이너 자격증 추가", responses = {
+            @ApiResponse(responseCode = "200", description = "추가 완료"),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "500", description = "s3에 파일 업로드 실패", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
+    })
     @PostMapping("/licenses")
     public ResponseEntity<Long> createTrainerLicenseImg(@AuthUser User user, @RequestPart MultipartFile file) {
         if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         return ResponseEntity.ok(trainerService.createTrainerLicenseImg(user.getId(), file));
     }
 
+    @Operation(summary = "트레이너 경력 하나 수정", responses = {
+            @ApiResponse(responseCode = "200", description = "수정 완료"),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "403", description = "경력을 수정할 권한이 없음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "500", description = "좌표 파싱 에러", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
+    })
     @PutMapping("/careers")
     public ResponseEntity<String> updateTrainerCareer(@AuthUser User user, @RequestParam Long careerId, @RequestBody TrainerCareerRequestDto dto) {
         if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
@@ -58,6 +95,11 @@ public class TrainerController {
         return ResponseEntity.ok().body("완료");
     }
 
+    @Operation(summary = "트레이너 경력 하나 삭제", responses = {
+            @ApiResponse(responseCode = "200", description = "삭제 완료"),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "403", description = "삭제 권한 없음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
+    })
     @DeleteMapping("/careers")
     public ResponseEntity<String> deleteTrainerCareer(@AuthUser User user, @RequestParam Long careerId) {
         if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
@@ -65,6 +107,11 @@ public class TrainerController {
         return ResponseEntity.ok().body("완료");
     }
 
+    @Operation(summary = "트레이너 자격증 하나 삭제", responses = {
+            @ApiResponse(responseCode = "200", description = "삭제 완료"),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "403", description = "삭제 권한 없음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+    })
     @DeleteMapping("/licenses")
     public ResponseEntity<String> deleteTrainerLicenseImg(@AuthUser User user, @RequestParam Long licenseId) {
         if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerController.java
@@ -64,4 +64,11 @@ public class TrainerController {
         trainerService.deleteTrainerCareer(user.getId(), careerId);
         return ResponseEntity.ok().body("완료");
     }
+
+    @DeleteMapping("/licenses")
+    public ResponseEntity<String> deleteTrainerLicenseImg(@AuthUser User user, @RequestParam Long licenseId) {
+        if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        trainerService.deleteTrainerLicenseImg(user.getId(), licenseId);
+        return ResponseEntity.ok().body("완료");
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerController.java
@@ -50,4 +50,11 @@ public class TrainerController {
         if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         return ResponseEntity.ok(trainerService.createTrainerLicenseImg(user.getId(), file));
     }
+
+    @PutMapping("/careers")
+    public ResponseEntity<String> updateTrainerCareer(@AuthUser User user, @RequestParam Long careerId, @RequestBody TrainerCareerRequestDto dto) {
+        if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        trainerService.updateTrainerCareer(user.getId(), careerId, dto);
+        return ResponseEntity.ok().body("완료");
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerController.java
@@ -1,14 +1,17 @@
 package com.fithub.fithubbackend.domain.trainer.api;
 
 import com.fithub.fithubbackend.domain.trainer.application.TrainerService;
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerCareerDto;
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerCareerRequestDto;
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerLicenseDto;
 import com.fithub.fithubbackend.domain.trainer.dto.TrainerSpecDto;
 import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.global.domain.AuthUser;
+import com.fithub.fithubbackend.global.exception.CustomException;
+import com.fithub.fithubbackend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,9 +22,25 @@ public class TrainerController {
 
     @GetMapping("/spec")
     public ResponseEntity<TrainerSpecDto> getTrainersSpec(@AuthUser User user) {
+        if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         return ResponseEntity.ok(trainerService.getTrainersSpec(user.getId()));
     }
 
-//    @PostMapping("/careers")
-//    public ResponseEntity<>
+    @GetMapping("/careers")
+    public ResponseEntity<TrainerCareerDto> getTrainerCareer(@AuthUser User user, @RequestParam Long careerId) {
+        if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        return ResponseEntity.ok(trainerService.getTrainerCareer(careerId));
+    }
+
+    @GetMapping("/licenses")
+    public ResponseEntity<TrainerLicenseDto> getTrainerLicenseImg(@AuthUser User user, @RequestParam Long licenseId) {
+        if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        return ResponseEntity.ok(trainerService.getTrainerLicenseImg(licenseId));
+    }
+
+    @PostMapping("/careers")
+    public ResponseEntity<Long> createTrainerCareer(@AuthUser User user, @RequestBody TrainerCareerRequestDto dto) {
+        if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        return ResponseEntity.ok(trainerService.createTrainerCareer(user.getId(), dto));
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerController.java
@@ -57,4 +57,11 @@ public class TrainerController {
         trainerService.updateTrainerCareer(user.getId(), careerId, dto);
         return ResponseEntity.ok().body("완료");
     }
+
+    @DeleteMapping("/careers")
+    public ResponseEntity<String> deleteTrainerCareer(@AuthUser User user, @RequestParam Long careerId) {
+        if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        trainerService.deleteTrainerCareer(user.getId(), careerId);
+        return ResponseEntity.ok().body("완료");
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerController.java
@@ -1,0 +1,27 @@
+package com.fithub.fithubbackend.domain.trainer.api;
+
+import com.fithub.fithubbackend.domain.trainer.application.TrainerService;
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerSpecDto;
+import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.global.domain.AuthUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/trainers")
+public class TrainerController {
+
+    private final TrainerService trainerService;
+
+    @GetMapping("/spec")
+    public ResponseEntity<TrainerSpecDto> getTrainersSpec(@AuthUser User user) {
+        return ResponseEntity.ok(trainerService.getTrainersSpec(user.getId()));
+    }
+
+//    @PostMapping("/careers")
+//    public ResponseEntity<>
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerController.java
@@ -12,6 +12,7 @@ import com.fithub.fithubbackend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -42,5 +43,11 @@ public class TrainerController {
     public ResponseEntity<Long> createTrainerCareer(@AuthUser User user, @RequestBody TrainerCareerRequestDto dto) {
         if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         return ResponseEntity.ok(trainerService.createTrainerCareer(user.getId(), dto));
+    }
+
+    @PostMapping("/licenses")
+    public ResponseEntity<Long> createTrainerLicenseImg(@AuthUser User user, @RequestPart MultipartFile file) {
+        if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        return ResponseEntity.ok(trainerService.createTrainerLicenseImg(user.getId(), file));
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerService.java
@@ -1,7 +1,15 @@
 package com.fithub.fithubbackend.domain.trainer.application;
 
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerCareerDto;
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerCareerRequestDto;
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerLicenseDto;
 import com.fithub.fithubbackend.domain.trainer.dto.TrainerSpecDto;
 
 public interface TrainerService {
     TrainerSpecDto getTrainersSpec(Long userId);
+
+    TrainerCareerDto getTrainerCareer(Long careerId);
+    TrainerLicenseDto getTrainerLicenseImg(Long licenseImgId);
+
+    Long createTrainerCareer(Long userId, TrainerCareerRequestDto dto);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerService.java
@@ -1,0 +1,7 @@
+package com.fithub.fithubbackend.domain.trainer.application;
+
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerSpecDto;
+
+public interface TrainerService {
+    TrainerSpecDto getTrainersSpec(Long userId);
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerService.java
@@ -16,4 +16,6 @@ public interface TrainerService {
     Long createTrainerLicenseImg(Long userId, MultipartFile file);
 
     void updateTrainerCareer(Long userId, Long careerId, TrainerCareerRequestDto dto);
+
+    void deleteTrainerCareer(Long userId, Long careerId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerService.java
@@ -4,6 +4,7 @@ import com.fithub.fithubbackend.domain.trainer.dto.TrainerCareerDto;
 import com.fithub.fithubbackend.domain.trainer.dto.TrainerCareerRequestDto;
 import com.fithub.fithubbackend.domain.trainer.dto.TrainerLicenseDto;
 import com.fithub.fithubbackend.domain.trainer.dto.TrainerSpecDto;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface TrainerService {
     TrainerSpecDto getTrainersSpec(Long userId);
@@ -12,4 +13,5 @@ public interface TrainerService {
     TrainerLicenseDto getTrainerLicenseImg(Long licenseImgId);
 
     Long createTrainerCareer(Long userId, TrainerCareerRequestDto dto);
+    Long createTrainerLicenseImg(Long userId, MultipartFile file);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerService.java
@@ -18,4 +18,5 @@ public interface TrainerService {
     void updateTrainerCareer(Long userId, Long careerId, TrainerCareerRequestDto dto);
 
     void deleteTrainerCareer(Long userId, Long careerId);
+    void deleteTrainerLicenseImg(Long userId, Long licenseId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerService.java
@@ -14,4 +14,6 @@ public interface TrainerService {
 
     Long createTrainerCareer(Long userId, TrainerCareerRequestDto dto);
     Long createTrainerLicenseImg(Long userId, MultipartFile file);
+
+    void updateTrainerCareer(Long userId, Long careerId, TrainerCareerRequestDto dto);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerServiceImpl.java
@@ -1,18 +1,30 @@
 package com.fithub.fithubbackend.domain.trainer.application;
 
 import com.fithub.fithubbackend.domain.trainer.domain.Trainer;
+import com.fithub.fithubbackend.domain.trainer.domain.TrainerCareer;
+import com.fithub.fithubbackend.domain.trainer.domain.TrainerLicenseImg;
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerCareerDto;
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerCareerRequestDto;
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerLicenseDto;
 import com.fithub.fithubbackend.domain.trainer.dto.TrainerSpecDto;
+import com.fithub.fithubbackend.domain.trainer.repository.TrainerCareerRepository;
+import com.fithub.fithubbackend.domain.trainer.repository.TrainerLicenseImgRepository;
 import com.fithub.fithubbackend.domain.trainer.repository.TrainerRepository;
 import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class TrainerServiceImpl implements TrainerService {
     private final TrainerRepository trainerRepository;
-
+    private final TrainerCareerRepository trainerCareerRepository;
+    private final TrainerLicenseImgRepository trainerLicenseImgRepository;
 
     @Override
     public TrainerSpecDto getTrainersSpec(Long userId) {
@@ -23,8 +35,46 @@ public class TrainerServiceImpl implements TrainerService {
                 .build();
     }
 
+    @Override
+    public TrainerCareerDto getTrainerCareer(Long careerId) {
+        TrainerCareer trainerCareer = trainerCareerRepository.findById(careerId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "해당 경력을 찾을 수 없습니다."));
+        return TrainerCareerDto.builder().career(trainerCareer).build();
+    }
+
+    @Override
+    public TrainerLicenseDto getTrainerLicenseImg(Long licenseImgId) {
+        TrainerLicenseImg trainerLicenseImg = trainerLicenseImgRepository.findById(licenseImgId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "해당 자격증 이미지를 찾을 수 없습니다."));
+        return TrainerLicenseDto.builder().licenseImg(trainerLicenseImg).build();
+    }
+
+    @Override
+    @Transactional
+    public Long createTrainerCareer(Long userId, TrainerCareerRequestDto dto) {
+        Trainer trainer = findTrainerByUserId(userId);
+        Point point = parsePoint(dto.getLatitude(), dto.getLongitude());
+
+        TrainerCareer trainerCareer = TrainerCareer.careerBuilder()
+                .trainer(trainer)
+                .dto(dto)
+                .point(point)
+                .careerBuild();
+
+        return trainerCareerRepository.save(trainerCareer).getId();
+    }
+
+    private Point parsePoint(Double latitude, Double longitude) {
+        try {
+            return latitude != null && longitude != null ?
+                    (Point) new WKTReader().read(String.format("POINT(%s %s)", longitude, latitude))
+                    : null;
+        } catch (ParseException e) {
+            throw new CustomException(ErrorCode.POINT_PARSING_ERROR);
+        }
+    }
+
     private Trainer findTrainerByUserId (Long userId) {
         return trainerRepository.findByUserId(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.PERMISSION_DENIED, "해당 회원은 트레이너가 아님"));
     }
+
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerServiceImpl.java
@@ -1,0 +1,30 @@
+package com.fithub.fithubbackend.domain.trainer.application;
+
+import com.fithub.fithubbackend.domain.trainer.domain.Trainer;
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerSpecDto;
+import com.fithub.fithubbackend.domain.trainer.repository.TrainerRepository;
+import com.fithub.fithubbackend.global.exception.CustomException;
+import com.fithub.fithubbackend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TrainerServiceImpl implements TrainerService {
+    private final TrainerRepository trainerRepository;
+
+
+    @Override
+    public TrainerSpecDto getTrainersSpec(Long userId) {
+        Trainer trainer = findTrainerByUserId(userId);
+        return TrainerSpecDto.builder()
+                .trainerCareerList(trainer.getTrainerCareerList())
+                .trainerLicenseList(trainer.getTrainerLicenseImgList())
+                .build();
+    }
+
+    private Trainer findTrainerByUserId (Long userId) {
+        return trainerRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PERMISSION_DENIED, "해당 회원은 트레이너가 아님"));
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerServiceImpl.java
@@ -97,6 +97,19 @@ public class TrainerServiceImpl implements TrainerService {
         career.updateCareer(dto, point);
     }
 
+    @Override
+    @Transactional
+    public void deleteTrainerCareer(Long userId, Long careerId) {
+        Trainer trainer = findTrainerByUserId(userId);
+        TrainerCareer career = findCareerById(careerId);
+
+        if (!career.getTrainer().getId().equals(trainer.getId())) {
+            throw new CustomException(ErrorCode.PERMISSION_DENIED);
+        }
+
+        trainerCareerRepository.delete(career);
+    }
+
     private Point parsePoint(Double latitude, Double longitude) {
         try {
             return latitude != null && longitude != null ?

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerServiceImpl.java
@@ -110,6 +110,20 @@ public class TrainerServiceImpl implements TrainerService {
         trainerCareerRepository.delete(career);
     }
 
+    @Override
+    @Transactional
+    public void deleteTrainerLicenseImg(Long userId, Long licenseId) {
+        Trainer trainer = findTrainerByUserId(userId);
+        TrainerLicenseImg licenseImg = findLicenseImgById(licenseId);
+
+        if (!licenseImg.getTrainer().getId().equals(trainer.getId())) {
+            throw new CustomException(ErrorCode.PERMISSION_DENIED);
+        }
+
+        s3Uploader.deleteS3(licenseImg.getDocument().getPath());
+        trainerLicenseImgRepository.delete(licenseImg);
+    }
+
     private Point parsePoint(Double latitude, Double longitude) {
         try {
             return latitude != null && longitude != null ?
@@ -128,6 +142,11 @@ public class TrainerServiceImpl implements TrainerService {
     private TrainerCareer findCareerById(Long careerId) {
         return trainerCareerRepository.findById(careerId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "해당 경력을 찾을 수 없습니다."));
+    }
+
+    private TrainerLicenseImg findLicenseImgById(Long licenseId) {
+        return trainerLicenseImgRepository.findById(licenseId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "해당 자격증 이미지를 찾을 수 없습니다."));
     }
 
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/Trainer.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/Trainer.java
@@ -3,6 +3,7 @@ package com.fithub.fithubbackend.domain.trainer.domain;
 
 import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.global.common.BaseTimeEntity;
+import com.fithub.fithubbackend.global.domain.Document;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -67,6 +68,14 @@ public class Trainer extends BaseTimeEntity {
 
     public void updateTrainerLicenseImg(List<TrainerLicenseImg> trainerLicenseImgList) {
         this.trainerLicenseImgList = trainerLicenseImgList;
+    }
+
+    public void linkedToUserName(String name) {
+        this.name = name;
+    }
+
+    public void linkedToUserProfileImg(Document document) {
+        this.profileUrl = document.getUrl();
     }
 
     public void grantPermission() {

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCareer.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCareer.java
@@ -1,5 +1,6 @@
 package com.fithub.fithubbackend.domain.trainer.domain;
 
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerCareerRequestDto;
 import com.fithub.fithubbackend.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
@@ -58,5 +59,17 @@ public class TrainerCareer extends BaseTimeEntity {
         this.startDate = trainerCareerTemp.getStartDate();
         this.endDate = trainerCareerTemp.getEndDate() != null ? trainerCareerTemp.getEndDate() : null;
         this.working = trainerCareerTemp.isWorking();
+    }
+
+    @Builder(builderMethodName = "careerBuilder", buildMethodName = "careerBuild")
+    public TrainerCareer(Trainer trainer, TrainerCareerRequestDto dto, Point point) {
+        this.trainer = trainer;
+        this.company = dto.getCompany();
+        this.address = dto.getAddress();
+        this.point = point;
+        this.work = dto.getWork();
+        this.working = dto.isWorking();
+        this.startDate = dto.getStartDate();
+        this.endDate = dto.getEndDate() != null ? dto.getEndDate() : null;
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCareer.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCareer.java
@@ -72,4 +72,14 @@ public class TrainerCareer extends BaseTimeEntity {
         this.startDate = dto.getStartDate();
         this.endDate = dto.getEndDate() != null ? dto.getEndDate() : null;
     }
+
+    public void updateCareer(TrainerCareerRequestDto dto, Point point) {
+        this.company = dto.getCompany();
+        this.address = dto.getAddress();
+        this.point = point;
+        this.work = dto.getWork();
+        this.working = dto.isWorking();
+        this.startDate = dto.getStartDate();
+        this.endDate = dto.getEndDate() != null ? dto.getEndDate() : null;
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerCareerDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerCareerDto.java
@@ -1,0 +1,50 @@
+package com.fithub.fithubbackend.domain.trainer.dto;
+
+import com.fithub.fithubbackend.domain.trainer.domain.TrainerCareer;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrainerCareerDto {
+
+    @NotNull
+    private Long careerId;
+
+    @NotNull
+    private String company;
+
+    @NotNull
+    private String address;
+
+//    private Point point;
+
+    @NotNull
+    private String work;
+
+    @NotNull
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    @NotNull
+    private boolean working;
+
+    @Builder
+    public TrainerCareerDto (TrainerCareer career) {
+        this.careerId = career.getId();
+        this.company = career.getCompany();
+        this.address = career.getAddress();
+//        this.point = career.getPoint() != null ? career.getPoint() : null;
+        this.startDate = career.getStartDate();
+        this.endDate = career.getEndDate() != null ? career.getEndDate() : null;
+        this.work = career.getWork();
+        this.working = career.isWorking();
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerCareerDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerCareerDto.java
@@ -23,8 +23,6 @@ public class TrainerCareerDto {
     @NotNull
     private String address;
 
-//    private Point point;
-
     @NotNull
     private String work;
 
@@ -41,7 +39,6 @@ public class TrainerCareerDto {
         this.careerId = career.getId();
         this.company = career.getCompany();
         this.address = career.getAddress();
-//        this.point = career.getPoint() != null ? career.getPoint() : null;
         this.startDate = career.getStartDate();
         this.endDate = career.getEndDate() != null ? career.getEndDate() : null;
         this.work = career.getWork();

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerLicenseDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerLicenseDto.java
@@ -1,0 +1,28 @@
+package com.fithub.fithubbackend.domain.trainer.dto;
+
+import com.fithub.fithubbackend.domain.trainer.domain.TrainerLicenseImg;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrainerLicenseDto {
+    private Long licenseId;
+
+    @NotNull
+    private String url;
+
+    @NotNull
+    private String inputName;
+
+    @Builder
+    public TrainerLicenseDto (TrainerLicenseImg licenseImg) {
+        this.licenseId = licenseImg.getId();
+        this.url = licenseImg.getDocument().getUrl();
+        this.inputName = licenseImg.getDocument().getInputName();
+    }
+
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerSpecDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerSpecDto.java
@@ -1,0 +1,23 @@
+package com.fithub.fithubbackend.domain.trainer.dto;
+
+import com.fithub.fithubbackend.domain.trainer.domain.TrainerCareer;
+import com.fithub.fithubbackend.domain.trainer.domain.TrainerLicenseImg;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrainerSpecDto {
+    private List<TrainerCareerDto> trainerCareerList;
+    private List<TrainerLicenseDto> trainerLicenseList;
+
+    @Builder
+    public TrainerSpecDto(List<TrainerCareer> trainerCareerList, List<TrainerLicenseImg> trainerLicenseList) {
+        this.trainerCareerList = trainerCareerList.stream().map(c -> TrainerCareerDto.builder().career(c).build()).toList();
+        this.trainerLicenseList = trainerLicenseList.stream().map(l -> TrainerLicenseDto.builder().licenseImg(l).build()).toList();
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/repository/TrainerCareerRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/repository/TrainerCareerRepository.java
@@ -1,0 +1,7 @@
+package com.fithub.fithubbackend.domain.trainer.repository;
+
+import com.fithub.fithubbackend.domain.trainer.domain.TrainerCareer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TrainerCareerRepository extends JpaRepository<TrainerCareer, Long> {
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/repository/TrainerLicenseImgRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/repository/TrainerLicenseImgRepository.java
@@ -1,0 +1,7 @@
+package com.fithub.fithubbackend.domain.trainer.repository;
+
+import com.fithub.fithubbackend.domain.trainer.domain.TrainerLicenseImg;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TrainerLicenseImgRepository extends JpaRepository<TrainerLicenseImg, Long> {
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/UserServiceImpl.java
@@ -1,5 +1,7 @@
 package com.fithub.fithubbackend.domain.user.application;
 
+import com.fithub.fithubbackend.domain.trainer.domain.Trainer;
+import com.fithub.fithubbackend.domain.trainer.repository.TrainerRepository;
 import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.domain.user.dto.ProfileDto;
 import com.fithub.fithubbackend.domain.user.dto.ProfileUpdateDto;
@@ -16,12 +18,15 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Optional;
+
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
+    private final TrainerRepository trainerRepository;
     private final DocumentRepository documentRepository;
     private final AwsS3Uploader awsS3Uploader;
 
@@ -49,6 +54,8 @@ public class UserServiceImpl implements UserService {
         try {
             user.updateProfile(profileUpdateDto);
             userRepository.save(user);
+            Optional<Trainer> optionalTrainer = trainerRepository.findByUserId(user.getId());
+            optionalTrainer.ifPresent(t -> t.linkedToUserName(user.getName()));
         } catch (Exception e) {
             throw new CustomException(ErrorCode.UPLOAD_PROFILE_ERROR, "프로필 업데이트 중 오류가 발생했습니다");
         }
@@ -71,6 +78,8 @@ public class UserServiceImpl implements UserService {
             documentRepository.save(document);
             user.updateProfileImg(document);
             userRepository.save(user);
+            Optional<Trainer> optionalTrainer = trainerRepository.findByUserId(user.getId());
+            optionalTrainer.ifPresent(t -> t.linkedToUserProfileImg(document));
         } catch (Exception e) {
             throw new CustomException(ErrorCode.UPLOAD_PROFILE_ERROR, "이미지 업데이트 중 오류가 발생했습니다");
         }

--- a/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
@@ -67,7 +67,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 HttpMethod.GET, PERMIT_ALL_GET_PATTERNS).permitAll()
 //                        .requestMatchers("/**").hasRole("USER")
-                        .requestMatchers("/trainer/training/**").hasRole("TRAINER")
+                        .requestMatchers("/trainers/**").hasRole("TRAINER")
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## pr 유형
- 기능 추가

## 변경 사항
- 사용자 프로필 업데이트 시, 사용자가 트레이너면 트레이너의 name도 변경 + 이미지 url도 변경하도록 수정
- 트레이너의 경력, 자격증 조회 기능 추가
- 트레이너의 경력 추가, 자격증 추가
- 트레이너의 경력 수정 기능 추가
- 트레이너의 경력, 자격증 삭제
- **트레이너 관련 api를 trainer -> trainers로 변경**

## 테스트 결과
- 트레이너 스펙 조회
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/6d15eb22-1718-4dd7-b8fe-74df457e2f28)

-트레이너 경력 추가
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/ee18899d-da94-411d-bf25-ae859add7dfe)

- 트레이너 자격증 추가
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/17b2b55a-7170-427a-87a3-74f5ed1dafa1)

- 트레이너 경력 수정
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/9d2c6878-0e84-479c-9cc9-5da6f03b58c5)

![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/a906654a-0e79-48c0-a469-0782ed32308d)
