### PR TITLE
feat: 트레이닝 예약 종료 리스트 조회 분리(리뷰 여부 필요해서)

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/UserTrainingReservationController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/UserTrainingReservationController.java
@@ -1,6 +1,7 @@
 package com.fithub.fithubbackend.domain.Training.api;
 
 import com.fithub.fithubbackend.domain.Training.application.UserTrainingReservationService;
+import com.fithub.fithubbackend.domain.Training.dto.reservation.UsersReserveCompleteOutlineDto;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.UsersReserveInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.UsersReserveOutlineDto;
 import com.fithub.fithubbackend.domain.Training.dto.review.TrainingReviewReqDto;
@@ -34,7 +35,7 @@ import java.util.List;
 public class UserTrainingReservationController {
     private final UserTrainingReservationService userTrainingReservationService;
 
-    @Operation(summary = "회원의 트레이닝 예약(진행 전, 진행 중/ 완료 / 취소 / 노쇼) 리스트", parameters = {
+    @Operation(summary = "회원의 트레이닝 예약(진행 전, 진행 중/ 취소 / 노쇼) 리스트", parameters = {
             @Parameter(name = "status", description = "예약 상태, 진행전,중을 불러올 때는 없어야 됨", example = "COMPLETE, CANCEL, NOSHOW"),
             @Parameter(name = "pageable", description = "조회할 목록의 page, size, sort(기본은 id desc(생성 순), 예약된 트레이닝 날짜 순은 reserveDateTime으로 주면 됨)")
     }, responses = {
@@ -47,6 +48,19 @@ public class UserTrainingReservationController {
                                                                                         @PageableDefault(size = 3, sort="id", direction = Sort.Direction.DESC) Pageable pageable) {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         return ResponseEntity.ok(userTrainingReservationService.getTrainingReservationList(user, status, pageable));
+    }
+
+    @Operation(summary = "회원의 트레이닝 예약 진행 종료 리스트", parameters = {
+            @Parameter(name = "pageable", description = "조회할 목록의 page, size, sort(기본은 id desc(생성 순), 예약된 트레이닝 날짜 순은 reserveDateTime으로 주면 됨)")
+    }, responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "로그인한 사용자만 가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
+    })
+    @GetMapping("/all/complete")
+    public ResponseEntity<Page<UsersReserveCompleteOutlineDto>> getUsersTrainingReservationCompleteList(@AuthUser User user,
+                                                                                                        @PageableDefault(size = 3, sort="id", direction = Sort.Direction.DESC) Pageable pageable) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        return ResponseEntity.ok(userTrainingReservationService.getTrainingReservationCompleteList(user, pageable));
     }
 
     @Operation(summary = "회원의 트레이닝 예약 내역 하나 상세 조회", parameters = {

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingReservationService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingReservationService.java
@@ -1,5 +1,6 @@
 package com.fithub.fithubbackend.domain.Training.application;
 
+import com.fithub.fithubbackend.domain.Training.dto.reservation.UsersReserveCompleteOutlineDto;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.UsersReserveInfoDto;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.UsersReserveOutlineDto;
 import com.fithub.fithubbackend.domain.Training.dto.review.TrainingReviewReqDto;
@@ -13,6 +14,8 @@ import java.util.List;
 
 public interface UserTrainingReservationService {
     Page<UsersReserveOutlineDto> getTrainingReservationList(User user, ReserveStatus status, Pageable pageable);
+    Page<UsersReserveCompleteOutlineDto> getTrainingReservationCompleteList(User user, Pageable pageable);
+
     UsersReserveInfoDto getTrainingReservation(Long reservationId);
 
     List<UsersTrainingReviewDto> getAllReviews(User user);

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/UsersReserveCompleteOutlineDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/UsersReserveCompleteOutlineDto.java
@@ -1,0 +1,64 @@
+package com.fithub.fithubbackend.domain.Training.dto.reservation;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fithub.fithubbackend.domain.Training.domain.ReserveInfo;
+import com.fithub.fithubbackend.domain.Training.domain.Training;
+import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+@AllArgsConstructor
+@Schema(description = "회원의 트레이닝 종료 내역 확인 dto")
+public class UsersReserveCompleteOutlineDto {
+    @Schema(description = "트레이닝 예약 id")
+    private Long reservationId;
+
+    @Schema(description = "트레이닝 id")
+    private Long trainingId;
+
+    @Schema(description = "트레이닝 제목")
+    private String title;
+
+    @Schema(description = "예약한 트레이닝 날짜, 시간")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime reserveDateTime;
+
+    private String location;
+
+    @Schema(description = "트레이닝 진행 상황(진행완료)")
+    private ReserveStatus status;
+
+    @Schema(description = "트레이닝 리뷰 작성 여부")
+    private boolean reviewWritten;
+
+    @Schema(description = "트레이닝 결제(예약)한 날짜, 시간")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime paymentDateTime;
+
+    @Schema(description = "트레이닝 결제 변경 날짜, 시간 (취소, 노쇼 처리 시 이걸 참고)")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime modifiedDateTime;
+
+    @Builder
+    public UsersReserveCompleteOutlineDto(ReserveInfo reserveInfo, boolean reviewWritten) {
+        Training training = reserveInfo.getTraining();
+
+        this.reservationId = reserveInfo.getId();
+        this.trainingId = training.getId();
+        this.title = training.getTitle();
+        this.reserveDateTime = reserveInfo.getReserveDateTime();
+        this.location = training.getAddress();
+        this.status = reserveInfo.getStatus();
+        this.reviewWritten = reviewWritten;
+        this.paymentDateTime = reserveInfo.getCreatedDate();
+        this.modifiedDateTime = reserveInfo.getModifiedDate();
+    }
+
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 public interface ReserveInfoRepository extends JpaRepository<ReserveInfo, Long> {
     Page<ReserveInfo> findByTrainerId(Long trainerId, Pageable pageable);
-
+    Page<ReserveInfo> findByUserIdAndStatus(Long userId, ReserveStatus status, Pageable pageable);
     List<ReserveInfo> findByTrainingIdAndStatus(Long trainingId, ReserveStatus status);
     boolean existsByTrainingIdAndStatusNotIn(Long trainingId, List<@NotNull ReserveStatus> status);
     boolean existsByTrainingId(Long trainingId);

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingReviewRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingReviewRepository.java
@@ -10,5 +10,6 @@ public interface TrainingReviewRepository extends JpaRepository<TrainingReview, 
     List<TrainingReview> findByUserIdOrderByIdDesc(Long userId);
     List<TrainingReview> findByLockedFalseAndTrainingId(Long trainingId);
 
+    boolean existsByReserveInfoId(Long reserveInfoId);
     Optional<TrainingReview> findByReserveInfoId(Long reserveInfoId);
 }

--- a/src/main/java/com/fithub/fithubbackend/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/exception/CustomExceptionHandler.java
@@ -1,9 +1,12 @@
 package com.fithub.fithubbackend.global.exception;
 
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.siot.IamportRestClient.exception.IamportResponseException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mapping.PropertyReferenceException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -56,6 +59,27 @@ public class CustomExceptionHandler {
                         .status(exception.getStatusCode().value())
                         .code("BAD_REQUEST")
                         .message(exception.getMessage())
+                        .build()
+                );
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponseDto> handleHttpMessageNotReadableException(HttpMessageNotReadableException exception) {
+        log.info("[CustomExceptionHandler] - HttpMessageNotReadableException 에러 {}", exception.getMessage());
+        if (exception.getCause() instanceof MismatchedInputException mismatchedInputException) {
+            return ResponseEntity.badRequest()
+                    .body(ErrorResponseDto.builder()
+                            .status(HttpStatus.BAD_REQUEST.value())
+                            .code("INVALID_JSON")
+                            .message(mismatchedInputException.getPath().get(0).getFieldName() + " 필드의 값이 잘못되었습니다.")
+                            .build()
+                    );
+        }
+        return ResponseEntity.badRequest()
+                .body(ErrorResponseDto.builder()
+                        .status(HttpStatus.BAD_REQUEST.value())
+                        .code("INVALID_JSON")
+                        .message("확인할 수 없는 형태의 데이터가 들어왔습니다")
                         .build()
                 );
     }


### PR DESCRIPTION
## pr 유형
- 기능 추가

## 변경 사항
- 트레이닝 예약 리스트 조회에서 종료된(COMPLETE) 리스트 받아오는 api 분리
  - 종료된 예약은 리뷰 작성 또는 조회가 가능해야 하는데 해당 예약에 리뷰가 있는지 없는지를 알 수 있는 데이터가 응답 데이터에 포함되어 있어야 돼서 api 분리

## 테스트 결과
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/776c512c-c7e6-4aaa-98fa-8318058068ef)
