### PR TITLE
update: 게시글 검색 기능 수정 (page 정보를 dto로 받는 대신 pageable 파라미터로 받도록 수정)

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
@@ -108,18 +108,18 @@ public class PostController {
         return ResponseEntity.ok().body(commentService.getDetailComments(commentId));
     }
 
-    @Operation(summary = "게시글 검색", parameters = {
+    @Operation(summary = "게시글 검색 (swagger에서 api 테스트 X. pageable을 request Body 전달 받기 때문. pageable를 파라미터로 전달해야 함.)", parameters = {
             @Parameter(name = "keyword", description = "검색 키워드"),
             @Parameter(name = "scope", description = " 검색 범위 ex) content(기본), writer, hashtags"),
-            @Parameter(name = "page", description = "페이지 번호 (기본 0 : 가장 첫 페이지), 필수 값"),
-            @Parameter(name = "size", description = "한 페이지에 노출할 데이터 건수 (기본 9, 생략 가능)"),
-            @Parameter(name = "sort", description = "페이지 정렬 방식 (기본 id desc : 최신순, 생략 가능) ex) likes(좋아요 순), comments(댓글 순) 지정 가능"),
+            @Parameter(name = "pageable", description = "page(size = 9, sort = \"id\", desc 적용). 파라미터로 전달. 페이지 이동 시 page 값만 보내주면 됨. ex) \"page\" : 0 인 경우 1 페이지"),
+            @Parameter(name = "pageable의 sort", description = "페이지 정렬 방식 (기본 id,desc : 최신순, 생략 가능) ex) likes,desc (좋아요 순), comments,desc (댓글 순) 지정 가능."),
     }, responses = {
             @ApiResponse(responseCode = "200", description = "검색 완료"),
     })
     @PostMapping("/search")
-    public ResponseEntity<Page<PostInfoDto>> searchPostsByKeyword(@RequestBody PostSearchFilterDto filter) {
-        return ResponseEntity.ok().body(postService.searchPostsByKeyword(filter));
+    public ResponseEntity<Page<PostInfoDto>> searchPostsByKeyword(@RequestBody PostSearchFilterDto filter,
+                                                                  @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok().body(postService.searchPostsByKeyword(filter, pageable));
     }
 
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostService.java
@@ -20,5 +20,5 @@ public interface PostService {
 
     List<LikedUsersInfoDto> getLikedUsersForPosts(List<PostRequestDto> postRequestDtos);
 
-    Page<PostInfoDto> searchPostsByKeyword(PostSearchFilterDto filter);
+    Page<PostInfoDto> searchPostsByKeyword(PostSearchFilterDto filter, Pageable pageable);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/PostServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/PostServiceImpl.java
@@ -64,8 +64,8 @@ public class PostServiceImpl implements PostService {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<PostInfoDto> searchPostsByKeyword(PostSearchFilterDto filter) {
-        Page<Post> posts = postRepository.searchPostsByKeyword(filter);
+    public Page<PostInfoDto> searchPostsByKeyword(PostSearchFilterDto filter, Pageable pageable) {
+        Page<Post> posts = postRepository.searchPostsByKeyword(filter, pageable);
         return posts.map(PostInfoDto::toDto);
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostSearchFilterDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostSearchFilterDto.java
@@ -15,7 +15,4 @@ public class PostSearchFilterDto {
     @Schema(description = "검색 범위 (내용, 작성자, 해시태그)", example = "content")
     private String scope = "content";
 
-    @Schema(description = "페이징")
-    private PageableDto pageable;
-
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/repository/CustomPostRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/repository/CustomPostRepository.java
@@ -3,9 +3,10 @@ package com.fithub.fithubbackend.domain.board.repository;
 import com.fithub.fithubbackend.domain.board.dto.PostSearchFilterDto;
 import com.fithub.fithubbackend.domain.board.post.domain.Post;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface CustomPostRepository {
 
-    Page<Post> searchPostsByKeyword(PostSearchFilterDto postSearchFilterDTO);
+    Page<Post> searchPostsByKeyword(PostSearchFilterDto postSearchFilterDTO, Pageable pageable);
 
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/repository/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/repository/CustomPostRepositoryImpl.java
@@ -1,6 +1,5 @@
 package com.fithub.fithubbackend.domain.board.repository;
 
-import com.fithub.fithubbackend.domain.board.dto.PageableDto;
 import com.fithub.fithubbackend.domain.board.dto.PostSearchFilterDto;
 import com.fithub.fithubbackend.domain.board.post.domain.Post;
 import com.querydsl.core.QueryResults;
@@ -15,6 +14,7 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import static com.fithub.fithubbackend.domain.board.post.domain.QPost.post;
+import static com.fithub.fithubbackend.domain.board.comment.domain.QComment.comment;
 import static com.fithub.fithubbackend.domain.user.domain.QUser.user;
 
 import java.util.*;
@@ -32,16 +32,16 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<Post> searchPostsByKeyword(PostSearchFilterDto filter) {
+    public Page<Post> searchPostsByKeyword(PostSearchFilterDto filter, Pageable pageable) {
          QueryResults<Post> posts = jpaQueryFactory.selectFrom(post)
                 .where(scopeEq(filter))
                  .join(post.user, user).fetchJoin()
-                .orderBy(getOrderSpecifier(filter.getPageable()).toArray(OrderSpecifier[]::new))
-                .offset(filter.getPageable().getPage() * filter.getPageable().getSize())
-                .limit(filter.getPageable().getSize())
+                .orderBy(getOrderSpecifier(pageable).toArray(OrderSpecifier[]::new))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
                 .fetchResults();
 
-        return new PageImpl<>(posts.getResults(), PageRequest.of(filter.getPageable().getPage(), filter.getPageable().getSize()), posts.getTotal());
+        return new PageImpl<>(posts.getResults(), pageable, posts.getTotal());
     }
 
     private BooleanExpression scopeEq(PostSearchFilterDto filter) {
@@ -54,28 +54,26 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
     }
 
 
-    private List<OrderSpecifier> getOrderSpecifier(PageableDto pageable) {
+    private List<OrderSpecifier> getOrderSpecifier(Pageable pageable) {
 
         List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
 
-
-        if (pageable == null || pageable.getSort() == null || pageable.getSort().isEmpty()) {
-            orderSpecifiers.add(post.id.desc());
-            return orderSpecifiers;
-        }
-
-        for (String sortProperty : pageable.getSort()) {
-            Sort.Order order = Sort.Order.by(sortProperty);
+        for (Sort.Order order : pageable.getSort()) {
+            Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
 
             switch (order.getProperty()) {
+                case "id":
+                    orderSpecifiers.add(new OrderSpecifier<>(direction, post.id));
+                    break;
                 case "likes":
-                    orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, post.likes.size()));
+                    orderSpecifiers.add(new OrderSpecifier<>(direction, post.likes.size()));
                     break;
                 case "comments":
-                    orderSpecifiers.add(new OrderSpecifier<>(Order.DESC,
-                            JPAExpressions.select(post.comments.size())
-                                    .from(post)
-                                    .where(post.comments.any().deleted.eq(false))));
+                    orderSpecifiers.add(
+                            new OrderSpecifier<>(direction,
+                                    JPAExpressions.select(comment.count())
+                                            .from(comment)
+                                            .where(comment.post.eq(post).and(comment.deleted.isNull()))));
                     break;
             }
         }


### PR DESCRIPTION
## PR 유형
- 기능 수정

## 반영 브랜치
- main -> main

## 변경 사항
- 게시글 검색 기능 수정 (page 정보를 **dto**로 받는 대신 **pageable 파라미터**로 받도록 수정) 

  - pageable
     - ex) /posts/search?page=0&size=9&sort=id,desc
     - page는 필수 / size와 sort는 선택 파라미터 (기본으로 size는 9, sort는 id desc)
     - sort는 정렬 기준(ex id/likes/comments), 정렬 방향(ex desc/asc) 설정 가능. 정렬 기준과 방향을 ','를 사용하여 같이 설정해야 함. 

  - 게시글 검색 dto
```
{
    "keyword": "검색 키워드",
    "scope": "content"
}

```
