### PR TITLE
feat: 트레이닝 카테고리 설정 기능 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
@@ -10,6 +10,7 @@ import com.fithub.fithubbackend.domain.Training.repository.*;
 import com.fithub.fithubbackend.domain.trainer.domain.Trainer;
 import com.fithub.fithubbackend.domain.trainer.repository.TrainerRepository;
 import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.global.common.Category;
 import com.fithub.fithubbackend.global.config.s3.AwsS3Uploader;
 import com.fithub.fithubbackend.global.domain.Document;
 import com.fithub.fithubbackend.global.exception.CustomException;
@@ -45,6 +46,8 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
     private final TrainingReviewRepository trainingReviewRepository;
     private final CustomReserveInfoRepository customReserveInfoRepository;
 
+    private final TrainingCategoryRepository trainingCategoryRepository;
+
     private final AwsS3Uploader awsS3Uploader;
 
     private final String imagePath =  "training";
@@ -79,6 +82,7 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
 
         Training training = Training.builder().dto(dto).trainer(trainer).build();
         saveDateTimeToTraining(training, dto);
+        saveTrainingCategories(training, dto.getCategories());
 
         if (dto.getImages() != null && !dto.getImages().isEmpty()) {
             saveTrainingImages(dto.getImages(), training);
@@ -117,6 +121,15 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
         }
     }
 
+    private void saveTrainingCategories(Training training, List<Category> newCategories) {
+        newCategories.forEach(category -> {
+            TrainingCategory trainingCategory = TrainingCategory.builder()
+                    .category(category)
+                    .training(training).build();
+            training.addCategory(trainingCategory);
+        });
+    }
+
     private Document createDocument(MultipartFile file) {
         String path = awsS3Uploader.imgPath(imagePath);
         return Document.builder()
@@ -136,6 +149,9 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
         if (dto.getTrainingImgUpdateDto() != null) {
             deleteOrAddImage(dto.getTrainingImgUpdateDto(), training);
         }
+
+        if (dto.getTrainingCategoryUpdateDto() != null)
+            deleteOrAddCategory(dto.getTrainingCategoryUpdateDto(), training);
 
         return training.getId();
     }
@@ -236,6 +252,23 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
                 awsS3Uploader.deleteS3(originalImg.getDocument().getPath());
             }
         }
+    }
+
+    private void deleteOrAddCategory(TrainingCategoryUpdateDto dto, Training training) {
+        if (dto.isCategoryDeleted() && !dto.getUnModifiedCategoryList().isEmpty()) {
+            deleteOriginalCategories(dto.getUnModifiedCategoryList(), training);
+        }
+
+        if (dto.isCategoryDeleted() && !dto.getNewCategoryList().isEmpty()) {
+            saveTrainingCategories(training, dto.getNewCategoryList());
+        }
+    }
+
+    private void deleteOriginalCategories(List<Category> unModifiedCategoryList, Training training) {
+        List<TrainingCategory> originalCategoryList = trainingCategoryRepository.findByTrainingId(training.getId());
+        for (TrainingCategory originalCategory : originalCategoryList)
+            if (!unModifiedCategoryList.contains(originalCategory.getCategory()))
+                training.removeCategory(originalCategory);
     }
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/TrainerTrainingServiceImpl.java
@@ -259,7 +259,7 @@ public class TrainerTrainingServiceImpl implements TrainerTrainingService {
             deleteOriginalCategories(dto.getUnModifiedCategoryList(), training);
         }
 
-        if (dto.isCategoryDeleted() && !dto.getNewCategoryList().isEmpty()) {
+        if (dto.isCategoryAdded() && !dto.getNewCategoryList().isEmpty()) {
             saveTrainingCategories(training, dto.getNewCategoryList());
         }
     }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/Training.java
@@ -53,6 +53,10 @@ public class Training extends BaseTimeEntity {
     @JsonIgnoreProperties({"training"})
     private List<TrainingDocument> images;
 
+    @OneToMany(mappedBy = "training", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnoreProperties({"training"})
+    private List<TrainingCategory> categories;
+
     @NotNull
     private boolean closed;
 
@@ -95,6 +99,7 @@ public class Training extends BaseTimeEntity {
         this.point = trainer.getPoint();
         this.availableDates = new ArrayList<>();
         this.images = new ArrayList<>();
+        this.categories = new ArrayList<>();
         this.deleted = false;
     }
 
@@ -135,4 +140,13 @@ public class Training extends BaseTimeEntity {
         this.address = trainerCareer.getAddress();
         this.point = trainerCareer.getPoint();
     }
+
+    public void addCategory(TrainingCategory category) {
+        this.categories.add(category);
+    }
+
+    public void removeCategory(TrainingCategory category) {
+        this.categories.remove(category);
+    }
+
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/TrainingCategory.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/TrainingCategory.java
@@ -18,7 +18,7 @@ public class TrainingCategory {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(cascade = CascadeType.MERGE, optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JsonIgnore
     private Training training;
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/domain/TrainingCategory.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/domain/TrainingCategory.java
@@ -1,0 +1,34 @@
+package com.fithub.fithubbackend.domain.Training.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fithub.fithubbackend.global.common.Category;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrainingCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(cascade = CascadeType.MERGE, optional = false)
+    @JsonIgnore
+    private Training training;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+    @Builder
+    public TrainingCategory(Training training, Category category) {
+        this.training = training;
+        this.category = category;
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainingInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainingInfoDto.java
@@ -2,10 +2,13 @@ package com.fithub.fithubbackend.domain.Training.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fithub.fithubbackend.domain.Training.domain.Training;
+import com.fithub.fithubbackend.domain.Training.domain.TrainingCategory;
+import com.fithub.fithubbackend.global.common.Category;
 import lombok.*;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @AllArgsConstructor
@@ -33,6 +36,8 @@ public class TrainingInfoDto {
 
     private List<TrainingAvailableDateDto> availableDates;
 
+    private List<Category> categories;
+
     public static TrainingInfoDto toDto(Training training) {
         return TrainingInfoDto.builder()
                 .id(training.getId())
@@ -44,6 +49,7 @@ public class TrainingInfoDto {
                 .startDate(training.getStartDate())
                 .endDate(training.getEndDate())
                 .availableDates(training.getAvailableDates().stream().map(TrainingAvailableDateDto::toDto).toList())
+                .categories(training.getCategories().stream().map(TrainingCategory::getCategory).collect(Collectors.toList()))
                 .build();
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainingOutlineDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainingOutlineDto.java
@@ -2,10 +2,14 @@ package com.fithub.fithubbackend.domain.Training.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fithub.fithubbackend.domain.Training.domain.Training;
+import com.fithub.fithubbackend.domain.Training.domain.TrainingCategory;
+import com.fithub.fithubbackend.global.common.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @AllArgsConstructor
@@ -26,6 +30,7 @@ public class TrainingOutlineDto {
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate endDate;
     private boolean closed;
+    private List<Category> categories;
 
     public static TrainingOutlineDto toDto(Training training) {
         return TrainingOutlineDto.builder()
@@ -37,6 +42,7 @@ public class TrainingOutlineDto {
                 .startDate(training.getStartDate())
                 .endDate(training.getEndDate())
                 .closed(training.isClosed())
+                .categories(training.getCategories().stream().map(TrainingCategory::getCategory).collect(Collectors.toList()))
                 .build();
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/trainersTraining/TrainingCategoryUpdateDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/trainersTraining/TrainingCategoryUpdateDto.java
@@ -15,12 +15,12 @@ public class TrainingCategoryUpdateDto {
     @Schema(description = "삭제된 카테고리가 있다면 true 로 주면 됨.")
     private boolean categoryDeleted;
 
-    @Schema(description = "categoryDeleted = true 일 때만 주면 됨. 수정되지 않는 카테고리 리스트. ex) PILATES, HEALTH, PT, CROSSFIT, YOGA")
+    @Schema(description = "categoryDeleted = true 일 때만 주면 됨. (false 일 경우 빈 리스트로 전달) 수정되지 않는 카테고리 리스트. ex) PILATES, HEALTH, PT, CROSSFIT, YOGA")
     private List<Category> unModifiedCategoryList;
 
     @Schema(description = "새로 추가된 카테고리가 있다면 true 로 주면 됨.")
     private boolean categoryAdded;
 
-    @Schema(description = "categoryAdded = true 일 때만 주면 됨. 새로 추가한 카테고리. ex) PILATES, HEALTH, PT, CROSSFIT, YOGA")
+    @Schema(description = "categoryAdded = true 일 때만 주면 됨. (false 일 경우 빈 리스트로 전달) 새로 추가한 카테고리. ex) PILATES, HEALTH, PT, CROSSFIT, YOGA")
     private List<Category> newCategoryList;
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/trainersTraining/TrainingCategoryUpdateDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/trainersTraining/TrainingCategoryUpdateDto.java
@@ -1,0 +1,26 @@
+package com.fithub.fithubbackend.domain.Training.dto.trainersTraining;
+
+import com.fithub.fithubbackend.global.common.Category;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Schema(description = "트레이닝 카테고리 수정 요청 Dto")
+public class TrainingCategoryUpdateDto {
+
+    @Schema(description = "삭제된 카테고리가 있다면 true 로 주면 됨.")
+    private boolean categoryDeleted;
+
+    @Schema(description = "categoryDeleted = true 일 때만 주면 됨. 수정되지 않는 카테고리 리스트. ex) PILATES, HEALTH, PT, CROSSFIT, YOGA")
+    private List<Category> unModifiedCategoryList;
+
+    @Schema(description = "새로 추가된 카테고리가 있다면 true 로 주면 됨.")
+    private boolean categoryAdded;
+
+    @Schema(description = "categoryAdded = true 일 때만 주면 됨. 새로 추가한 카테고리. ex) PILATES, HEALTH, PT, CROSSFIT, YOGA")
+    private List<Category> newCategoryList;
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/trainersTraining/TrainingContentUpdateDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/trainersTraining/TrainingContentUpdateDto.java
@@ -20,4 +20,7 @@ public class TrainingContentUpdateDto {
 
     @Schema(description = "트레이닝 이미지를 수정했다면 값을 넣어주면 됨. 수정 없으면 안 줘야 됨")
     private TrainingImgUpdateDto trainingImgUpdateDto;
+
+    @Schema(description = "트레이닝 카테고리를 수정했다면 값을 넣어주면 됨. 수정 없으면 안 줘야 됨")
+    private TrainingCategoryUpdateDto trainingCategoryUpdateDto;
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/trainersTraining/TrainingCreateDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/trainersTraining/TrainingCreateDto.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fithub.fithubbackend.global.common.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
@@ -34,6 +35,7 @@ public class TrainingCreateDto {
     private int price;
 
     @Schema(description = "트레이닝 카테고리 ex) PILATES, HEALTH, PT, CROSSFIT, YOGA")
+    @NotEmpty(message = "트레이닝 카테고리는 1개 이상 선택해야 합니다.")
     private List<Category> categories;
 
     @JsonFormat(pattern = "yyyy-MM-dd")

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/trainersTraining/TrainingCreateDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/trainersTraining/TrainingCreateDto.java
@@ -1,6 +1,7 @@
 package com.fithub.fithubbackend.domain.Training.dto.trainersTraining;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fithub.fithubbackend.global.common.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -31,6 +32,9 @@ public class TrainingCreateDto {
 
     @Schema(description = "가격")
     private int price;
+
+    @Schema(description = "트레이닝 카테고리 ex) PILATES, HEALTH, PT, CROSSFIT, YOGA")
+    private List<Category> categories;
 
     @JsonFormat(pattern = "yyyy-MM-dd")
     @Schema(description = "트레이닝 시작 날짜")

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingCategoryRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingCategoryRepository.java
@@ -1,0 +1,11 @@
+package com.fithub.fithubbackend.domain.Training.repository;
+
+import com.fithub.fithubbackend.domain.Training.domain.TrainingCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.*;
+
+public interface TrainingCategoryRepository extends JpaRepository<TrainingCategory, Long> {
+
+    List<TrainingCategory> findByTrainingId(long trainingId);
+}


### PR DESCRIPTION
## PR 유형
- 기능 추가

## 반영 브랜치
- main -> main

## 변경 사항
- 트레이닝 카테고리 설정 기능 추가

## 테스트 결과

### 트레이닝 수정

> PUT /trainers/training

####  Request Body
1. 수정된 카테고리 X
![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/9d6a2b96-b78a-4000-9201-78c5e59d1634)
- trainingCategoryUpdateDto의 **unModifiedCategoryList**, **newCategoryList**: 빈 리스트 형태로 전달. 

<hr>

2. 삭제된 카테고리 O
![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/caf188c6-e9a5-49ad-846c-b16c4b78b681)
- categoryDeleted: true 설정
- unModifiedCategoryList: 삭제되지 않는 카테고리 리스트

<hr>

3. 추가된 카테고리 O
![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/8a36cf79-9711-4a36-9722-c0a36fbec7e3)
- categoryAdded: true 설정
- newCategoryList: 새로 추가된 카테고리 리스트



## 이슈
- 트레이닝의 카테고리 null 허용 여부 (현재는 null  허용)
- **2024-03-11 update**
   - @NotEmpty 설정하여 null 허용 X
   - 트레이닝 생성 시 카테고리 리스트를 안 보내거나 빈 리스트로 전달 받을 시, 검증 실패 메시지 출력
    ![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/11bf42e9-4dcd-4468-b4a3-96770f8d79e0)
 


