### PR TITLE
feat: 트레이너 상세 조회 기능 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerSearchController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/api/TrainerSearchController.java
@@ -1,11 +1,12 @@
 package com.fithub.fithubbackend.domain.trainer.api;
 
 import com.fithub.fithubbackend.domain.trainer.application.TrainerSearchService;
-import com.fithub.fithubbackend.domain.trainer.dto.TrainerOutlineDto;
-import com.fithub.fithubbackend.domain.trainer.dto.TrainerSearchAllReviewDto;
-import com.fithub.fithubbackend.domain.trainer.dto.TrainerSearchFilterDto;
+import com.fithub.fithubbackend.domain.trainer.dto.*;
+import com.fithub.fithubbackend.global.exception.ErrorResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -46,5 +47,37 @@ public class TrainerSearchController {
     @GetMapping("/reviews")
     public ResponseEntity<TrainerSearchAllReviewDto> getTrainerReviews (@RequestParam Long trainerId) {
         return ResponseEntity.ok(trainerSearchService.searchTrainerReviews(trainerId));
+    }
+
+    @Operation(summary = "트레이너 상세 조회 시 프로필 조회", parameters = {
+            @Parameter(name = "trainerId", description = "조회할 트레이너의 primary key(id)")
+    }, responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 트레이너", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
+    })
+    @GetMapping("/{trainerId}")
+    public ResponseEntity<TrainerOutlineDto> getTrainerProfileInfo(@PathVariable Long trainerId) {
+        return ResponseEntity.ok(trainerSearchService.searchTrainerProfileInfo(trainerId));
+    }
+
+    @Operation(summary = "트레이너 상세 조회 시 자격 사항 조회", parameters = {
+            @Parameter(name = "trainerId", description = "조회할 트레이너의 primary key(id)")
+    }, responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+    })
+    @GetMapping("/licenses")
+    public ResponseEntity<TrainerSearchAllLicenseDto> getTrainerLicenses(@RequestParam Long trainerId) {
+        return ResponseEntity.ok(trainerSearchService.searchTrainerLicenses(trainerId));
+    }
+
+    @Operation(summary = "트레이너 상세 조회 시 현재 근무 중인 회사 조회", description = "근무 중인 회사가 없는 경우 null 반환",
+            parameters = {
+                    @Parameter(name = "trainerId", description = "조회할 트레이너의 primary key(id)")
+            }, responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+    })
+    @GetMapping("/company")
+    public ResponseEntity<TrainerSearchCompanyDto> getTrainerCompanyInfo(@RequestParam Long trainerId) {
+        return ResponseEntity.ok(trainerSearchService.searchTrainerCompanyInfo(trainerId));
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerSearchService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/application/TrainerSearchService.java
@@ -1,8 +1,6 @@
 package com.fithub.fithubbackend.domain.trainer.application;
 
-import com.fithub.fithubbackend.domain.trainer.dto.TrainerOutlineDto;
-import com.fithub.fithubbackend.domain.trainer.dto.TrainerSearchAllReviewDto;
-import com.fithub.fithubbackend.domain.trainer.dto.TrainerSearchFilterDto;
+import com.fithub.fithubbackend.domain.trainer.dto.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -10,4 +8,10 @@ public interface TrainerSearchService {
     Page<TrainerOutlineDto> searchTrainers(TrainerSearchFilterDto dto, Pageable pageable);
 
     TrainerSearchAllReviewDto searchTrainerReviews(Long trainerId);
+
+    TrainerSearchAllLicenseDto searchTrainerLicenses(Long trainerId);
+
+    TrainerSearchCompanyDto searchTrainerCompanyInfo(Long trainerId);
+
+    TrainerOutlineDto searchTrainerProfileInfo(Long trainerId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerOutlineDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerOutlineDto.java
@@ -13,7 +13,7 @@ import java.util.List;
 @AllArgsConstructor
 public class TrainerOutlineDto {
 
-    @Schema(description = "현재 일하는 장소")
+    @Schema(description = "근무 중인 회사 주소")
     private String address;
 
     @Schema(description = "트레이너 id")

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerSearchAllLicenseDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerSearchAllLicenseDto.java
@@ -1,0 +1,26 @@
+package com.fithub.fithubbackend.domain.trainer.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrainerSearchAllLicenseDto {
+
+    @Schema(description = "자격 사항 수")
+    private int totalCounts;
+
+    @Schema(description = "자격 사항 정보")
+    List<TrainerLicenseDto> licenses;
+
+    @Builder
+    public TrainerSearchAllLicenseDto(int totalCounts, List<TrainerLicenseDto> licenses) {
+        this.totalCounts = totalCounts;
+        this.licenses = licenses;
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerSearchCompanyDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/dto/TrainerSearchCompanyDto.java
@@ -1,0 +1,28 @@
+package com.fithub.fithubbackend.domain.trainer.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrainerSearchCompanyDto {
+
+    @Schema(description = "근무 중인 회사명")
+    private String company;
+
+    @Schema(description = "위도", example = "37.573319")
+    private Double latitude;
+
+    @Schema(description = "경도", example = "126.915444")
+    private Double longitude;
+
+    @Builder
+    public TrainerSearchCompanyDto(String company, Double latitude, Double longitude) {
+        this.company = company;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/repository/TrainerLicenseImgRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/repository/TrainerLicenseImgRepository.java
@@ -3,5 +3,9 @@ package com.fithub.fithubbackend.domain.trainer.repository;
 import com.fithub.fithubbackend.domain.trainer.domain.TrainerLicenseImg;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TrainerLicenseImgRepository extends JpaRepository<TrainerLicenseImg, Long> {
+
+    List<TrainerLicenseImg> findByTrainerId(long trainerId);
 }


### PR DESCRIPTION
## PR 유형
- 기능 추가

## 반영 브랜치
- main -> main

## 변경 사항
- 트레이너 상세 조회 기능 추가

## 테스트 결과

### 트레이너 프로필 조회

> /search/trainers/{trainerId}

![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/39d9e8ab-6f2f-4f0e-aebb-1ed57b946bda)
- **address**: 현재 근무 중인 회사 주소 
- **id**: 트레이너 id (pk)
- **name**: 트레이너 성명
- **email**: 이메일
- **profileUrl**: 프로필 이미지 url
- **interests**: 트레이너 전문 분야
 
<hr>

### 트레이너 자격증 조회

> /search/trainers/licenses

![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/ff68026e-7fb0-48fe-be93-300d4ed84420)
- **totalCounts**: 자격증 수
- **licenses**: 자격증 정보 
    - **licenseId**: 자격증 id (pk)
    - **url**: 자격증 이미지 url
    - **inputName**: 자격증 명

<hr>

### 트레이너 현재 근무 중인 회사 조회

> /search/trainers/company

![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/ed553ecc-dcb0-4b38-9a39-3c31fd3223dc)
- **company**: 현재 근무 중인 회사명
- **latitude**: 회사 위치의 위도 
 - **longitude**: 회사 위치의 경도
