### PR TITLE
fix: 키워드 없이 페이지 정렬 조건으로 게시글 검색 시 401 에러 발생 해결

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostSearchFilterDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/dto/PostSearchFilterDto.java
@@ -13,6 +13,6 @@ public class PostSearchFilterDto {
     private String keyword;
 
     @Schema(description = "검색 범위 (내용, 작성자, 해시태그)", example = "content")
-    private String scope = "content";
+    private String scope;
 
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/repository/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/repository/CustomPostRepositoryImpl.java
@@ -45,7 +45,10 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
     }
 
     private BooleanExpression scopeEq(PostSearchFilterDto filter) {
-        if (filter.getScope().equals("content"))
+        if (filter.getKeyword() == null)
+            return null;
+
+        if (filter.getScope() == null || filter.getScope().equals("content"))
             return post.content.containsIgnoreCase(filter.getKeyword());
         else if (filter.getScope().equals("writer"))
             return post.user.nickname.containsIgnoreCase(filter.getKeyword());


### PR DESCRIPTION
## PR 유형
- 에러 수정

## 반영 브랜치
- main -> main

## 변경 사항
- 키워드 없이 페이지 정렬 조건으로 게시글 검색 시 **401 에러 발생** 
    - **발생 원인** : 검색 필터 DTO 중 검색 범위(scope)가 null 인 경우, 디폴트 값으로 지정된 "content"로 바인딩 되지 않음. 생성자에도 기본값이 설정되어 있지 않음.
    - **해결** : 검색 범위의 디폴트로 지정된 값 삭제 및 CustomPostRepositoryImpl에 조건문 추가