### PR TITLE
feat: 좌표로 행정 구역 정보 받기 기능 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/user/dto/map/MapDocument.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/dto/map/MapDocument.java
@@ -1,0 +1,40 @@
+package com.fithub.fithubbackend.domain.user.dto.map;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Schema(description = "응답 결과")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MapDocument {
+
+    @Schema(description = "H(행정동) 또는 B(법정동)")
+    public String region_type;
+
+    @Schema(description = "region 코드")
+    public String code;
+
+    @Schema(description = "전체 지역 명칭")
+    public String address_name;
+
+    @Schema(description = "지역 1Depth, 시도 단위")
+    public String region_1depth_name;
+
+    @Schema(description = "지역 2Depth, 구 단위")
+    public String region_2depth_name;
+
+    @Schema(description = "지역 3Depth, 동 단위")
+    public String region_3depth_name;
+
+    @Schema(description = "지역 4Depth. region_type 이 법정동이며, 리 영역인 경우만 존재")
+    public String region_4depth_name;
+
+    @Schema(description = "경도(longitude)")
+    public double x;
+
+    @Schema(description = " 위도(latitude)")
+    public double y;
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/user/dto/map/MapResDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/dto/map/MapResDto.java
@@ -1,0 +1,19 @@
+package com.fithub.fithubbackend.domain.user.dto.map;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class MapResDto {
+
+    @Schema(description = "응답 관련 정보")
+    public Meta meta;
+
+    @Schema(description = "응답 결과")
+    public List<MapDocument> documents;
+
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/user/dto/map/Meta.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/dto/map/Meta.java
@@ -1,0 +1,14 @@
+package com.fithub.fithubbackend.domain.user.dto.map;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Data
+@Schema(description = "응답 관련 정보")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Meta {
+
+    @Schema(description = "검색어에 검색된 문서 수")
+    public int total_count;
+
+}

--- a/src/main/java/com/fithub/fithubbackend/global/util/KakaoMapUtil.java
+++ b/src/main/java/com/fithub/fithubbackend/global/util/KakaoMapUtil.java
@@ -1,15 +1,13 @@
 package com.fithub.fithubbackend.global.util;
 
+import com.fithub.fithubbackend.domain.user.dto.map.MapResDto;
+import com.google.gson.Gson;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
-import org.springframework.http.MediaType;
-import org.springframework.http.RequestEntity;
-import org.springframework.http.ResponseEntity;
-import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
@@ -41,5 +39,28 @@ public class KakaoMapUtil {
                 .build();
         ResponseEntity<String> result = restTemplate.exchange(requestEntity, String.class);
         return result.getBody();
+    }
+
+    public String getRegionAddress(double x, double y) {
+        String url = "https://dapi.kakao.com/v2/local/geo/coord2regioncode.json";
+
+        UriComponents  uri = UriComponentsBuilder.newInstance()
+                .fromHttpUrl(url)
+                .queryParam("x",x)
+                .queryParam("y",y)
+                .build();
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add("Authorization", "KakaoAK " + key);
+
+        HttpEntity requestMessage = new HttpEntity(httpHeaders);
+
+        ResponseEntity response = restTemplate.exchange(uri.toUriString(), HttpMethod.GET, requestMessage, String.class);
+
+        Gson gson = new Gson();
+
+        MapResDto mapped_data = gson.fromJson(response.getBody().toString(), MapResDto.class);
+        String target = mapped_data.documents.get(0).address_name;
+        return target;
     }
 }


### PR DESCRIPTION
## PR 유형
- 기능 추가

## 반영 브랜치
- update -> main

## 변경 사항
- 좌표로 행정 구역 정보 받기 

## 테스트 결과
![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/ce844ce7-7ef8-4f50-9244-c681551eda00)
![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/03165129-e077-41b2-8df4-06d8fa4bd8c5)


## 참고 자료
- 카카오맵 api
   - https://developers.kakao.com/docs/latest/ko/local/dev-guide#coord-to-district-response-body-meta 