### PR TITLE
feat: 트레이닝 생성을 위해 트레이닝이 이미 있는 날짜 받아오는 기능 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainerTrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainerTrainingController.java
@@ -29,6 +29,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Tag(name = "trainer's training (트레이너의 트레이닝)", description = "트레이너가 사용하는 트레이닝 관련 api (트레이너 권한 필요)")
@@ -53,6 +54,18 @@ public class TrainerTrainingController {
                                                                                     @PageableDefault(sort="id", size = 9, direction = Sort.Direction.DESC) Pageable pageable) {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         return ResponseEntity.ok(trainerTrainingService.getTrainersTrainingList(user.getId(), closed, pageable));
+    }
+
+    @Operation(summary = "트레이닝이 있는 날짜 리스트 가져오기", description = "트레이닝 생성 시, 이미 트레이닝이 있는 날짜들은 중복이 있을 수 있으니 제외하기 위해 트레이닝이 있는 날짜를 받아옴" ,
+            responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "403", description = "해당 회원은 트레이너가 아님", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+    })
+    @GetMapping("/date-list/impossible")
+    public ResponseEntity<List<LocalDate>> getDateListOfOtherTraining(@AuthUser User user) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        return ResponseEntity.ok(trainerTrainingService.getDateListOfOtherTraining(user.getId()));
     }
 
     @Operation(summary = "트레이닝 생성, swagger에서 테스트 불가능, 이미지는 모두 images로 주면 됨", responses = {

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingService.java
@@ -12,11 +12,15 @@ import com.fithub.fithubbackend.domain.user.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface TrainerTrainingService {
 
     Page<TrainersTrainingOutlineDto> getTrainersTrainingList(Long userId, boolean closed, Pageable pageable);
+
+    List<LocalDate> getDateListOfOtherTraining(Long userId);
+
     Long createTraining(TrainingCreateDto dto, User user);
     Long updateTrainingContent(TrainingContentUpdateDto dto, Long trainingId, String email);
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
@@ -26,10 +26,8 @@ import java.sql.Date;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -56,6 +54,18 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
         Trainer trainer = findTrainerByUserId(userId);
         Page<Training> trainersTrainingList = trainingRepository.findAllByDeletedFalseAndTrainerIdAndClosed(trainer.getId(), closed, pageable);
         return trainersTrainingList.map(t -> TrainersTrainingOutlineDto.builder().training(t).build());
+    }
+
+    @Override
+    public List<LocalDate> getDateListOfOtherTraining(Long userId) {
+        Trainer trainer = findTrainerByUserId(userId);
+        List<Training> trainingList = trainingRepository.findByDeletedFalseAndClosedFalseAndTrainerId(trainer.getId());
+
+        List<LocalDate> dateList = trainingList.stream()
+                .flatMap(t -> t.getAvailableDates().stream().map(AvailableDate::getDate))
+                .sorted()
+                .collect(Collectors.toList());
+        return dateList;
     }
 
     @Override


### PR DESCRIPTION
## pr 유형
- 기능 추가

## 변경 사항
- 트레이닝 생성 시, 날짜 중복을 피하기위해 트레이닝이 이미 있는 날짜는 불가능하게 해놔야됨. 그래서 이미 트레이닝이 있는 날짜(closed=false,delete=false)를 받아오는 api 추가

## 테스트 결과
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/3de1ee2f-c895-4c49-bf3d-8e8ebcc1a0b7)
