### PR TITLE
fix: 예약 동시성 문제 date가 아닌 time에 Lock으로 수정

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/AvailableDateRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/AvailableDateRepository.java
@@ -1,25 +1,12 @@
 package com.fithub.fithubbackend.domain.Training.repository;
 
 import com.fithub.fithubbackend.domain.Training.domain.AvailableDate;
-import jakarta.persistence.LockModeType;
-import jakarta.persistence.QueryHint;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.QueryHints;
 
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Optional;
 
 public interface AvailableDateRepository extends JpaRepository<AvailableDate, Long> {
-    @NotNull
-    @Override
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000")})
-    Optional<AvailableDate> findById(@NotNull Long aLong);
-
-    List<AvailableDate> findByTrainingIdOrderByDate(Long trainingId);
     Optional<AvailableDate> findByTrainingIdAndDate(Long trainingId, LocalDate date);
 
     boolean existsByEnabledTrueAndTrainingIdAndIdNot(Long trainingId, Long id);

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/AvailableTimeRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/AvailableTimeRepository.java
@@ -1,14 +1,25 @@
 package com.fithub.fithubbackend.domain.Training.repository;
 
 import com.fithub.fithubbackend.domain.Training.domain.AvailableTime;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.QueryHints;
 
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
 public interface AvailableTimeRepository extends JpaRepository<AvailableTime, Long> {
-    List<AvailableTime> findByAvailableDateIdOrderByTime(Long availableDateId);
+
+    @NotNull
+    @Override
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000")})
+    Optional<AvailableTime> findById(@NotNull Long id);
+
     boolean existsByEnabledTrueAndAvailableDateIdAndIdNot(Long availableDateId, Long id);
     boolean existsByEnabledTrueAndAvailableDateId(Long availableDateId);
     Optional<AvailableTime> findByEnabledTrueAndAvailableDateIdAndTime(Long availableDateId, LocalTime time);


### PR DESCRIPTION
## pr 유형
- 기능 수정

## 변경 사항
- 예약 동시성 문제를 해결하기 위해 기존에는 예약 시간 저장 api 에서 availableDate에 lock을 걸었으나 그 후에 availableTime에서 제대로 수정사항을 읽지 못 하는 걸 확인함
  - date대신 time에 lock으로 수정

## 테스트 결과
쓰레드로 테스트 시, 먼저 접근한 시간이 수정되면 그 후에 제대로 불가능한 시간으로 수정된 데이터를 읽고 오는 걸 확인함

```
2024-04-08 16:55:01.073  [TIME] - availableTimeRepository.findById, 트레이너입니다
2024-04-08 16:55:01.076  [TIME] - availableTimeRepository.findById, 서가람
Hibernate: 
    select
        ...
    from
        available_time a1_0 
    where
        a1_0.id=? 
        and (
            a1_0.deleted = 0
        ) for update wait 3
Hibernate: 
    select
        ...
    from
        available_time a1_0 
    where
        a1_0.id=? 
        and (
            a1_0.deleted = 0
        ) for update wait 3
2024-04-08 16:55:01.095  [TIME] - availbleTime: 63 true 서가람
Hibernate: 
    update
        available_time 
    set
        available_date_id=?,
        deleted=?,
        enabled=?,
        time=? 
    where
        id=?
Hibernate: 
    select
        a1_0.id 
    from
        available_time a1_0 
    where
        (
            a1_0.deleted = 0
        ) 
        and a1_0.enabled 
        and a1_0.available_date_id=? 
        and a1_0.id!=? limit ?
2024-04-08 16:55:01.356  [saveAndFlush] - closeReservationDateTime 후에 saveAndFlush, 서가람
2024-04-08 16:55:01.357  [saveAndFlush 후에 Time] - false 서가람
Hibernate: 
    select
        a1_0.id 
    from
        available_date a1_0 
    where
        (
            a1_0.deleted = 0
        ) 
        and a1_0.enabled 
        and a1_0.training_id=? 
        and a1_0.id!=? limit ?
...
2024-04-08 16:55:01.472  [TIME] - availableTime.isEnabled(): 63 false 트레이너입니다
Exception in thread "pool-3-thread-2" com.fithub.fithubbackend.global.exception.CustomException: 
해당 시간은 이미 예약되었습니다.
	at com.fithub.fithubbackend.domain.Training.application.PaymentServiceImpl.saveOrder(PaymentServiceImpl.java:79)

```