### PR TITLE
Update: 트레이닝 예약 정보 조회, 후기 조회 프로필 이미지 추가, 로직 변경 / feat: 트레이닝 검색 시 카테고리 필터 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainingSearchConditionDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/TrainingSearchConditionDto.java
@@ -1,5 +1,6 @@
 package com.fithub.fithubbackend.domain.Training.dto;
 
+import com.fithub.fithubbackend.global.common.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
@@ -22,4 +23,7 @@ public class TrainingSearchConditionDto {
 
     private LocalDate startDate;
     private LocalDate endDate;
+
+    @Schema(description = "카테고리, 하나만 가능")
+    private Category category;
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/UsersReserveCompleteOutlineDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/UsersReserveCompleteOutlineDto.java
@@ -23,6 +23,9 @@ public class UsersReserveCompleteOutlineDto {
     @Schema(description = "트레이닝 id")
     private Long trainingId;
 
+    @Schema(description = "예약한 트레이닝의 트레이너 프로필 이미지")
+    private String trainerProfileImgUrl;
+
     @Schema(description = "트레이닝 제목")
     private String title;
 
@@ -52,6 +55,7 @@ public class UsersReserveCompleteOutlineDto {
 
         this.reservationId = reserveInfo.getId();
         this.trainingId = training.getId();
+        this.trainerProfileImgUrl = training.getTrainer().getProfileUrl();
         this.title = training.getTitle();
         this.reserveDateTime = reserveInfo.getReserveDateTime();
         this.location = training.getAddress();

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/UsersReserveInfoDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/UsersReserveInfoDto.java
@@ -1,6 +1,8 @@
 package com.fithub.fithubbackend.domain.Training.dto.reservation;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fithub.fithubbackend.domain.Training.domain.ReserveInfo;
+import com.fithub.fithubbackend.domain.Training.domain.Training;
 import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
@@ -10,7 +12,6 @@ import java.time.LocalDateTime;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Builder
 public class UsersReserveInfoDto {
 
     @Schema(description = "트레이닝 예약 id")
@@ -18,6 +19,9 @@ public class UsersReserveInfoDto {
 
     @Schema(description = "트레이닝 id")
     private Long trainingId;
+
+    @Schema(description = "예약한 트레이닝의 트레이너 프로필 이미지")
+    private String trainerProfileImgUrl;
 
     @Schema(description = "트레이닝 제목")
     private String title;
@@ -43,4 +47,19 @@ public class UsersReserveInfoDto {
     @Schema(description = "트레이닝 결제 변경 날짜, 시간 (취소, 노쇼 처리 시 이걸 참고)")
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime modifiedDateTime;
+
+    @Builder
+    public UsersReserveInfoDto(ReserveInfo reserveInfo, Training training) {
+        this.reservationId = reserveInfo.getId();
+        this.trainingId = training.getId();
+        this.trainerProfileImgUrl = training.getTrainer().getProfileUrl();
+        this.title = training.getTitle();
+        this.address = training.getAddress();
+        this.reserveDateTime = reserveInfo.getReserveDateTime();
+        this.price = reserveInfo.getPrice();
+        this.impUid = reserveInfo.getImpUid();
+        this.status = reserveInfo.getStatus();
+        this.paymentDateTime = reserveInfo.getCreatedDate();
+        this.modifiedDateTime = reserveInfo.getModifiedDate();
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/UsersReserveOutlineDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/UsersReserveOutlineDto.java
@@ -1,20 +1,17 @@
 package com.fithub.fithubbackend.domain.Training.dto.reservation;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fithub.fithubbackend.domain.Training.domain.ReserveInfo;
+import com.fithub.fithubbackend.domain.Training.domain.Training;
 import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
-import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Getter
-@RequiredArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
 @Schema(description = "회원의 트레이닝 예약, 진행,종료 정보 확인")
 public class UsersReserveOutlineDto {
 
@@ -23,6 +20,9 @@ public class UsersReserveOutlineDto {
 
     @Schema(description = "트레이닝 id")
     private Long trainingId;
+
+    @Schema(description = "예약한 트레이닝의 트레이너 프로필 이미지")
+    private String trainerProfileImgUrl;
 
     @Schema(description = "트레이닝 제목")
     private String title;
@@ -44,17 +44,18 @@ public class UsersReserveOutlineDto {
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime modifiedDateTime;
 
-    @QueryProjection
-    public UsersReserveOutlineDto(Long reservationId, Long trainingId, String title, String location,
-                                  LocalDateTime reserveDateTime, ReserveStatus status,
-                                  LocalDateTime paymentDateTime, LocalDateTime modifiedDateTime) {
-        this.reservationId = reservationId;
-        this.trainingId = trainingId;
-        this.title = title;
-        this.location = location;
-        this.reserveDateTime = reserveDateTime;
-        this.status = status;
-        this.paymentDateTime = paymentDateTime;
-        this.modifiedDateTime = modifiedDateTime;
+    @Builder
+    public UsersReserveOutlineDto(ReserveInfo reserveInfo) {
+        Training training = reserveInfo.getTraining();
+
+        this.reservationId = reserveInfo.getId();
+        this.trainingId = training.getId();
+        this.trainerProfileImgUrl = training.getTrainer().getProfileUrl();
+        this.title = training.getTitle();
+        this.reserveDateTime = reserveInfo.getReserveDateTime();
+        this.location = training.getAddress();
+        this.status = reserveInfo.getStatus();
+        this.paymentDateTime = reserveInfo.getCreatedDate();
+        this.modifiedDateTime = reserveInfo.getModifiedDate();
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/review/UsersTrainingReviewDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/review/UsersTrainingReviewDto.java
@@ -13,6 +13,9 @@ import java.time.LocalDateTime;
 public class UsersTrainingReviewDto {
     private Long reviewId;
     private Long trainingId;
+
+    private String trainerProfileImg;
+
     private String trainingTitle;
 
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
@@ -29,6 +32,7 @@ public class UsersTrainingReviewDto {
         return UsersTrainingReviewDto.builder()
                 .reviewId(review.getId())
                 .trainingId(review.getTraining().getId())
+                .trainerProfileImg(review.getTraining().getTrainer().getProfileUrl())
                 .trainingTitle(review.getTraining().getTitle())
                 .reserveDateTime(review.getReserveInfo().getReserveDateTime())
                 .content(review.getContent())

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/CustomTrainingRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/CustomTrainingRepository.java
@@ -5,6 +5,7 @@ import com.fithub.fithubbackend.domain.Training.dto.TrainingSearchConditionDto;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.QUsersReserveOutlineDto;
 import com.fithub.fithubbackend.domain.Training.dto.reservation.UsersReserveOutlineDto;
 import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
+import com.fithub.fithubbackend.global.common.Category;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -38,7 +39,8 @@ public class CustomTrainingRepository {
                         keywordContains(conditions.getKeyword()),
                         startDateGoe(conditions.getStartDate()),
                         endDateLoe(conditions.getEndDate()),
-                        priceBetween(conditions.getLowestPrice(), conditions.getHighestPrice())
+                        priceBetween(conditions.getLowestPrice(), conditions.getHighestPrice()),
+                        categoryEqual(conditions.getCategory())
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -51,7 +53,8 @@ public class CustomTrainingRepository {
                         keywordContains(conditions.getKeyword()),
                         startDateGoe(conditions.getStartDate()),
                         endDateLoe(conditions.getEndDate()),
-                        priceBetween(conditions.getLowestPrice(), conditions.getHighestPrice())
+                        priceBetween(conditions.getLowestPrice(), conditions.getHighestPrice()),
+                        categoryEqual(conditions.getCategory())
                 )
                 .fetchOne();
 
@@ -103,6 +106,10 @@ public class CustomTrainingRepository {
 
     private BooleanExpression priceBetween(Integer lowestPrice, Integer highestPrice) {
         return lowestPrice != 0 || highestPrice != 0 ? training.price.between(lowestPrice, highestPrice) : null;
+    }
+
+    private BooleanExpression categoryEqual(Category category) {
+        return category != null ? training.categories.any().category.eq(category) : null;
     }
 
     private BooleanExpression statusCondition(ReserveStatus status) {

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ReserveInfoRepository extends JpaRepository<ReserveInfo, Long> {
-    Page<ReserveInfo> findByTrainerId(Long trainerId, Pageable pageable);
+    Page<ReserveInfo> findByUserIdAndStatusInOrderByStatusDesc(Long userId, List<@NotNull ReserveStatus> status, Pageable pageable);
     Page<ReserveInfo> findByUserIdAndStatus(Long userId, ReserveStatus status, Pageable pageable);
     List<ReserveInfo> findByTrainingIdAndStatus(Long trainingId, ReserveStatus status);
     boolean existsByTrainingIdAndStatusNotIn(Long trainingId, List<@NotNull ReserveStatus> status);


### PR DESCRIPTION
## pr 유형
- 기능 추가, 수정

## 변경사항
- 트레이닝 검색 시 카테고리 추가
- 회원의 트레이닝 예약 정보, 후기 조회 시에 트레이너 프로필 이미지 필요해서 dto에 추가
- 회원의 트레이닝 예약 정보 조회 시 querydsl 사용할 필요가 없어서 jpa로 변경

## 테스트 결과
- 트레이닝 검색 시 카테고리
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/0d994a07-34e9-45d5-90d4-efce353ed957)

- 회원의 트레이닝 예약 정보, 후기 조회 시 트레이너 프로필 이미지 추가
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/88c59e20-bbb0-48d5-b7a7-0c5286757126)

- 후기 조회 시 트레이너 프로필 이미지 추가
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/d439e7d1-26d6-4874-90b3-c65b85014a00)


## 추가 작업
- queryProjection 삭제로 compileJava 필요