### PR TITLE
feat: 채팅 메세지 조회

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatMessageController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatMessageController.java
@@ -2,15 +2,27 @@ package com.fithub.fithubbackend.domain.chat.api;
 
 import com.fithub.fithubbackend.domain.chat.application.ChatMessageService;
 import com.fithub.fithubbackend.domain.chat.dto.ChatMessageRequestDto;
+import com.fithub.fithubbackend.domain.chat.dto.ChatMessageResponseDto;
+import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.global.auth.JwtTokenProvider;
+import com.fithub.fithubbackend.global.domain.AuthUser;
 import com.fithub.fithubbackend.global.domain.UserAdapter;
+import com.fithub.fithubbackend.global.exception.CustomException;
+import com.fithub.fithubbackend.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -27,6 +39,17 @@ public class ChatMessageController {
         UserAdapter userAdapter = (UserAdapter) authentication.getPrincipal();
         chatMessageService.save(messageRequestDto, userAdapter.getUser());
         simpMessagingTemplate.convertAndSend("/topic/chatroom/" + messageRequestDto.getRoomId(), messageRequestDto.getMessage());
+    }
+
+    @Operation(summary = "채팅 메세지 조회", responses = {
+            @ApiResponse(responseCode = "200", description = "채팅 메세지 조회 완료"),
+    })
+    @GetMapping("/chatroom/message")
+    public ResponseEntity<List<ChatMessageResponseDto>> getChatList(@AuthUser User user, @RequestParam("chatRoomId") Long chatRoomId) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+
+        List<ChatMessageResponseDto> chatMessageResponseDtoList = chatMessageService.findAllByChatRoomId(chatRoomId);
+        return ResponseEntity.ok(chatMessageResponseDtoList);
     }
 }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatMessageController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatMessageController.java
@@ -47,7 +47,6 @@ public class ChatMessageController {
     @GetMapping("/chatroom/message")
     public ResponseEntity<List<ChatMessageResponseDto>> getChatList(@AuthUser User user, @RequestParam("chatRoomId") Long chatRoomId) {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
-
         List<ChatMessageResponseDto> chatMessageResponseDtoList = chatMessageService.findAllByChatRoomId(chatRoomId);
         return ResponseEntity.ok(chatMessageResponseDtoList);
     }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatMessageService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatMessageService.java
@@ -13,6 +13,6 @@ public interface ChatMessageService {
 
     void delete(final Long chatMessageId);
 
-    List<ChatMessageResponseDto> findAllByChatRoomIdDesc(final Long chatRoomId);
+    List<ChatMessageResponseDto> findAllByChatRoomId(final Long chatRoomId);
 
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatMessageServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatMessageServiceImpl.java
@@ -1,6 +1,5 @@
 package com.fithub.fithubbackend.domain.chat.application;
 
-import com.fithub.fithubbackend.domain.chat.domain.Chat;
 import com.fithub.fithubbackend.domain.chat.domain.ChatMessage;
 import com.fithub.fithubbackend.domain.chat.domain.ChatRoom;
 import com.fithub.fithubbackend.domain.chat.dto.ChatMessageRequestDto;
@@ -11,14 +10,14 @@ import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Sort;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class ChatMessageServiceImpl implements ChatMessageService{
@@ -55,7 +54,10 @@ public class ChatMessageServiceImpl implements ChatMessageService{
 
     @Transactional
     @Override
-    public List<ChatMessageResponseDto> findAllByChatRoomIdDesc(Long chatRoomId) {
-        return null;
+    public List<ChatMessageResponseDto> findAllByChatRoomId(Long chatRoomId) {
+        ChatRoom chatRoomEntity = this.chatRoomRepository.findById(chatRoomId).orElseThrow(
+                () -> new CustomException(ErrorCode.NOT_FOUND, "채팅방이 존재하지 않음"));
+        List<ChatMessage> chatMessageList = this.chatMessageRepository.findAllByChatRoomOrderByCreatedDateDesc(chatRoomEntity);
+        return  chatMessageList.stream().map(ChatMessageResponseDto::new).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomServiceImpl.java
@@ -2,7 +2,6 @@ package com.fithub.fithubbackend.domain.chat.application;
 
 import com.fithub.fithubbackend.domain.chat.domain.Chat;
 import com.fithub.fithubbackend.domain.chat.domain.ChatRoom;
-import com.fithub.fithubbackend.domain.chat.dto.ChatRequestDto;
 import com.fithub.fithubbackend.domain.chat.dto.ChatRoomResponseDto;
 import com.fithub.fithubbackend.domain.chat.repository.ChatRepository;
 import com.fithub.fithubbackend.domain.chat.repository.ChatRoomRepository;
@@ -15,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -36,20 +36,13 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         // Chat 테이블: 현재 유저의 채팅방 id와 채팅방 이름 가져옴
         List<Chat> chatList = this.chatRepository.findChatsById(user.getId());
 
-        // ChatRoom 테이블: 위에서 가져온 채팅방의 추가 정보를 가져옴
-        List<ChatRoomResponseDto> dtoList = new ArrayList<>();
-        Iterator<Chat> chatIterator = chatList.iterator();
-
-        while(chatIterator.hasNext()) {
-            Chat chat = chatIterator.next();
-            ChatRoomResponseDto dto = new ChatRoomResponseDto(chat);
-            dto.setModifiedDate(this.chatRoomRepository.findByRoomId(dto.getRoomId()).getModifiedDate());
-            dtoList.add(dto);
-        }
+        List<ChatRoomResponseDto> dtoList = chatList.stream()
+                .map(ChatRoomResponseDto::new)
+                .collect(Collectors.toList());
 
         // modifiedDate 기준으로 정렬
-        Comparator<ChatRoomResponseDto> comparator = Comparator.comparing(ChatRoomResponseDto::getModifiedDate);
-        Collections.sort(dtoList, comparator);
+        Comparator<ChatRoomResponseDto> comparator = Comparator.comparing(ChatRoomResponseDto::getLastMessageDate);
+        Collections.sort(dtoList, comparator.reversed());
         return dtoList;
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/domain/ChatMessage.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/domain/ChatMessage.java
@@ -36,5 +36,4 @@ public class ChatMessage extends BaseTimeEntity {
         this.chatRoom = chatRoom;
         this.message = message;
     }
-
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/dto/ChatMessageResponseDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/dto/ChatMessageResponseDto.java
@@ -2,6 +2,7 @@ package com.fithub.fithubbackend.domain.chat.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fithub.fithubbackend.domain.chat.domain.ChatMessage;
+import com.fithub.fithubbackend.global.domain.Document;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
@@ -12,9 +13,14 @@ public class ChatMessageResponseDto {
     @Schema(description = "메세지 id")
     private Long messageId;
 
-
     @Schema(description = "발신자 id")
     private Long senderId;
+
+    @Schema(description = "발신자 닉네임")
+    private String senderNickname;
+
+    @Schema(description = "발신자 프로필이미지")
+    private Document senderProfileImg;
 
     @Schema(description = "메세지 내용")
     private String message;
@@ -27,6 +33,8 @@ public class ChatMessageResponseDto {
     public ChatMessageResponseDto(ChatMessage entity) {
         this.messageId = entity.getMessageId();
         this.senderId = entity.getSender().getId();
+        this.senderNickname = entity.getSender().getNickname();
+        this.senderProfileImg = entity.getSender().getProfileImg();
         this.message = entity.getMessage();
         this.createdDate = entity.getCreatedDate();
     }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/dto/ChatMessageResponseDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/dto/ChatMessageResponseDto.java
@@ -2,12 +2,11 @@ package com.fithub.fithubbackend.domain.chat.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fithub.fithubbackend.domain.chat.domain.ChatMessage;
-import com.fithub.fithubbackend.domain.user.domain.User;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-
+@Getter
 public class ChatMessageResponseDto {
 
     @Schema(description = "메세지 id")

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/dto/ChatRoomResponseDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/dto/ChatRoomResponseDto.java
@@ -4,14 +4,12 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fithub.fithubbackend.domain.chat.domain.Chat;
 import com.fithub.fithubbackend.domain.chat.domain.ChatMessage;
-import com.fithub.fithubbackend.domain.chat.domain.ChatRoom;
-import com.fithub.fithubbackend.domain.chat.repository.ChatRoomRepository;
+import com.fithub.fithubbackend.global.domain.Document;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Getter
 @Setter
@@ -21,17 +19,35 @@ public class ChatRoomResponseDto {
     @Schema(description = "채팅방 id")
     private Long roomId;
 
-    @Schema(description = "채팅상대 이름")
+    @Schema(description = "채팅상대 이름(채팅방 이름)")
     private String roomName; // 채팅 상대 이름
+
+    @Schema(description = "채팅상대 프로필 이미지")
+    private Document senderProfileImg;
 
     @Schema(description = "채팅방 수정일")
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-    private LocalDateTime modifiedDate;
+    private LocalDateTime lastMessageDate;
+
+    @Schema(description = "마지막 채팅 내용")
+    private String lastMessage;
+
+    @Schema(description = "안읽은 채팅 개수")
+    private int unreadChatCount;
+
 
 
     public ChatRoomResponseDto(Chat entity) {
         this.roomId = entity.getChatPK().getChatRoom().getRoomId();
         this.roomName = entity.getChatRoomName();
+        this.senderProfileImg = entity.getChatPK().getUser().getProfileImg();
+
+        int messageListSize = entity.getChatPK().getChatRoom().getChatMessageList().size();
+        ChatMessage lastChatMessage = entity.getChatPK().getChatRoom().getChatMessageList().get(messageListSize - 1);
+        this.lastMessageDate = lastChatMessage.getCreatedDate();
+        this.lastMessage = lastChatMessage.getMessage();
+
+        this.unreadChatCount = 0;
     }
 
 

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/repository/ChatMessageRepository.java
@@ -8,5 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
-    List<ChatMessage> findAllByChatRoom(ChatRoom chatRoom, Sort sort);
+    List<ChatMessage> findAllByChatRoomOrderByCreatedDateDesc(ChatRoom chatRoom);
 }

--- a/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
@@ -38,7 +38,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     };
 
     private static final String[] SHOULD_NOT_FILTER_GET_URI_LIST = new String[] {
-            "/training/**", "/auth/oauth/login", "/posts/**", "/ws/chat", "/search/trainers"
+            "/training/**", "/auth/oauth/login", "/posts/**", "/ws", "/search/trainers"
     };
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
     private final OAuthFailureHandler oAuthFailureHandler;
 
     private static final String[] PERMIT_ALL_PATTERNS = new String[] {
-            "/", "/auth/**", "/oauth2/**", "/training/**", "/posts/**", "/ws/chat/**"
+            "/", "/auth/**", "/oauth2/**", "/training/**", "/posts/**", "/ws/**"
     };
 
     private static final String[] PERMIT_ALL_GET_PATTERNS = new String[] {

--- a/src/main/java/com/fithub/fithubbackend/global/config/stomp/StompConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/stomp/StompConfig.java
@@ -1,6 +1,5 @@
-package com.fithub.fithubbackend.domain.chat.config;
+package com.fithub.fithubbackend.global.config.stomp;
 
-import com.fithub.fithubbackend.domain.chat.Handler.StompHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
@@ -20,7 +19,7 @@ public class StompConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws/chat").setAllowedOrigins("*");
+        registry.addEndpoint("/ws").setAllowedOrigins("*");
     }
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/global/config/stomp/StompHandler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/stomp/StompHandler.java
@@ -1,4 +1,4 @@
-package com.fithub.fithubbackend.domain.chat.Handler;
+package com.fithub.fithubbackend.global.config.stomp;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,11 +14,11 @@ import org.springframework.stereotype.Component;
 public class StompHandler implements ChannelInterceptor {
 
 
-    // 메세지 전송 사전 작업 필요 시
+    // ws 송신 사전 작업 필요 시
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
-        log.info("presend 진입");
         return message;
     }
 }
+
 


### PR DESCRIPTION
## PR 유형
- 기능 추가
- 기능 수정
- 파일 위치 변경

## 반영 브랜치
- main -> main

## 변경 사항
- 채팅 메세지 조회 기능 추가 
- 채팅방 목록 조회 응답 데이터 추가
- stomp 설정 파일(config, handler) 위치 변경(global/config/stomp)
- 웹소켓 연결 요청 경로 변경 /ws/chat -> /ws
   
## 테스트 결과

### 채팅 메세지 조회

![image](https://github.com/team-Fithub/fithub-backend/assets/81075657/5fd73219-eed3-44d0-98a5-51d31392caab)

### 채팅 목록 조회

![image](https://github.com/team-Fithub/fithub-backend/assets/81075657/a14bac34-d97a-47fa-b851-644f49aa4b2e)

**'안읽은메세지개수(unreadChatCount)' 기능 구현 아직 되지 않은 관계로 우선 초기값 0으로 작성해두었습니다.**
