### PR TITLE
fix: 스케줄러 timezone 설정, 트레이닝 생성 시 필요없는  location 삭제

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/AvailableDate.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/AvailableDate.java
@@ -12,7 +12,6 @@ import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.Where;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.List;
 
 @Entity
@@ -54,22 +53,6 @@ public class AvailableDate {
     public void addTraining(Training training) {
         this.training = training;
         training.getAvailableDates().add(this);
-    }
-
-    public void closeCurrentTime(LocalTime now) {
-        for (AvailableTime time : this.getAvailableTimes()) {
-            if (time.isEnabled() && time.getTime().getHour() == now.getHour()) {
-                time.closeTime();
-                return;
-            }
-        }
-    }
-
-    public boolean isAllClosed() {
-        for (AvailableTime time : this.getAvailableTimes()) {
-            if (time.isEnabled()) return false;
-        }
-        return true;
     }
 
     public void closeDate() {

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/trainersTraining/TrainingCreateDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/trainersTraining/TrainingCreateDto.java
@@ -29,10 +29,6 @@ public class TrainingCreateDto {
 
     private List<MultipartFile> images = new ArrayList<>();
 
-    @NotBlank
-    @Schema(description = "트레이닝이 진행 장소")
-    private String location;
-
     @Schema(description = "가격")
     private int price;
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/AvailableTimeRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/AvailableTimeRepository.java
@@ -3,9 +3,13 @@ package com.fithub.fithubbackend.domain.Training.repository;
 import com.fithub.fithubbackend.domain.Training.domain.AvailableTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface AvailableTimeRepository extends JpaRepository<AvailableTime, Long> {
     List<AvailableTime> findByAvailableDateIdOrderByTime(Long availableDateId);
     boolean existsByEnabledTrueAndAvailableDateIdAndIdNot(Long availableDateId, Long id);
+    boolean existsByEnabledTrueAndAvailableDateId(Long availableDateId);
+    Optional<AvailableTime> findByAvailableDateIdAndTime(Long availableDateId, LocalTime time);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingRepository.java
@@ -16,7 +16,7 @@ public interface TrainingRepository extends JpaRepository<Training, Long> {
     Page<Training> findAllByDeletedFalseAndTrainerIdAndClosed(Long trainerId, boolean closed, Pageable pageable);
     List<Training> findByDeletedFalseAndClosedFalseAndTrainerId(Long trainerId);
 
-    List<Training> findByClosedFalseAndEndDateLessThanEqual(LocalDate now);
+    List<Training> findByDeletedFalseAndClosedFalseAndStartDateLessThanEqualAndEndDateGreaterThanEqual(LocalDate startDate, LocalDate endDate);
 
     boolean existsByDeletedFalseAndClosedFalseAndTrainerId(Long trainerId);
 

--- a/src/main/java/com/fithub/fithubbackend/global/component/Scheduler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/component/Scheduler.java
@@ -42,7 +42,7 @@ public class Scheduler {
         LocalDateTime nowDateTime = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
         log.info("[SCHEDULE] - checkTrainingDateTimeValidation 실행: {}", nowDateTime);
         LocalDate date = nowDateTime.toLocalDate();
-        LocalTime time = LocalTime.of(nowDateTime.toLocalTime().getHour(), 0);
+        LocalTime time = LocalTime.of(nowDateTime.getHour(), 0);
 
         List<Training> openTrainingList =
                 trainingRepository.findByDeletedFalseAndClosedFalseAndStartDateLessThanEqualAndEndDateGreaterThanEqual(date, date);


### PR DESCRIPTION
## pr 유형
- 기능 수정

## 변경 사항
- 스케줄러에서 LocalDateTime.now()를 할 경우 서버의 date는 Asia/Seoul로 잡혀있는데 UTC 날짜로 계속 진행됨. 코드에서 Asia/Seoul 정보를 가져오도록 수정
- 트레이닝 위치가 트레이너 위치로 잡혀 트레이닝 생성 dto에서 받을 필요 없는 location 삭제
