### PR TITLE
feat: 회원의 관심사 수정 기능 추가, 회원 가입 시 관심사 설정 기능 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/user/api/UserController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/api/UserController.java
@@ -2,6 +2,7 @@ package com.fithub.fithubbackend.domain.user.api;
 
 import com.fithub.fithubbackend.domain.user.application.UserService;
 import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.domain.user.dto.InterestUpdateDto;
 import com.fithub.fithubbackend.domain.user.dto.ProfileDto;
 import com.fithub.fithubbackend.domain.user.dto.ProfileUpdateDto;
 import com.fithub.fithubbackend.global.domain.AuthUser;
@@ -10,6 +11,7 @@ import com.fithub.fithubbackend.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -53,6 +55,16 @@ public class UserController {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         userService.updateImage(multipartFile, user);
         return ResponseEntity.ok().body("완료");
+    }
+
+    @Operation(summary = "관심사 수정", responses = {
+            @ApiResponse(responseCode = "200", description = "관심사 수정 성공"),
+    })
+    @PutMapping("/interest")
+    public ResponseEntity<String> updateInterest(@Valid @RequestBody InterestUpdateDto interestUpdateDto, @AuthUser User user){
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        userService.updateInterest(interestUpdateDto, user);
+        return ResponseEntity.ok().body("관심사 수정 완료");
     }
 
 

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/UserService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/UserService.java
@@ -1,6 +1,7 @@
 package com.fithub.fithubbackend.domain.user.application;
 
 import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.domain.user.dto.InterestUpdateDto;
 import com.fithub.fithubbackend.domain.user.dto.ProfileDto;
 import com.fithub.fithubbackend.domain.user.dto.ProfileUpdateDto;
 import org.springframework.web.multipart.MultipartFile;
@@ -9,4 +10,5 @@ public interface UserService {
     ProfileDto myProfile(User user);
     void updateProfile(ProfileUpdateDto profileUpdateDto, User user);
     void updateImage(MultipartFile profileImg, User user);
+    void updateInterest(InterestUpdateDto interestUpdateDto, User user);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/UserServiceImpl.java
@@ -99,9 +99,11 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public void updateInterest(InterestUpdateDto interestUpdateDto, User user) {
         if (interestUpdateDto.isInterestsDeleted()) {
-            interestUpdateDto.getDeletedInterests().forEach(interest -> {
-                UserInterest userInterest = userInterestRepository.findByInterestAndUser(interest, user);
-                userInterestRepository.delete(userInterest);
+            List<UserInterest> originalInterests = userInterestRepository.findByUser(user);
+            originalInterests.forEach(originalInterest -> {
+                if (!interestUpdateDto.getUnModifiedInterests().contains(originalInterest.getInterest())) {
+                    userInterestRepository.delete(originalInterest);
+                }
             });
         }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/UserServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/UserServiceImpl.java
@@ -3,10 +3,14 @@ package com.fithub.fithubbackend.domain.user.application;
 import com.fithub.fithubbackend.domain.trainer.domain.Trainer;
 import com.fithub.fithubbackend.domain.trainer.repository.TrainerRepository;
 import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.domain.user.domain.UserInterest;
+import com.fithub.fithubbackend.domain.user.dto.InterestUpdateDto;
 import com.fithub.fithubbackend.domain.user.dto.ProfileDto;
 import com.fithub.fithubbackend.domain.user.dto.ProfileUpdateDto;
 import com.fithub.fithubbackend.domain.user.repository.DocumentRepository;
+import com.fithub.fithubbackend.domain.user.repository.UserInterestRepository;
 import com.fithub.fithubbackend.domain.user.repository.UserRepository;
+import com.fithub.fithubbackend.global.common.Category;
 import com.fithub.fithubbackend.global.config.s3.AwsS3Uploader;
 import com.fithub.fithubbackend.global.domain.Document;
 import com.fithub.fithubbackend.global.exception.CustomException;
@@ -20,6 +24,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Optional;
 
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -28,6 +33,7 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final TrainerRepository trainerRepository;
     private final DocumentRepository documentRepository;
+    private final UserInterestRepository userInterestRepository;
     private final AwsS3Uploader awsS3Uploader;
 
     @Value("${default.image.address}")
@@ -36,6 +42,8 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional(readOnly = true)
     public ProfileDto myProfile(User user) {
+        List<Category> interests = userInterestRepository.findInterestsByUser(user);
+
         return ProfileDto.builder()
                 .name(user.getName())
                 .nickname(user.getNickname())
@@ -45,6 +53,7 @@ public class UserServiceImpl implements UserService {
                 .bio(user.getBio())
                 .gender(user.getGender())
                 .grade(user.getGrade())
+                .interests(interests)
                 .trainer(user.isTrainer())
                 .build();
     }
@@ -83,6 +92,26 @@ public class UserServiceImpl implements UserService {
             optionalTrainer.ifPresent(t -> t.linkedToUserProfileImg(document));
         } catch (Exception e) {
             throw new CustomException(ErrorCode.UPLOAD_PROFILE_ERROR, "이미지 업데이트 중 오류가 발생했습니다");
+        }
+    }
+
+    @Override
+    @Transactional
+    public void updateInterest(InterestUpdateDto interestUpdateDto, User user) {
+        if (interestUpdateDto.isInterestsDeleted()) {
+            interestUpdateDto.getDeletedInterests().forEach(interest -> {
+                UserInterest userInterest = userInterestRepository.findByInterestAndUser(interest, user);
+                userInterestRepository.delete(userInterest);
+            });
+        }
+
+        if (interestUpdateDto.isInterestsAdded()) {
+            interestUpdateDto.getAddedInterests().forEach(interest -> {
+                UserInterest userInterest = UserInterest.builder()
+                        .interest(interest)
+                        .user(user).build();
+                userInterestRepository.save(userInterest);
+            });
         }
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/user/domain/UserInterest.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/domain/UserInterest.java
@@ -1,0 +1,32 @@
+package com.fithub.fithubbackend.domain.user.domain;
+
+import com.fithub.fithubbackend.global.common.Category;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserInterest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private User user;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private Category interest;
+
+    @Builder
+    public UserInterest(User user, Category interest) {
+        this.user = user;
+        this.interest = interest;
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/user/dto/InterestUpdateDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/dto/InterestUpdateDto.java
@@ -1,0 +1,30 @@
+package com.fithub.fithubbackend.domain.user.dto;
+
+import com.fithub.fithubbackend.global.common.Category;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Schema(description = "회원의 관심사 수정 dto")
+public class InterestUpdateDto {
+
+    @NotNull
+    @Schema(description = "관심사 삭제 여부")
+    private boolean interestsDeleted;
+
+    @Schema(description = "삭제된 관심사 ex) PILATES, HEALTH, PT, CROSSFIT, YOGA")
+    private List<Category> deletedInterests;
+
+    @NotNull
+    @Schema(description = "관심사 추가 여부")
+    private boolean interestsAdded;
+
+    @Schema(description = "추가된 관심사 ex) PILATES, HEALTH, PT, CROSSFIT, YOGA")
+    private List<Category> addedInterests;
+
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/user/dto/InterestUpdateDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/dto/InterestUpdateDto.java
@@ -17,14 +17,14 @@ public class InterestUpdateDto {
     @Schema(description = "관심사 삭제 여부")
     private boolean interestsDeleted;
 
-    @Schema(description = "삭제된 관심사 ex) PILATES, HEALTH, PT, CROSSFIT, YOGA")
-    private List<Category> deletedInterests;
+    @Schema(description = "interestsDeleted = true 일 때만 사용. 삭제되지 않는 관심사. ex) PILATES, HEALTH, PT, CROSSFIT, YOGA")
+    private List<Category> unModifiedInterests;
 
     @NotNull
     @Schema(description = "관심사 추가 여부")
     private boolean interestsAdded;
 
-    @Schema(description = "추가된 관심사 ex) PILATES, HEALTH, PT, CROSSFIT, YOGA")
+    @Schema(description = "추가된 관심사. ex) PILATES, HEALTH, PT, CROSSFIT, YOGA")
     private List<Category> addedInterests;
 
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/dto/ProfileDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/dto/ProfileDto.java
@@ -2,7 +2,10 @@ package com.fithub.fithubbackend.domain.user.dto;
 
 import com.fithub.fithubbackend.domain.user.enums.Gender;
 import com.fithub.fithubbackend.domain.user.enums.Grade;
+import com.fithub.fithubbackend.global.common.Category;
 import lombok.*;
+
+import java.util.List;
 
 @Getter
 @Builder
@@ -17,6 +20,7 @@ public class ProfileDto {
     private String bio;
     private String profileImg;
     private Grade grade;
+    private List<Category> interests;
 
     private boolean trainer;
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/dto/SignUpDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/dto/SignUpDto.java
@@ -1,6 +1,7 @@
 package com.fithub.fithubbackend.domain.user.dto;
 
 import com.fithub.fithubbackend.domain.user.enums.Gender;
+import com.fithub.fithubbackend.global.common.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -11,6 +12,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import static com.fithub.fithubbackend.domain.user.dto.constants.SignUpDtoConstants.*;
+
+import java.util.List;
 
 @Getter
 @AllArgsConstructor
@@ -46,4 +49,7 @@ public class SignUpDto {
 
     @NotNull
     private Gender gender;
+
+    @Schema(description = "관심사 입력은 선택입니다. 여러 개 선택 가능합니다. ex) PILATES, HEALTH, PT, CROSSFIT, YOGA")
+    private List<Category> categories;
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/repository/UserInterestRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/repository/UserInterestRepository.java
@@ -1,0 +1,18 @@
+package com.fithub.fithubbackend.domain.user.repository;
+
+import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.domain.user.domain.UserInterest;
+import com.fithub.fithubbackend.global.common.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface UserInterestRepository extends JpaRepository<UserInterest, Long> {
+
+    UserInterest findByInterestAndUser(Category interest, User user);
+
+    @Query("select u.interest from UserInterest u where u.user = :user")
+    List<Category> findInterestsByUser(@Param(value = "user") User user);
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/user/repository/UserInterestRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/repository/UserInterestRepository.java
@@ -10,8 +10,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface UserInterestRepository extends JpaRepository<UserInterest, Long> {
-
-    UserInterest findByInterestAndUser(Category interest, User user);
+    List<UserInterest> findByUser(User user);
 
     @Query("select u.interest from UserInterest u where u.user = :user")
     List<Category> findInterestsByUser(@Param(value = "user") User user);

--- a/src/main/java/com/fithub/fithubbackend/global/common/Category.java
+++ b/src/main/java/com/fithub/fithubbackend/global/common/Category.java
@@ -1,0 +1,7 @@
+package com.fithub.fithubbackend.global.common;
+
+public enum Category {
+
+    PILATES, HEALTH, PT, CROSSFIT, YOGA;
+
+}


### PR DESCRIPTION
## PR 유형
- 기능 추가

## 반영 브랜치
- main -> main

## 변경 사항
- 회원의 관심사 수정 기능 추가
- 회원 가입 시 관심사 설정 기능 추가
- 회원의 프로필 조회 시 관심사도 조회하도록 수정

## 테스트 결과 

### 회원 가입 시 관심사 설정

> POST /auth/sign-up

- **Request Body**
   - **categories**: 필수 데이터가 아닌 관심사 리스트. 여러 개 선택 가능 (enum).  ex) PILATES, HEALTH, PT, CROSSFIT, YOGA

```
{
  "email": "fithub2@fithub.com",
  "password": "q1w2e3r4!",
  "name": "name",
  "nickname": "nickname",
  "phone": "01012345678",
  "gender": "F",
  "categories": [
    "PILATES", "YOGA"
  ]
}
```



### 회원의 관심사 수정

> PUT /users/interest

- **Request Body**
   - **interestsDeleted**: 관심사 삭제 여부
   - **unModifiedInterests**: interestsDeleted = true 일 때만 사용. 삭제되지 않는 관심사. (enum)  ex) PILATES, HEALTH, PT, CROSSFIT, YOGA
   - **interestsAdded**: 관심사 추가 여부
    - **addedInterests**: 추가된 관심사 리스트  (enum)  ex) PILATES, HEALTH, PT, CROSSFIT, YOGA

```
{
  "interestsDeleted": true,
  "unModifiedInterests": [
    "PILATES"
  ],
  "interestsAdded": true,
  "addedInterests": [
    "PILATES"
  ]
}
```




## 이슈
- @RequestBody 사용하여 관심사 dto를 전달 받으려고 하였으나 boolean 타입의 데이터가 전달되지 않는 문제 발생
  - lombok에서 제공하는 @Getter 혹은 @Setter 을 사용 할 경우 자동으로 getter/setter 메서드 생성
  - 이 때 boolean 타입의 변수에 붙는 prefix는 is. 
  - 변수명을 isDeleted으로 설정했을 경우, isIsDeleted() 와 같은 메소드 생성되므로 @RequestBody에서 찾을 수 없어 바인딩 되지 않아 발생하는 문제
  - 해결: boolean 변수 명에서 is prefix 제거

참고 문헌: https://jungguji.github.io/2020/12/31/RequestBody-Annotation-%EC%82%AC%EC%9A%A9-%EC%8B%9C-boolean-%EB%B3%80%EC%88%98-%EB%B0%94%EC%9D%B8%EB%94%A9-%EC%97%90%EB%9F%AC/


