### PR TITLE
feat: 일반 회원 탈퇴 기능 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
@@ -2,6 +2,7 @@ package com.fithub.fithubbackend.domain.Training.repository;
 
 import com.fithub.fithubbackend.domain.Training.domain.ReserveInfo;
 import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
+import com.fithub.fithubbackend.domain.user.domain.User;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -17,6 +18,7 @@ public interface ReserveInfoRepository extends JpaRepository<ReserveInfo, Long> 
     Page<ReserveInfo> findByUserIdAndStatus(Long userId, ReserveStatus status, Pageable pageable);
     List<ReserveInfo> findByTrainingIdAndStatus(Long trainingId, ReserveStatus status);
     boolean existsByTrainingIdAndStatusNotIn(Long trainingId, List<@NotNull ReserveStatus> status);
+    boolean existsByUserAndStatusNotIn(User user, List<@NotNull ReserveStatus> status);
     boolean existsByTrainingId(Long trainingId);
 
     List<ReserveInfo> findByReserveDateTimeAndStatus(LocalDateTime now, ReserveStatus status);

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingLikesRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingLikesRepository.java
@@ -1,6 +1,7 @@
 package com.fithub.fithubbackend.domain.Training.repository;
 
 import com.fithub.fithubbackend.domain.Training.domain.TrainingLikes;
+import com.fithub.fithubbackend.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -12,4 +13,5 @@ public interface TrainingLikesRepository extends JpaRepository<TrainingLikes, Lo
     List<TrainingLikes> findByUserId(Long userId);
 
     List<TrainingLikes> findByTrainingId(Long trainingId);
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/repository/BookmarkRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/repository/BookmarkRepository.java
@@ -18,5 +18,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     boolean existsByUserAndPostId(User user, Long postId);
     @Query("select b.post from Bookmark b where b.user = :user")
     Page<Post> findPostsByUser(@Param("user") User user, Pageable pageable);
+    void deleteByUser(User user);
 
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/board/repository/LikesRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/repository/LikesRepository.java
@@ -21,4 +21,5 @@ public interface LikesRepository extends JpaRepository<Likes, Long> {
 
     @Query("select l.post from Likes l where l.user = :user")
     Page<Post> findPostsByUser(@Param("user") User user, Pageable pageable);
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/api/UserController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/api/UserController.java
@@ -2,14 +2,18 @@ package com.fithub.fithubbackend.domain.user.api;
 
 import com.fithub.fithubbackend.domain.user.application.UserService;
 import com.fithub.fithubbackend.domain.user.domain.User;
+import com.fithub.fithubbackend.domain.user.dto.CloseAccountReasonDto;
 import com.fithub.fithubbackend.domain.user.dto.InterestUpdateDto;
 import com.fithub.fithubbackend.domain.user.dto.ProfileDto;
 import com.fithub.fithubbackend.domain.user.dto.ProfileUpdateDto;
 import com.fithub.fithubbackend.global.domain.AuthUser;
 import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
+import com.fithub.fithubbackend.global.exception.ErrorResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -65,6 +69,19 @@ public class UserController {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         userService.updateInterest(interestUpdateDto, user);
         return ResponseEntity.ok().body("관심사 수정 완료");
+    }
+
+    @Operation(summary = "회원 탈퇴", responses = {
+            @ApiResponse(responseCode = "200", description = "탈퇴 성공"),
+            @ApiResponse(responseCode = "400", description = "예약 또는 진행 중인 트레이닝이 존재해 탈퇴 작업 불가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+    }, parameters = {
+            @Parameter(name="CloseAccountReasonDto", description = "탈퇴 사유 dto. reason 이 other(기타)가 아니라면 customReason 를 안 보내거나 null 로 보내주기.")
+    })
+    @PutMapping
+    public ResponseEntity<String> closeAccount(@AuthUser User user, @RequestBody CloseAccountReasonDto reason) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        userService.closeAccount(user, reason);
+        return ResponseEntity.ok().body("회원 탈퇴 완료");
     }
 
 

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/UserService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/UserService.java
@@ -2,6 +2,7 @@ package com.fithub.fithubbackend.domain.user.application;
 
 import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.domain.user.domain.UserInterest;
+import com.fithub.fithubbackend.domain.user.dto.CloseAccountReasonDto;
 import com.fithub.fithubbackend.domain.user.dto.InterestUpdateDto;
 import com.fithub.fithubbackend.domain.user.dto.ProfileDto;
 import com.fithub.fithubbackend.domain.user.dto.ProfileUpdateDto;
@@ -15,4 +16,5 @@ public interface UserService {
     void updateImage(MultipartFile profileImg, User user);
     void updateInterest(InterestUpdateDto interestUpdateDto, User user);
     List<UserInterest> getUserInterests(Long userId);
+    void closeAccount(User user, CloseAccountReasonDto reason);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/domain/ClosureReason.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/domain/ClosureReason.java
@@ -1,0 +1,35 @@
+package com.fithub.fithubbackend.domain.user.domain;
+
+import com.fithub.fithubbackend.domain.user.enums.ClosureReasonType;
+import com.fithub.fithubbackend.global.common.BaseTimeEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ClosureReason extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Schema(description = "탈퇴 사유")
+    @Enumerated(EnumType.STRING)
+    private ClosureReasonType reasonType;
+
+    @Schema(description = "회원이 직접 입력한 탈퇴 사유")
+    private String customReason;
+
+    @Builder
+    public ClosureReason (ClosureReasonType reasonType, String customReason) {
+        this.reasonType = reasonType;
+        this.customReason = customReason;
+    }
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/user/domain/User.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/domain/User.java
@@ -209,4 +209,18 @@ public class User extends BaseTimeEntity implements UserDetails {
     public boolean isTrainer() {
         return this.roles.contains("ROLE_TRAINER");
     }
+
+    public void deleteUser() {
+        this.name = "탈퇴 회원";
+        this.nickname = "탈퇴 회원";
+        this.email = "";
+        this.phone = "";
+        this.gender = Gender.UNDEFINED;
+        this.bio = null;
+        this.password = null;
+        this.status = Status.DELETE;
+        this.provider = null;
+        this.providerId = null;
+        roles.clear();
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/dto/CloseAccountReasonDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/dto/CloseAccountReasonDto.java
@@ -1,0 +1,24 @@
+package com.fithub.fithubbackend.domain.user.dto;
+
+import com.fithub.fithubbackend.domain.user.enums.ClosureReasonType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CloseAccountReasonDto {
+
+    @NotNull
+    @Schema(description = "탈퇴 사유")
+    @Enumerated(EnumType.STRING)
+    private ClosureReasonType closureReasonType;
+
+    @Schema(description = "회원이 직접 입력한 탈퇴 사유. closureReasonType 이 \"OTHER\" 일 경우에만 보내줌.")
+    private String customReason;
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/user/enums/ClosureReasonType.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/enums/ClosureReasonType.java
@@ -1,0 +1,11 @@
+package com.fithub.fithubbackend.domain.user.enums;
+
+public enum ClosureReasonType {
+
+    INSUFFICIENT_FACILITIES,
+    UNSATISFACTORY_SERVICE,
+    LOW_USAGE,
+    OTHER
+
+
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/user/enums/Status.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/enums/Status.java
@@ -1,5 +1,5 @@
 package com.fithub.fithubbackend.domain.user.enums;
 
 public enum Status {
-    NORMAL
+    NORMAL, DELETE
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/repository/ClosureReasonRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/repository/ClosureReasonRepository.java
@@ -1,0 +1,7 @@
+package com.fithub.fithubbackend.domain.user.repository;
+
+import com.fithub.fithubbackend.domain.user.domain.ClosureReason;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClosureReasonRepository extends JpaRepository<ClosureReason, Long> {
+}

--- a/src/main/java/com/fithub/fithubbackend/domain/user/repository/UserInterestRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/repository/UserInterestRepository.java
@@ -10,4 +10,5 @@ public interface UserInterestRepository extends JpaRepository<UserInterest, Long
     List<UserInterest> findByUser(User user);
 
     List<UserInterest> findByUserId(Long userId);
+    void deleteByUser(User user);
 }


### PR DESCRIPTION
## PR 유형
- 기능 추가

## 반영 브랜치
- main -> main

## 변경 사항

### 일반 회원 탈퇴 기능 추가
   - 탈퇴 전 탈퇴 사유 선택 및 입력
   - **관심사, 게시글 좋아요 및 북마크, 트레이닝 찜** 삭제
   - **회원의 개인 정보** (이메일, 비밀번호, 전화번호, 성별, 자기소개, roles 등)  null 또는 빈 문자열(””)로 변경
   - 회원 프로필 이미지가 기본 이미지가 아니라면, **기존 이미지 삭제 후 기본 이미지**로 변경
   - 작성한 게시글, 댓글, 트레이닝 후기에 "**탈퇴 회원**"으로 표시되도록 **사용자 이름 및 닉네임** 변경
   - DB에 탈퇴 회원으로 알도록 수정 ( soft delete / **status**를 **DELETE**로 변경)
   - **예약되거나 진행 중인 트레이닝**이 있을 경우 탈퇴 보류 (**400 error** 발생)

## 테스트 결과 

### 일반 회원 탈퇴

> PUT /users

**Request body**
- closureReasonType: 탈퇴 사유 (**INSUFFICIENT_FACILITIES(원하는 시설 부족), 
   UNSATISFACTORY_SERVICE(고객 응대에 대한 불만족, LOW_USAGE(낮은 사용 빈도), OTHER(기타)** 중 택 1)
- customReason: closureReasonType 이 "OTHER" 일 경우 값 전달. 회원이 직접 탈퇴 사유 입력.

<hr>

![탈퇴 불가능 사유](https://github.com/team-Fithub/fithub-backend/assets/106025529/28320dc0-5c19-49ca-b10a-a5dd64a3c511)
- **예약되거나 진행 중인 트레이닝**이 있을 경우 탈퇴 보류 (**400 error** 발생)
