### PR TITLE
feat: 트레이너 경력 추가 및 수정 시 현 근무지 주소 업데이트 기능 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainerTrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainerTrainingController.java
@@ -81,7 +81,7 @@ public class TrainerTrainingController {
         return ResponseEntity.ok(trainerTrainingService.updateTrainingContent(dto, trainingId, user.getEmail()));
     }
 
-    @Operation(summary = "트레이닝 날짜, 시간 수정을 위해 그 날짜들에 있는 진행 전 예약 수 받아오기", responses = {
+    @Operation(summary = "트레이닝 날짜 수정을 위해 그 날짜들에 있는 진행 전 예약 수 받아오기", responses = {
             @ApiResponse(responseCode = "200", description = "성공"),
             @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
     })

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
@@ -2,7 +2,6 @@ package com.fithub.fithubbackend.domain.Training.application;
 
 import com.fithub.fithubbackend.domain.Training.domain.*;
 import com.fithub.fithubbackend.domain.Training.dto.TrainersTrainingOutlineDto;
-import com.fithub.fithubbackend.domain.Training.dto.TrainingAvailableTimeDto;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.TrainersReserveInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.TrainingDateReservationNumDto;
 import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.*;
@@ -144,7 +143,6 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
         return TrainingDateReservationNumDto.builder()
                 .id(date.getId())
                 .date(date.getDate())
-                .availableTimes(date.getAvailableTimes().stream().map(TrainingAvailableTimeDto::toDto).toList())
                 .reservationNum(reservationNum)
                 .build();
     }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.TrainingContentUpdateDto;
 import com.fithub.fithubbackend.domain.Training.dto.trainersTraining.TrainingCreateDto;
 import com.fithub.fithubbackend.domain.trainer.domain.Trainer;
+import com.fithub.fithubbackend.domain.trainer.domain.TrainerCareer;
 import com.fithub.fithubbackend.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
@@ -128,5 +129,10 @@ public class Training extends BaseTimeEntity {
     public void updateStartAndEndDate(LocalDate startDate, LocalDate endDate) {
         this.startDate = startDate;
         this.endDate = endDate;
+    }
+
+    public void updateAddress(TrainerCareer trainerCareer) {
+        this.address = trainerCareer.getAddress();
+        this.point = trainerCareer.getPoint();
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/TrainingDateReservationNumDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/TrainingDateReservationNumDto.java
@@ -1,12 +1,9 @@
 package com.fithub.fithubbackend.domain.Training.dto.reservation;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fithub.fithubbackend.domain.Training.dto.TrainingAvailableTimeDto;
 import lombok.*;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -19,6 +16,4 @@ public class TrainingDateReservationNumDto {
     private LocalDate date;
 
     private Long reservationNum;
-
-    private List<TrainingAvailableTimeDto> availableTimes = new ArrayList<>();
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/TrainingDateReservationNumDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/TrainingDateReservationNumDto.java
@@ -1,6 +1,7 @@
 package com.fithub.fithubbackend.domain.Training.dto.reservation;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -15,5 +16,6 @@ public class TrainingDateReservationNumDto {
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate date;
 
+    @Schema(description = "해당 날에 잡혀있는 진행 전 예약")
     private Long reservationNum;
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/trainersTraining/TrainingDateUpdateDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/trainersTraining/TrainingDateUpdateDto.java
@@ -14,11 +14,11 @@
 public class TrainingDateUpdateDto {
 
     @NotNull
-    @Schema(description = "트레이닝 시작 날짜")
+    @Schema(description = "트레이닝 시작 날짜, 달라지지 않았으면 기존의 날짜로")
     private LocalDate startDate;
     
     @NotNull
-    @Schema(description = "트레이닝 마지막 날짜")
+    @Schema(description = "트레이닝 마지막 날짜, 달라지지 않았으면 기존의 날짜로")
     private LocalDate endDate;
 
     @Schema(description = "트레이닝 불가 날짜", example = "[\"2024-03-02\",\"2024-03-05\"]")

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingRepository.java
@@ -14,8 +14,11 @@ public interface TrainingRepository extends JpaRepository<Training, Long> {
 
     Page<Training> findAllByDeletedFalseAndClosedFalse(Pageable pageable);
     Page<Training> findAllByDeletedFalseAndTrainerIdAndClosed(Long trainerId, boolean closed, Pageable pageable);
+    List<Training> findByDeletedFalseAndClosedFalseAndTrainerId(Long trainerId);
 
     List<Training> findByClosedFalseAndEndDateLessThanEqual(LocalDate now);
+
+    boolean existsByDeletedFalseAndClosedFalseAndTrainerId(Long trainerId);
 
     @Query(value = "SELECT * FROM Training AS t WHERE t.deleted = false AND t.closed = false AND MBRContains(ST_LINESTRINGFROMTEXT(:pointFormat), t.point)", nativeQuery = true)
     List<Training> findByPoint(@Param("pointFormat")String pointFormat, Pageable pageable);

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerServiceImpl.java
@@ -22,6 +22,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class TrainerServiceImpl implements TrainerService {
@@ -63,6 +65,14 @@ public class TrainerServiceImpl implements TrainerService {
                 .point(point)
                 .careerBuild();
 
+        if (dto.isWorking()) {
+            Optional<TrainerCareer> currentWorkingCareer = trainerCareerRepository.findByWorkingTrueAndTrainerId(trainer.getId());
+            if (currentWorkingCareer.isPresent()) {
+                TrainerCareer current = currentWorkingCareer.get();
+                current.quitCompany();
+            }
+            trainer.updateAddress(trainerCareer);
+        }
         return trainerCareerRepository.save(trainerCareer).getId();
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerServiceImpl.java
@@ -1,5 +1,7 @@
 package com.fithub.fithubbackend.domain.trainer.application;
 
+import com.fithub.fithubbackend.domain.Training.domain.Training;
+import com.fithub.fithubbackend.domain.Training.repository.TrainingRepository;
 import com.fithub.fithubbackend.domain.trainer.domain.Trainer;
 import com.fithub.fithubbackend.domain.trainer.domain.TrainerCareer;
 import com.fithub.fithubbackend.domain.trainer.domain.TrainerLicenseImg;
@@ -22,6 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -30,6 +33,9 @@ public class TrainerServiceImpl implements TrainerService {
     private final TrainerRepository trainerRepository;
     private final TrainerCareerRepository trainerCareerRepository;
     private final TrainerLicenseImgRepository trainerLicenseImgRepository;
+
+    private final TrainingRepository trainingRepository;
+
     private final AwsS3Uploader s3Uploader;
 
     @Override
@@ -66,12 +72,7 @@ public class TrainerServiceImpl implements TrainerService {
                 .careerBuild();
 
         if (dto.isWorking()) {
-            Optional<TrainerCareer> currentWorkingCareer = trainerCareerRepository.findByWorkingTrueAndTrainerId(trainer.getId());
-            if (currentWorkingCareer.isPresent()) {
-                TrainerCareer current = currentWorkingCareer.get();
-                current.quitCompany();
-            }
-            trainer.updateAddress(trainerCareer);
+            changeCurrentAddressToThis(trainer, trainerCareer);
         }
         return trainerCareerRepository.save(trainerCareer).getId();
     }
@@ -105,6 +106,35 @@ public class TrainerServiceImpl implements TrainerService {
             point = parsePoint(dto.getLatitude(), dto.getLongitude());
         }
         career.updateCareer(dto, point);
+
+        changeAddressOrQuitCompany(trainer, career, dto.isWorking());
+    }
+
+    private void changeAddressOrQuitCompany(Trainer trainer, TrainerCareer trainerCareer, boolean working) {
+        if (!trainerCareer.isWorking() && working) {
+            changeCurrentAddressToThis(trainer, trainerCareer);
+            trainerCareer.joinCompany();
+        } else if (trainerCareer.isWorking() && !working) {
+            if (trainingRepository.existsByDeletedFalseAndClosedFalseAndTrainerId(trainer.getId())) {
+                throw new CustomException(ErrorCode.BAD_REQUEST, "진행중인 트레이닝 모집이 있어 근무지가 필요합니다. 현재 재직중인 회사가 없다면 트레이닝 삭제 후 근무지 수정을 진행해야됩니다.");
+            }
+            trainerCareer.quitCompany();
+        }
+    }
+
+    private void changeCurrentAddressToThis(Trainer trainer, TrainerCareer trainerCareer) {
+        Optional<TrainerCareer> currentWorkingCareer = trainerCareerRepository.findByWorkingTrueAndTrainerId(trainer.getId());
+        currentWorkingCareer.ifPresent(TrainerCareer::quitCompany);
+
+        trainer.updateAddress(trainerCareer);
+        updateAddressOfOpenTraining(trainer.getId(), trainerCareer);
+    }
+
+    private void updateAddressOfOpenTraining(Long trainerId, TrainerCareer trainerCareer) {
+        List<Training> trainingList = trainingRepository.findByDeletedFalseAndClosedFalseAndTrainerId(trainerId);
+        for (Training training : trainingList) {
+            training.updateAddress(trainerCareer);
+        }
     }
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCareer.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCareer.java
@@ -82,4 +82,12 @@ public class TrainerCareer extends BaseTimeEntity {
         this.startDate = dto.getStartDate();
         this.endDate = dto.getEndDate() != null ? dto.getEndDate() : null;
     }
+
+    public void JoinCompany() {
+        this.working = true;
+    }
+
+    public void quitCompany() {
+        this.working = false;
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCareer.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/TrainerCareer.java
@@ -78,12 +78,11 @@ public class TrainerCareer extends BaseTimeEntity {
         this.address = dto.getAddress();
         this.point = point;
         this.work = dto.getWork();
-        this.working = dto.isWorking();
         this.startDate = dto.getStartDate();
         this.endDate = dto.getEndDate() != null ? dto.getEndDate() : null;
     }
 
-    public void JoinCompany() {
+    public void joinCompany() {
         this.working = true;
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/repository/TrainerCareerRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/repository/TrainerCareerRepository.java
@@ -3,5 +3,8 @@ package com.fithub.fithubbackend.domain.trainer.repository;
 import com.fithub.fithubbackend.domain.trainer.domain.TrainerCareer;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TrainerCareerRepository extends JpaRepository<TrainerCareer, Long> {
+    Optional<TrainerCareer> findByWorkingTrueAndTrainerId(Long trainerId);
 }


### PR DESCRIPTION
## pr 유형
- 기능 추가

## 변경 사항
- 트레이너 경력 추가 시, 현재 재직중이라는 표시를 하면 트레이너의 근무지를 요청이 들어온 근무지로 변경 + 현재 트레이너가 만들어놓은 트레이닝 중 삭제X 마감X인 트레이닝의 근무지 변경

- 트레이너 경력 수정 시, 재직중이라는 표시를 하면 트레이너의 근무지 수정
  - working = false로 수정 시,  삭제 X, 마감 X인 트레이닝이 있다면 에러 발생
  - working = true로 수정 시, 경력 추가와 같게 동작