### PR TITLE
Update: 회원의 트레이닝 예약 내역에 가격 정보 추가, Feat: 트레이너 검색 시, 해당 트레이너의 모든 리뷰 조회 기능 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/UsersReserveOutlineDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/dto/reservation/UsersReserveOutlineDto.java
@@ -27,6 +27,9 @@ public class UsersReserveOutlineDto {
     @Schema(description = "트레이닝 제목")
     private String title;
 
+    @Schema(description = "트레이닝 가격")
+    private int price;
+
     @Schema(description = "예약한 트레이닝 날짜, 시간")
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime reserveDateTime;
@@ -52,6 +55,7 @@ public class UsersReserveOutlineDto {
         this.trainingId = training.getId();
         this.trainerProfileImgUrl = training.getTrainer().getProfileUrl();
         this.title = training.getTitle();
+        this.price = training.getPrice();
         this.reserveDateTime = reserveInfo.getReserveDateTime();
         this.location = training.getAddress();
         this.status = reserveInfo.getStatus();

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingRepository.java
@@ -17,7 +17,7 @@ public interface TrainingRepository extends JpaRepository<Training, Long> {
     List<Training> findByDeletedFalseAndClosedFalseAndTrainerId(Long trainerId);
 
     List<Training> findByDeletedFalseAndClosedFalseAndStartDateLessThanEqualAndEndDateGreaterThanEqual(LocalDate startDate, LocalDate endDate);
-
+    List<Training> findByTrainerId(Long trainerId);
     boolean existsByDeletedFalseAndClosedFalseAndTrainerId(Long trainerId);
 
     @Query(value = "SELECT * FROM training AS t WHERE t.deleted = false AND t.closed = false AND MBRContains(ST_LINESTRINGFROMTEXT(:pointFormat), t.point)", nativeQuery = true)

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingReviewRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingReviewRepository.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 public interface TrainingReviewRepository extends JpaRepository<TrainingReview, Long> {
     List<TrainingReview> findByUserIdOrderByIdDesc(Long userId);
     List<TrainingReview> findByLockedFalseAndTrainingId(Long trainingId);
-
     boolean existsByReserveInfoId(Long reserveInfoId);
     Optional<TrainingReview> findByReserveInfoId(Long reserveInfoId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerSearchController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerSearchController.java
@@ -2,6 +2,7 @@ package com.fithub.fithubbackend.domain.trainer.api;
 
 import com.fithub.fithubbackend.domain.trainer.application.TrainerSearchService;
 import com.fithub.fithubbackend.domain.trainer.dto.TrainerOutlineDto;
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerSearchAllReviewDto;
 import com.fithub.fithubbackend.domain.trainer.dto.TrainerSearchFilterDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -14,8 +15,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.*;
 
 @Tag(name = "trainer's search (트레이너 조회)", description = "인증이 필요없는 트레이너 조회 api")
 @RestController
@@ -37,5 +36,15 @@ public class TrainerSearchController {
     public ResponseEntity<Page<TrainerOutlineDto>> searchTrainers(@ModelAttribute TrainerSearchFilterDto dto,
                                                                   @PageableDefault(size = 9, sort = "id",  direction = Sort.Direction.DESC)  Pageable pageable) {
         return ResponseEntity.ok(trainerSearchService.searchTrainers(dto, pageable));
+    }
+
+    @Operation(summary = "트레이너 조회 시 트레이너의 트레이닝에 작성된 모든 리뷰 조회", parameters = {
+            @Parameter(name = "trainerId", description = "조회할 트레이너의 primary key(id)")
+    }, responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+    })
+    @GetMapping("/reviews")
+    public ResponseEntity<TrainerSearchAllReviewDto> getTrainerReviews (@RequestParam Long trainerId) {
+        return ResponseEntity.ok(trainerSearchService.searchTrainerReviews(trainerId));
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerSearchService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerSearchService.java
@@ -1,12 +1,13 @@
 package com.fithub.fithubbackend.domain.trainer.application;
 
 import com.fithub.fithubbackend.domain.trainer.dto.TrainerOutlineDto;
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerSearchAllReviewDto;
 import com.fithub.fithubbackend.domain.trainer.dto.TrainerSearchFilterDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.util.List;
-
 public interface TrainerSearchService {
     Page<TrainerOutlineDto> searchTrainers(TrainerSearchFilterDto dto, Pageable pageable);
+
+    TrainerSearchAllReviewDto searchTrainerReviews(Long trainerId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerSearchServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerSearchServiceImpl.java
@@ -1,7 +1,13 @@
 package com.fithub.fithubbackend.domain.trainer.application;
 
+import com.fithub.fithubbackend.domain.Training.domain.Training;
+import com.fithub.fithubbackend.domain.Training.domain.TrainingReview;
+import com.fithub.fithubbackend.domain.Training.dto.review.UsersTrainingReviewDto;
+import com.fithub.fithubbackend.domain.Training.repository.TrainingRepository;
+import com.fithub.fithubbackend.domain.Training.repository.TrainingReviewRepository;
 import com.fithub.fithubbackend.domain.trainer.domain.Trainer;
 import com.fithub.fithubbackend.domain.trainer.dto.TrainerOutlineDto;
+import com.fithub.fithubbackend.domain.trainer.dto.TrainerSearchAllReviewDto;
 import com.fithub.fithubbackend.domain.trainer.dto.TrainerSearchFilterDto;
 import com.fithub.fithubbackend.domain.trainer.repository.TrainerRepository;
 import lombok.RequiredArgsConstructor;
@@ -10,18 +16,50 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
 
 @Service
 @RequiredArgsConstructor
 public class TrainerSearchServiceImpl implements TrainerSearchService {
 
     private final TrainerRepository trainerRepository;
+    private final TrainingRepository trainingRepository;
+    private final TrainingReviewRepository reviewRepository;
 
     @Override
     @Transactional(readOnly = true)
     public Page<TrainerOutlineDto> searchTrainers(TrainerSearchFilterDto dto, Pageable pageable) {
         Page<Trainer> trainers = trainerRepository.searchTrainers(dto, pageable);
         return trainers.map(TrainerOutlineDto::toDto);
+    }
+
+    @Override
+    public TrainerSearchAllReviewDto searchTrainerReviews(Long trainerId) {
+        List<Training> trainingList = trainingRepository.findByTrainerId(trainerId);
+        List<Long> trainingIdList = trainingList.stream().mapToLong(Training::getId).boxed().toList();
+        List<UsersTrainingReviewDto> list = new ArrayList<>();
+
+        int reviewNum = 0;
+        int sum = 0;
+        for (Long id : trainingIdList) {
+            List<TrainingReview> trainingReviewList = reviewRepository.findByLockedFalseAndTrainingId(id);
+            reviewNum += trainingReviewList.size();
+            for (TrainingReview r : trainingReviewList) {
+                list.add(UsersTrainingReviewDto.toDto(r));
+                sum += r.getStar();
+            }
+        }
+
+        list.sort(Comparator.comparing(UsersTrainingReviewDto::getCreatedDate, Comparator.reverseOrder()));
+        return TrainerSearchAllReviewDto.builder()
+                .trainerId(trainerId)
+                .reviewNum(reviewNum)
+                .average((double)sum / reviewNum)
+                .list(list)
+                .build();
     }
 
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerSearchAllReviewDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerSearchAllReviewDto.java
@@ -1,0 +1,28 @@
+package com.fithub.fithubbackend.domain.trainer.dto;
+
+import com.fithub.fithubbackend.domain.Training.dto.review.UsersTrainingReviewDto;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrainerSearchAllReviewDto {
+    private Long trainerId;
+
+    private Double average;
+    private int reviewNum;
+
+    private List<UsersTrainingReviewDto> usersReviewList;
+
+    @Builder
+    public TrainerSearchAllReviewDto(Long trainerId, Double average, int reviewNum, List<UsersTrainingReviewDto> list) {
+        this.trainerId = trainerId;
+        this.average = average;
+        this.reviewNum = reviewNum;
+        this.usersReviewList = list;
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
@@ -38,7 +38,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     };
 
     private static final String[] SHOULD_NOT_FILTER_GET_URI_LIST = new String[] {
-            "/training/**", "/auth/oauth/login", "/posts/**", "/ws/chat", "/search/trainers"
+            "/training/**", "/auth/oauth/login", "/posts/**", "/ws/chat", "/search/trainers/**"
     };
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig {
     };
 
     private static final String[] PERMIT_ALL_GET_PATTERNS = new String[] {
-        "/training/**", "/posts/**", "/search/trainers"
+        "/training/**", "/posts/**", "/search/trainers/**"
     };
 
     @Bean


### PR DESCRIPTION
## pr 유형
- 기능 추가

## 변경 사항
1. 회원의 마이페이지 - 예약 내역 조회에 가격 정보 추가
2. 트레이너 검색 시, 해당 트레이너의 모든 리뷰 조회 기능 추가

## 테스트 결과
- 트레이너의 모든 리뷰 조회 기능 (최신순 정렬)
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/f8e4a6f4-0550-4206-ae60-b955d040eb75)
