### PR TITLE
feat: 트레이너 검색 기능

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerSearchController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerSearchController.java
@@ -1,0 +1,41 @@
+package com.fithub.fithubbackend.domain.trainer.api;
+
+import com.fithub.fithubbackend.domain.trainer.application.TrainerSearchService;
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerOutlineDto;
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerSearchFilterDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.*;
+
+@Tag(name = "trainer's search (트레이너 조회)", description = "인증이 필요없는 트레이너 조회 api")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/search/trainers")
+public class TrainerSearchController {
+
+    private final TrainerSearchService trainerSearchService;
+
+    @Operation(summary = "트레이너 검색(관심사, 검색 키워드, 성별). 사용할 검색 조건만 url 파라미터로 전달", parameters = {
+            @Parameter(name = "interest", description = "1개의 관심사(PILATES, HEALTH, PT, CROSSFIT, YOGA)"),
+            @Parameter(name = "keyword", description = "검색 키워드(트레이너 이름)"),
+            @Parameter(name = "gender", description = "성별 (F, M)"),
+            @Parameter(name = "pageable", description = "page(size = 9, sort = \"id\", desc 적용). 페이지 이동 시 page 값만 보내주면 됨. ex) \"page\" : 0 인 경우 1 페이지")
+    }, responses = {
+            @ApiResponse(responseCode = "200", description = "검색 완료"),
+    })
+    @GetMapping
+    public ResponseEntity<Page<TrainerOutlineDto>> searchTrainers(@ModelAttribute TrainerSearchFilterDto dto,
+                                                                  @PageableDefault(size = 9, sort = "id",  direction = Sort.Direction.DESC)  Pageable pageable) {
+        return ResponseEntity.ok(trainerSearchService.searchTrainers(dto, pageable));
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerSearchService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerSearchService.java
@@ -1,0 +1,12 @@
+package com.fithub.fithubbackend.domain.trainer.application;
+
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerOutlineDto;
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerSearchFilterDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface TrainerSearchService {
+    Page<TrainerOutlineDto> searchTrainers(TrainerSearchFilterDto dto, Pageable pageable);
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerSearchServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerSearchServiceImpl.java
@@ -1,0 +1,27 @@
+package com.fithub.fithubbackend.domain.trainer.application;
+
+import com.fithub.fithubbackend.domain.trainer.domain.Trainer;
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerOutlineDto;
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerSearchFilterDto;
+import com.fithub.fithubbackend.domain.trainer.repository.TrainerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+public class TrainerSearchServiceImpl implements TrainerSearchService {
+
+    private final TrainerRepository trainerRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<TrainerOutlineDto> searchTrainers(TrainerSearchFilterDto dto, Pageable pageable) {
+        Page<Trainer> trainers = trainerRepository.searchTrainers(dto, pageable);
+        return trainers.map(TrainerOutlineDto::toDto);
+    }
+
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerOutlineDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerOutlineDto.java
@@ -1,0 +1,61 @@
+package com.fithub.fithubbackend.domain.trainer.dto;
+
+import com.fithub.fithubbackend.domain.trainer.domain.Trainer;
+import com.fithub.fithubbackend.domain.user.domain.UserInterest;
+import com.fithub.fithubbackend.global.common.Category;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.util.List;
+
+@Setter @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class TrainerOutlineDto {
+
+    @Schema(description = "현재 일하는 장소")
+    private String address;
+
+    @Schema(description = "트레이너 id")
+    private long id;
+
+    @Schema(description = "트레이너 이름")
+    private String bio;
+
+    @Schema(description = "트레이너 이름")
+    private String name;
+
+    @Schema(description = "트레이너 이메일")
+    private String email;
+
+    @Schema(description = "트레이너 프로필 이미지")
+    private String profileUrl;
+
+    @Schema(description = "트레이너 전문 분야")
+    private List<Category> interests;
+
+    @Builder
+    public TrainerOutlineDto(long id, String bio, String address, String name, String email,
+                             String profileUrl, List<Category> interests) {
+        this.id = id;
+        this.bio = bio;
+        this.address = address;
+        this.name = name;
+        this.email = email;
+        this.profileUrl = profileUrl;
+        this.interests = interests;
+    }
+
+    public static TrainerOutlineDto toDto(Trainer trainer) {
+        return TrainerOutlineDto.builder()
+                .id(trainer.getId())
+                .bio(trainer.getUser().getBio())
+                .address(trainer.getAddress())
+                .name(trainer.getName())
+                .email(trainer.getEmail())
+                .profileUrl(trainer.getProfileUrl())
+                .interests(trainer.getUser().getInterests().stream().map(UserInterest::getInterest).toList())
+                .build();
+    }
+
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerSearchFilterDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerSearchFilterDto.java
@@ -1,0 +1,24 @@
+package com.fithub.fithubbackend.domain.trainer.dto;
+
+import com.fithub.fithubbackend.domain.user.enums.Gender;
+import com.fithub.fithubbackend.global.common.Category;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter @Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrainerSearchFilterDto {
+
+    @Schema(description = "관심사(PILATES, HEALTH, PT, CROSSFIT, YOGA). 여러 개 선택 불가능", example = "PILATES")
+    private Category interest;
+
+    @Schema(description = "검색 키워드(트레이너 이름)", example = "김핏헙")
+    private String keyword;
+
+    @Schema(description = "성별 (F, M)", example = "F")
+    private Gender gender;
+
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/repository/CustomTrainerRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/repository/CustomTrainerRepository.java
@@ -1,0 +1,11 @@
+package com.fithub.fithubbackend.domain.trainer.repository;
+
+import com.fithub.fithubbackend.domain.trainer.domain.Trainer;
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerSearchFilterDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomTrainerRepository {
+    Page<Trainer> searchTrainers(TrainerSearchFilterDto dto, Pageable pageable);
+
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/repository/CustomTrainerRepositoryImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/repository/CustomTrainerRepositoryImpl.java
@@ -1,0 +1,74 @@
+package com.fithub.fithubbackend.domain.trainer.repository;
+
+import com.fithub.fithubbackend.domain.trainer.domain.Trainer;
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerSearchFilterDto;
+import com.fithub.fithubbackend.domain.user.enums.Gender;
+import com.fithub.fithubbackend.global.common.Category;
+import com.querydsl.core.QueryResults;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.fithub.fithubbackend.domain.trainer.domain.QTrainer.trainer;
+import static com.fithub.fithubbackend.domain.user.domain.QUser.user;
+
+@Repository
+public class CustomTrainerRepositoryImpl implements CustomTrainerRepository {
+    private JPAQueryFactory jpaQueryFactory;
+
+    public CustomTrainerRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<Trainer> searchTrainers(TrainerSearchFilterDto filter, Pageable pageable) {
+        QueryResults<Trainer> trainers = jpaQueryFactory.selectFrom(trainer)
+                .where(interestEq(filter.getInterest()), genderEq((Gender) filter.getGender()), keywordContains((String) filter.getKeyword()))
+                .join(trainer.user, user).fetchJoin()
+                .orderBy(getOrderSpecifier(pageable).toArray(OrderSpecifier[]::new))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetchResults();
+
+        return new PageImpl<>(trainers.getResults(), pageable, trainers.getTotal());
+    }
+
+    private BooleanExpression genderEq(Gender gender) {
+        return gender != null ? trainer.user.gender.eq(gender) : null;
+    }
+
+    private BooleanExpression keywordContains(String keyword) {
+        return keyword != null ? trainer.name.containsIgnoreCase(keyword) : null;
+    }
+
+    private BooleanExpression interestEq(Category category) {
+        return category != null ? trainer.user.interests.any().interest.eq(category) : null;
+    }
+
+    private List<OrderSpecifier> getOrderSpecifier(Pageable pageable) {
+
+        List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
+
+        for (Sort.Order order : pageable.getSort()) {
+            Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+
+            switch (order.getProperty()) {
+                case "id":
+                    orderSpecifiers.add(new OrderSpecifier<>(direction, trainer.id));
+                    break;
+            }
+        }
+        return orderSpecifiers;
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/repository/TrainerRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/repository/TrainerRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface TrainerRepository extends JpaRepository<Trainer, Long> {
+public interface TrainerRepository extends JpaRepository<Trainer, Long>, CustomTrainerRepository {
     boolean existsByUserId(Long userId);
     Optional<Trainer> findByUserId(Long userId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/domain/UserInterest.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/domain/UserInterest.java
@@ -1,5 +1,6 @@
 package com.fithub.fithubbackend.domain.user.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fithub.fithubbackend.global.common.Category;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
@@ -17,6 +18,7 @@ public class UserInterest {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
 
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     private User user;
 

--- a/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
@@ -38,7 +38,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     };
 
     private static final String[] SHOULD_NOT_FILTER_GET_URI_LIST = new String[] {
-            "/training/**", "/auth/oauth/login", "/posts/**"
+            "/training/**", "/auth/oauth/login", "/posts/**", "/search/trainers"
     };
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig {
     };
 
     private static final String[] PERMIT_ALL_GET_PATTERNS = new String[] {
-        "/training/**", "/posts/**"
+        "/training/**", "/posts/**", "/search/trainers"
     };
 
     @Bean


### PR DESCRIPTION
## PR 유형
- 기능 추가

## 반영 브랜치
- main -> main

## 변경 사항
- 트레이너 검색 기능 추가
- 관심사 엔티티에 @JsonIgnore 사용하여 불필요한 속성(user) 제외

## 테스트 결과

### 트레이너 검색

> GET /search/trainers

- **request parameters** 
   - **interest**: 1개의 관심사(PILATES, HEALTH, PT, CROSSFIT, YOGA)
   - **keyword**: 검색 키워드(트레이너 이름)
   - **gender**: 트레이너 성별

- **request URL**
   - ex) http://localhost:8080/search/trainers?page=0&interest=YOGA&gender=F
![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/074b48cd-b676-4c05-b576-b489ecaa30f9)

## 논의 사항

### 트레이너 검색 api 
- **/trainers/search** 를 사용하면 트레이너 인증이 필요한 api와 구분되지 않으므로, **/search/trainers**로 변경

### 게시글, 트레이닝 검색 api
- 문제
   -  검색 필터를 **파라미터**로, 페이징을 **request body**로 전달 받으면, 전달 받은 페이징으로 적용되지 않는 문제 발생 
   - 페이징을 검색 필터와 같이 **파라미터**로 전달해야 페이징 적용
- 해결
   -  POST 대신 **GET**을 사용하여 검색 필터와 페이징을 **파라미터**로 전달