### PR TITLE
fix: 트레이닝 검색, 게시글 검색 시 requestBody로 데이터 못 받는 에러 수정

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainingController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/TrainingController.java
@@ -65,7 +65,7 @@ public class TrainingController {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
     })
     @PostMapping("/search")
-    public ResponseEntity<Page<TrainingOutlineDto>> searchTrainingByConditions(@RequestBody TrainingSearchConditionDto conditions
+    public ResponseEntity<Page<TrainingOutlineDto>> searchTrainingByConditions(TrainingSearchConditionDto conditions
             , @PageableDefault(size = 9, sort = "id",  direction = Sort.Direction.DESC) Pageable pageable) {
         return ResponseEntity.ok(trainingService.searchTrainingByConditions(conditions, pageable));
     }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/api/PostController.java
@@ -117,7 +117,7 @@ public class PostController {
             @ApiResponse(responseCode = "200", description = "검색 완료"),
     })
     @PostMapping("/search")
-    public ResponseEntity<Page<PostInfoDto>> searchPostsByKeyword(@RequestBody PostSearchFilterDto filter,
+    public ResponseEntity<Page<PostInfoDto>> searchPostsByKeyword(PostSearchFilterDto filter,
                                                                   @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
         return ResponseEntity.ok().body(postService.searchPostsByKeyword(filter, pageable));
     }


### PR DESCRIPTION
## pr 유형
- 기능 수정

## 변경 사항
- RequestBody로 필터 조건을 받아왔는데 포스트맨에서는 가능했던게 스웨거, 프론트쪽 시도 시 설정한 데이터가 들어가지 않음을 발견. 
  - 이유: RequestBody로 설정한 필터 조건들과 Pageable이 RequestBody로 처리되어 RequesyBody가 두 개인 것. 이렇게 다중 RequestBody는 Single Object만을 처리할 수 있도록 되어 있기 때문. 그래서 두 개의 RequestBody를 사용중인 우리 코드에서 받아오지 못했던것,
  - 변경: RequestBody 대신 ModelAttribute(query) 사용. 이제 프론트에서는 query String으로 보내줘야됨

## 테스트 결과 
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/f2c545cb-7d6e-471d-9ff7-6ebb5748b3e6)
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/81f949c8-f8d9-46e6-8fb9-c14b0bedec13)

게시글
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/0d0181df-173b-4bf7-beac-2cd2714b39aa)
