### PR TITLE
Notify: 알림 기능 소켓으로 사용 추가, 알림 기능들 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingReservationServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingReservationServiceImpl.java
@@ -14,7 +14,10 @@ import com.fithub.fithubbackend.domain.Training.repository.TrainingReviewReposit
 import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
+import com.fithub.fithubbackend.global.notify.NotificationType;
+import com.fithub.fithubbackend.global.notify.dto.NotifyRequestDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -28,6 +31,8 @@ public class UserTrainingReservationServiceImpl implements UserTrainingReservati
 
     private final ReserveInfoRepository reserveInfoRepository;
     private final TrainingReviewRepository trainingReviewRepository;
+
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     public Page<UsersReserveOutlineDto> getTrainingReservationList(User user, ReserveStatus status, Pageable pageable) {
@@ -90,7 +95,18 @@ public class UserTrainingReservationServiceImpl implements UserTrainingReservati
                 .trainingReviewReqDto(dto)
                 .build();
 
-        return trainingReviewRepository.save(trainingReview).getId();
+        TrainingReview review = trainingReviewRepository.save(trainingReview);
+        eventPublisher.publishEvent(createReviewNotifyRequest(reserveInfo));
+        return review.getId();
+    }
+
+    private NotifyRequestDto createReviewNotifyRequest(ReserveInfo reserveInfo) {
+        return NotifyRequestDto.builder()
+                .receiver(reserveInfo.getTraining().getTrainer().getUser())
+                .content("트레이닝에 리뷰가 달렸습니다.")
+                .urlId(reserveInfo.getTraining().getId())
+                .type(NotificationType.NEW_REVIEW)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingReservationServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/UserTrainingReservationServiceImpl.java
@@ -82,7 +82,6 @@ public class UserTrainingReservationServiceImpl implements UserTrainingReservati
 
     @Override
     @Transactional
-    // TODO: 리뷰 작성 시 트레이닝의 트레이너에게 리뷰가 달렸다는 알림?
     public Long writeReviewOnCompletedReservation(User user, TrainingReviewReqDto dto) {
         ReserveInfo reserveInfo = findReserveInfoById(dto.getReservationId());
 

--- a/src/main/java/com/fithub/fithubbackend/global/domain/Notify.java
+++ b/src/main/java/com/fithub/fithubbackend/global/domain/Notify.java
@@ -1,0 +1,48 @@
+package com.fithub.fithubbackend.global.domain;
+
+import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.global.common.BaseTimeEntity;
+import com.fithub.fithubbackend.global.notify.NotificationType;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notify extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private User receiver;
+
+    @NotNull
+    private String content;
+
+    @NotNull
+    private String url;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    private NotificationType type;
+
+    @NotNull
+    private Boolean isRead;
+
+    @Builder
+    public Notify(User receiver, String content, String url, NotificationType type) {
+        this.receiver = receiver;
+        this.content = content;
+        this.url = url;
+        this.type = type;
+        this.isRead = false;
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/global/domain/Notify.java
+++ b/src/main/java/com/fithub/fithubbackend/global/domain/Notify.java
@@ -20,7 +20,7 @@ public class Notify extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @OnDelete(action = OnDeleteAction.CASCADE)
     private User receiver;
 
@@ -44,5 +44,9 @@ public class Notify extends BaseTimeEntity {
         this.url = url;
         this.type = type;
         this.isRead = false;
+    }
+
+    public void setStatusToRead() {
+        this.isRead = true;
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/global/notify/NotificationType.java
+++ b/src/main/java/com/fithub/fithubbackend/global/notify/NotificationType.java
@@ -1,0 +1,9 @@
+package com.fithub.fithubbackend.global.notify;
+
+public enum NotificationType {
+    COMMENT, LIKE_POST,
+    TRAINER_AUTHENTICATION_ACCEPT, TRAINER_AUTHENTICATION_REJECT,
+    NEW_RESERVATION, CANCEL_RESERVATION, NEW_REVIEW,
+    NOSHOW,
+    NEW_CHAT
+}

--- a/src/main/java/com/fithub/fithubbackend/global/notify/NotifyListener.java
+++ b/src/main/java/com/fithub/fithubbackend/global/notify/NotifyListener.java
@@ -1,0 +1,23 @@
+package com.fithub.fithubbackend.global.notify;
+
+import com.fithub.fithubbackend.global.notify.dto.NotifyRequestDto;
+import com.fithub.fithubbackend.global.notify.service.NotifyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class NotifyListener {
+
+    private final NotifyService notifyService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT) //커밋완료 후 작업
+    @Transactional(propagation = Propagation.REQUIRES_NEW)// 새로운 트랜잭션으로 구성
+    public void handleNotify(NotifyRequestDto dto) {
+        notifyService.notifyByRequest(dto);
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/global/notify/controller/NotifyController.java
+++ b/src/main/java/com/fithub/fithubbackend/global/notify/controller/NotifyController.java
@@ -1,0 +1,58 @@
+package com.fithub.fithubbackend.global.notify.controller;
+
+import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.global.domain.AuthUser;
+import com.fithub.fithubbackend.global.exception.CustomException;
+import com.fithub.fithubbackend.global.exception.ErrorCode;
+import com.fithub.fithubbackend.global.notify.dto.NotifyDto;
+import com.fithub.fithubbackend.global.notify.service.NotifyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/notify")
+public class NotifyController {
+
+    private final NotifyService notifyService;
+
+    @GetMapping("/count")
+    public ResponseEntity<Long> getUnReadNotiNum(@AuthUser User user) {
+        if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        return ResponseEntity.ok(notifyService.getUnReadNotiNum(user.getId()));
+    }
+    @GetMapping("/all")
+    public ResponseEntity<Page<NotifyDto>> getAllNotifyForUsers(@AuthUser User user,
+                                                                @PageableDefault(sort="id", size = 5, direction = Sort.Direction.DESC) Pageable pageable) {
+        if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        return ResponseEntity.ok(notifyService.getAllNotifyForUser(user.getId(), pageable));
+    }
+
+    @PutMapping("/select/status/read")
+    public ResponseEntity<String> setStatusRead(@AuthUser User user, @RequestParam Long notifyId) {
+        if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        notifyService.setStatusRead(notifyId);
+        return ResponseEntity.ok().body("완료");
+    }
+
+    @DeleteMapping("/select/delete")
+    public ResponseEntity<String> deleteNotify(@AuthUser User user, @RequestParam Long notifyId) {
+        if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        notifyService.deleteNoti(notifyId);
+        return ResponseEntity.ok().body("완료");
+    }
+
+    @DeleteMapping("/select/delete/list")
+    public ResponseEntity<String> deleteNotifyAll(@AuthUser User user, @RequestParam List<Long> notiList) {
+        if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        notifyService.deleteNotiAll(notiList);
+        return ResponseEntity.ok().body("완료");
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/global/notify/controller/NotifyController.java
+++ b/src/main/java/com/fithub/fithubbackend/global/notify/controller/NotifyController.java
@@ -6,6 +6,10 @@ import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
 import com.fithub.fithubbackend.global.notify.dto.NotifyDto;
 import com.fithub.fithubbackend.global.notify.service.NotifyService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,15 +23,24 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/notify")
+@Tag(name = "Notify 알림 관련 api", description = "알림 관련 api")
 public class NotifyController {
 
     private final NotifyService notifyService;
 
+
+    @Operation(summary = "읽지 않은 알림 개수 확인", responses = {
+            @ApiResponse(responseCode = "200", description = "읽지 않은 알림 개수 반환"),
+    })
     @GetMapping("/count")
     public ResponseEntity<Long> getUnReadNotiNum(@AuthUser User user) {
         if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         return ResponseEntity.ok(notifyService.getUnReadNotiNum(user.getId()));
     }
+
+    @Operation(summary = "모든 알림 조회(page 기본 size = 5, 최신순)", responses = {
+            @ApiResponse(responseCode = "200", description = "목록 조회"),
+    })
     @GetMapping("/all")
     public ResponseEntity<Page<NotifyDto>> getAllNotifyForUsers(@AuthUser User user,
                                                                 @PageableDefault(sort="id", size = 5, direction = Sort.Direction.DESC) Pageable pageable) {
@@ -35,6 +48,11 @@ public class NotifyController {
         return ResponseEntity.ok(notifyService.getAllNotifyForUser(user.getId(), pageable));
     }
 
+    @Operation(summary = "선택한 알림 읽음으로 처리 / 알림 선택 시 읽음 처리", parameters = {
+            @Parameter(name = "notifyId", description = "목록 조회시 dto에 담겨있는 id")
+    }, responses = {
+            @ApiResponse(responseCode = "200", description = "읽음 처리 성공")
+    })
     @PutMapping("/select/status/read")
     public ResponseEntity<String> setStatusRead(@AuthUser User user, @RequestParam Long notifyId) {
         if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
@@ -42,6 +60,11 @@ public class NotifyController {
         return ResponseEntity.ok().body("완료");
     }
 
+    @Operation(summary = "선택한 알림 삭제", parameters = {
+            @Parameter(name = "notifyId", description = "목록 조회시 dto에 담겨있는 id")
+    }, responses = {
+            @ApiResponse(responseCode = "200", description = "삭제 성공")
+    })
     @DeleteMapping("/select/delete")
     public ResponseEntity<String> deleteNotify(@AuthUser User user, @RequestParam Long notifyId) {
         if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
@@ -49,6 +72,11 @@ public class NotifyController {
         return ResponseEntity.ok().body("완료");
     }
 
+    @Operation(summary = "선택한 알림들 삭제, 네이버 메일같은것", parameters = {
+            @Parameter(name = "notiList", description = "목록 조회시 dto에 담겨있는 id 리스트")
+    }, responses = {
+            @ApiResponse(responseCode = "200", description = "읽음 처리 성공")
+    })
     @DeleteMapping("/select/delete/list")
     public ResponseEntity<String> deleteNotifyAll(@AuthUser User user, @RequestParam List<Long> notiList) {
         if (user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");

--- a/src/main/java/com/fithub/fithubbackend/global/notify/dto/NotifyDto.java
+++ b/src/main/java/com/fithub/fithubbackend/global/notify/dto/NotifyDto.java
@@ -1,0 +1,57 @@
+package com.fithub.fithubbackend.global.notify.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fithub.fithubbackend.global.domain.Notify;
+import com.fithub.fithubbackend.global.notify.NotificationType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "알림 dto")
+public class NotifyDto {
+
+    @NotNull
+    @Schema(description = "알림 primary key")
+    private Long id;
+
+    @NotNull
+    @Schema(description = "알림 내용")
+    private String content;
+
+    @NotNull
+    @Schema(description = "클릭 시 이동할 주소")
+    private String url;
+
+    @NotNull
+    @Schema(description = "알림 타입")
+    private NotificationType type;
+
+    @NotNull
+    @Schema(description = "알림 읽음 / 안 읽음")
+    private boolean read;
+
+    @Schema(description = "알림 생성일")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createDate;
+
+    @Schema(description = "알림 수정일 -> 알림 읽은 시간")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime modifiedDate;
+
+    @Builder
+    public NotifyDto (Notify notify) {
+        this.id = notify.getId();
+        this.content = notify.getContent();
+        this.url = notify.getUrl();
+        this.type = notify.getType();
+        this.read = notify.getIsRead();
+        this.createDate = notify.getCreatedDate();
+        this.modifiedDate = notify.getModifiedDate();
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/global/notify/dto/NotifyRequestDto.java
+++ b/src/main/java/com/fithub/fithubbackend/global/notify/dto/NotifyRequestDto.java
@@ -1,0 +1,40 @@
+package com.fithub.fithubbackend.global.notify.dto;
+
+import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.global.notify.NotificationType;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NotifyRequestDto {
+
+    @NotNull
+    private User receiver;
+
+    @NotNull
+    private String content;
+
+    private String url;
+
+    @NotNull
+    private NotificationType type;
+
+    @Builder
+    public NotifyRequestDto(User receiver, Long urlId, String content, NotificationType type) {
+        String url = switch (type) {
+            case COMMENT, LIKE_POST -> "/posts/" + urlId;
+            case NEW_RESERVATION, CANCEL_RESERVATION -> "/trainers/training/reservations/all";
+            case NEW_REVIEW -> "/training?" + urlId;
+            case NOSHOW -> "/users/training/reservation?" + urlId;
+            default -> null;
+        };
+
+        this.receiver = receiver;
+        this.content = content;
+        this.url = url;
+        this.type = type;
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/global/notify/repository/NotifyRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/global/notify/repository/NotifyRepository.java
@@ -1,7 +1,14 @@
 package com.fithub.fithubbackend.global.notify.repository;
 
 import com.fithub.fithubbackend.global.domain.Notify;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface NotifyRepository extends JpaRepository<Notify, Long> {
+    Long countByIsReadFalseAndReceiverId(Long receiverId);
+    Page<Notify> findByReceiverId(Long receiverId, Pageable pageable);
+    List<Notify> findByIdIn(List<Long> idList);
 }

--- a/src/main/java/com/fithub/fithubbackend/global/notify/repository/NotifyRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/global/notify/repository/NotifyRepository.java
@@ -1,0 +1,7 @@
+package com.fithub.fithubbackend.global.notify.repository;
+
+import com.fithub.fithubbackend.global.domain.Notify;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotifyRepository extends JpaRepository<Notify, Long> {
+}

--- a/src/main/java/com/fithub/fithubbackend/global/notify/service/NotifyService.java
+++ b/src/main/java/com/fithub/fithubbackend/global/notify/service/NotifyService.java
@@ -17,7 +17,7 @@ public class NotifyService {
 
     public void notifyByRequest(NotifyRequestDto dto) {
         notifyRepository.save(createNotify(dto.getReceiver(), dto.getContent(), dto.getUrl(), dto.getType()));
-        messagingTemplate.convertAndSend("/topic/alarm" + dto.getReceiver().getId(), dto.getContent());
+        messagingTemplate.convertAndSend("/topic/alarm/" + dto.getReceiver().getId(), dto.getContent());
     }
 
     private Notify createNotify(User receiver, String content, String url, NotificationType type) {

--- a/src/main/java/com/fithub/fithubbackend/global/notify/service/NotifyService.java
+++ b/src/main/java/com/fithub/fithubbackend/global/notify/service/NotifyService.java
@@ -1,0 +1,31 @@
+package com.fithub.fithubbackend.global.notify.service;
+
+import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.global.domain.Notify;
+import com.fithub.fithubbackend.global.notify.NotificationType;
+import com.fithub.fithubbackend.global.notify.dto.NotifyRequestDto;
+import com.fithub.fithubbackend.global.notify.repository.NotifyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotifyService {
+    private final SimpMessageSendingOperations messagingTemplate;
+    private final NotifyRepository notifyRepository;
+
+    public void notifyByRequest(NotifyRequestDto dto) {
+        notifyRepository.save(createNotify(dto.getReceiver(), dto.getContent(), dto.getUrl(), dto.getType()));
+        messagingTemplate.convertAndSend("/topic/alarm" + dto.getReceiver().getId(), dto.getContent());
+    }
+
+    private Notify createNotify(User receiver, String content, String url, NotificationType type) {
+        return Notify.builder()
+                .receiver(receiver)
+                .content(content)
+                .url(url)
+                .type(type)
+                .build();
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/global/notify/service/NotifyService.java
+++ b/src/main/java/com/fithub/fithubbackend/global/notify/service/NotifyService.java
@@ -1,31 +1,19 @@
 package com.fithub.fithubbackend.global.notify.service;
 
-import com.fithub.fithubbackend.domain.user.domain.User;
-import com.fithub.fithubbackend.global.domain.Notify;
-import com.fithub.fithubbackend.global.notify.NotificationType;
+import com.fithub.fithubbackend.global.notify.dto.NotifyDto;
 import com.fithub.fithubbackend.global.notify.dto.NotifyRequestDto;
-import com.fithub.fithubbackend.global.notify.repository.NotifyRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
-import org.springframework.stereotype.Service;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
-@Service
-@RequiredArgsConstructor
-public class NotifyService {
-    private final SimpMessageSendingOperations messagingTemplate;
-    private final NotifyRepository notifyRepository;
+import java.util.List;
 
-    public void notifyByRequest(NotifyRequestDto dto) {
-        notifyRepository.save(createNotify(dto.getReceiver(), dto.getContent(), dto.getUrl(), dto.getType()));
-        messagingTemplate.convertAndSend("/topic/alarm/" + dto.getReceiver().getId(), dto.getContent());
-    }
+public interface NotifyService {
+    void notifyByRequest(NotifyRequestDto dto);
 
-    private Notify createNotify(User receiver, String content, String url, NotificationType type) {
-        return Notify.builder()
-                .receiver(receiver)
-                .content(content)
-                .url(url)
-                .type(type)
-                .build();
-    }
+    Long getUnReadNotiNum(Long userId);
+    Page<NotifyDto> getAllNotifyForUser(Long userId, Pageable pageable);
+
+    void setStatusRead(Long id);
+    void deleteNoti(Long id);
+    void deleteNotiAll(List<Long> notiList);
 }

--- a/src/main/java/com/fithub/fithubbackend/global/notify/service/NotifyServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/global/notify/service/NotifyServiceImpl.java
@@ -1,0 +1,75 @@
+package com.fithub.fithubbackend.global.notify.service;
+
+import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.global.domain.Notify;
+import com.fithub.fithubbackend.global.exception.CustomException;
+import com.fithub.fithubbackend.global.exception.ErrorCode;
+import com.fithub.fithubbackend.global.notify.NotificationType;
+import com.fithub.fithubbackend.global.notify.dto.NotifyDto;
+import com.fithub.fithubbackend.global.notify.dto.NotifyRequestDto;
+import com.fithub.fithubbackend.global.notify.repository.NotifyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotifyServiceImpl implements NotifyService {
+    private final SimpMessageSendingOperations messagingTemplate;
+    private final NotifyRepository notifyRepository;
+
+    @Override
+    public void notifyByRequest(NotifyRequestDto dto) {
+        notifyRepository.save(createNotify(dto.getReceiver(), dto.getContent(), dto.getUrl(), dto.getType()));
+        messagingTemplate.convertAndSend("/topic/alarm/" + dto.getReceiver().getId(), dto.getContent());
+    }
+
+    private Notify createNotify(User receiver, String content, String url, NotificationType type) {
+        return Notify.builder()
+                .receiver(receiver)
+                .content(content)
+                .url(url)
+                .type(type)
+                .build();
+    }
+
+    @Override
+    public Long getUnReadNotiNum(Long userId) {
+        return notifyRepository.countByIsReadFalseAndReceiverId(userId);
+    }
+
+    @Override
+    public Page<NotifyDto> getAllNotifyForUser(Long userId, Pageable pageable) {
+        Page<Notify> notifyPage = notifyRepository.findByReceiverId(userId, pageable);
+        return notifyPage.map(NotifyDto::new);
+    }
+
+    @Override
+    @Transactional
+    public void setStatusRead(Long id) {
+        Notify notify = findNotify(id);
+        notify.setStatusToRead();
+    }
+
+    @Override
+    @Transactional
+    public void deleteNoti(Long id) {
+        notifyRepository.deleteById(id);
+    }
+
+    @Override
+    @Transactional
+    public void deleteNotiAll(List<Long> notiList) {
+        List<Notify> notifyList = notifyRepository.findByIdIn(notiList);
+        notifyRepository.deleteAll(notifyList);
+    }
+
+    private Notify findNotify(Long id) {
+        return notifyRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "해당하는 알림을 찾을 수 없습니다."));
+    }
+}


### PR DESCRIPTION
## pr 유형
- 기능 추가

## 변경 사항
- Notify 엔티티 추가
- 알림 SSE가 아닌 소켓으로 사용
  - SSE 코드 만들었으나 open-in-view=false 설정 시 너무 많은 에러 확인. 고치기 힘든 부분이 많음 + nginx 에서 제대로 돌아갈지 모르겠음 -> 채팅으로 소켓 사용하니 그냥 소켓으로 실시간 알림 보내도록
- 이벤트 리스너 사용으로 알림 보내도록
  - ApplicationEventPublisher의 publishEvent 호출하면 NotifyListener로 이동함

- 읽지 않은 알림 개수 조회
- 모든 알림 조회(page, size = 5)
- 선택한 알림 읽음 처리
- 선택한 알림 삭제, 선택 리스트 삭제

## 테스트 결과
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/5b8ea6d0-8d0f-439c-b891-9369e226fdaa)
후기 작성 시
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/c0b85a6b-f01c-43a5-a867-3c24dd8e5b9f)
구독한 사용자에게 알림 감 (사용자가 실시간으로 접속해 있어야 볼 수 있음)

- 읽지 않은 알림 개수 조회
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/d7d5375d-8881-4200-bbd9-4d86dcbcf02b)

- 알림 목록 조회
![image](https://github.com/team-Fithub/fithub-backend/assets/68698007/d162fd52-af9b-4bf8-bcd3-d1468161d4e7)

## 논의
@Songhee120 저희 소켓 통신을 /ws/chat으로 잡았는데 알림에도 쓰니까 /chat 없애고 fithub을 쓰거나 그냥 /ws 까지만 쓰는 거 어떨까요?? 그리고 chat 폴더에 있는 StompConfig와 handler 파일은 global 폴더로 옮기는 게 좋을 것 같은데 어떠신가요?
