### PR TITLE
feat: 채팅 메세지 알림 기능, 채팅방 목록 조회 데이터 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatMessageController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatMessageController.java
@@ -53,24 +53,5 @@ public class ChatMessageController {
         List<ChatMessageResponseDto> chatMessageResponseDtoList = chatMessageService.findAllByChatRoomId(chatRoomId);
         return ResponseEntity.ok(chatMessageResponseDtoList);
     }
-
-    @Operation(summary = "채팅방 참여하기", responses = {
-            @ApiResponse(responseCode = "200", description = "채팅방 참여(메세지 조회) 완료"),
-    })
-    @PostMapping("/chatroom/join")
-    public ResponseEntity<List<ChatMessageResponseDto>> joinChatRoom(@AuthUser User user, @RequestParam("receiverId") Long receiverId) {
-        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
-
-        long chatRoomId;
-        if(chatRoomService.hasChatRoom(user.getId())) {
-            chatRoomId = chatRoomService.findRoomIdByUserId(user.getId());
-        } else {
-            chatRoomId = chatRoomService.save(user, receiverId);
-        }
-
-        List<ChatMessageResponseDto> chatMessageResponseDtoList = chatMessageService.findAllByChatRoomId(chatRoomId);
-        simpMessagingTemplate.convertAndSend("/topic/chatroom/" + chatRoomId, chatRoomId);
-        return ResponseEntity.ok(chatMessageResponseDtoList);
-    }
 }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatMessageController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatMessageController.java
@@ -38,7 +38,6 @@ public class ChatMessageController {
         Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
         UserAdapter userAdapter = (UserAdapter) authentication.getPrincipal();
         chatMessageService.save(messageRequestDto, userAdapter.getUser());
-        simpMessagingTemplate.convertAndSend("/topic/chatroom/" + messageRequestDto.getRoomId(), messageRequestDto.getMessage());
     }
 
     @Operation(summary = "채팅 메세지 조회", responses = {
@@ -48,6 +47,7 @@ public class ChatMessageController {
     public ResponseEntity<List<ChatMessageResponseDto>> getChatList(@AuthUser User user, @RequestParam("chatRoomId") Long chatRoomId) {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         List<ChatMessageResponseDto> chatMessageResponseDtoList = chatMessageService.findAllByChatRoomId(chatRoomId);
+        simpMessagingTemplate.convertAndSend("/topic/chatroom/" + chatRoomId, chatRoomId);
         return ResponseEntity.ok(chatMessageResponseDtoList);
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatMessageController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatMessageController.java
@@ -41,6 +41,7 @@ public class ChatMessageController {
         Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
         UserAdapter userAdapter = (UserAdapter) authentication.getPrincipal();
         chatMessageService.save(messageRequestDto, userAdapter.getUser());
+        simpMessagingTemplate.convertAndSend("/topic/chatroom/" + messageRequestDto.getRoomId(), messageRequestDto.getMessage());
     }
 
     @Operation(summary = "채팅 메세지 조회", responses = {
@@ -50,7 +51,6 @@ public class ChatMessageController {
     public ResponseEntity<List<ChatMessageResponseDto>> getChatList(@AuthUser User user, @RequestParam("chatRoomId") Long chatRoomId) {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         List<ChatMessageResponseDto> chatMessageResponseDtoList = chatMessageService.findAllByChatRoomId(chatRoomId);
-        simpMessagingTemplate.convertAndSend("/topic/chatroom/" + chatRoomId, chatRoomId);
         return ResponseEntity.ok(chatMessageResponseDtoList);
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatMessageController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatMessageController.java
@@ -19,7 +19,6 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import lombok.extern.slf4j.Slf4j;
@@ -32,7 +31,6 @@ import java.util.List;
 public class ChatMessageController {
 
     private final ChatMessageService chatMessageService;
-    private final ChatRoomService chatRoomService;
     private final SimpMessagingTemplate simpMessagingTemplate;
     private final JwtTokenProvider jwtTokenProvider;
 

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatRoomController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatRoomController.java
@@ -1,6 +1,5 @@
 package com.fithub.fithubbackend.domain.chat.api;
 
-import com.fithub.fithubbackend.domain.chat.application.ChatMessageService;
 import com.fithub.fithubbackend.domain.chat.application.ChatRoomService;
 import com.fithub.fithubbackend.domain.chat.dto.ChatRoomResponseDto;
 import com.fithub.fithubbackend.domain.user.domain.User;

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatRoomController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatRoomController.java
@@ -1,6 +1,5 @@
 package com.fithub.fithubbackend.domain.chat.api;
 
-import com.fithub.fithubbackend.domain.chat.application.ChatMessageService;
 import com.fithub.fithubbackend.domain.chat.application.ChatRoomService;
 import com.fithub.fithubbackend.domain.chat.dto.ChatRoomResponseDto;
 import com.fithub.fithubbackend.domain.user.domain.User;
@@ -8,7 +7,6 @@ import com.fithub.fithubbackend.global.domain.AuthUser;
 import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,19 +20,6 @@ import java.util.List;
 public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
-    private final ChatMessageService chatMessageService;
-
-    @Operation(summary = "채팅방 생성", responses = {
-            @ApiResponse(responseCode = "200", description = "채팅방 생성 완료"),
-            }, parameters = {
-            @Parameter(name = "receiverId", description = "수신자 아이디"),
-    })
-    @PostMapping("/create")
-    public ResponseEntity<Void> createChat(@AuthUser User user, @RequestParam("receiverId") Long receiverId) {
-        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
-        chatRoomService.save(user, receiverId);
-        return ResponseEntity.ok().build();
-    }
 
     @Operation(summary = "채팅방 목록 조회", responses = {
             @ApiResponse(responseCode = "200", description = "채팅방 목록 조회 완료"),

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatRoomController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatRoomController.java
@@ -1,5 +1,6 @@
 package com.fithub.fithubbackend.domain.chat.api;
 
+import com.fithub.fithubbackend.domain.chat.application.ChatMessageService;
 import com.fithub.fithubbackend.domain.chat.application.ChatRoomService;
 import com.fithub.fithubbackend.domain.chat.dto.ChatRoomResponseDto;
 import com.fithub.fithubbackend.domain.user.domain.User;
@@ -7,18 +8,23 @@ import com.fithub.fithubbackend.global.domain.AuthUser;
 import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/chatroom")
 public class ChatRoomController {
 
+    @Autowired
     private final ChatRoomService chatRoomService;
 
     @Operation(summary = "채팅방 목록 조회", responses = {
@@ -30,5 +36,27 @@ public class ChatRoomController {
         return ResponseEntity.ok(chatRoomService.findChatRoomDesc(user));
     }
 
+    @Operation(summary = "채팅방 생성", responses = {
+            @ApiResponse(responseCode = "200", description = "채팅방 생성 완료"),
+    }, parameters = {
+            @Parameter(name = "receiverId", description = "수신자 아이디"),
+    })
+    @PostMapping("/create")
+    public ResponseEntity<Void> createChat(@AuthUser User user, @RequestParam("receiverId") Long receiverId) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        chatRoomService.save(user, receiverId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "기존 채팅방 존재 유무 확인", responses = {
+            @ApiResponse(responseCode = "200", description = "채팅방 존재 확인 완료"),
+    }, parameters = {
+            @Parameter(name = "receiverId", description = "수신자 아이디"),
+    })
+    @GetMapping("/check")
+    public ResponseEntity<Boolean> hasChatRoom(@AuthUser User user, @RequestParam("receiverId") Long receiverId) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        return ResponseEntity.ok(chatRoomService.hasChatRoom(user.getId(), receiverId));
+    }
 
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatMessageServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatMessageServiceImpl.java
@@ -15,7 +15,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -73,9 +72,9 @@ public class ChatMessageServiceImpl implements ChatMessageService{
                 () -> new CustomException(ErrorCode.NOT_FOUND, "채팅방이 존재하지 않음"));
         List<ChatMessage> chatMessageList = this.chatMessageRepository.findAllByChatRoomOrderByCreatedDateDesc(chatRoomEntity);
 
-        // 읽음 표시
-        if(!chatMessageList.get(0).isChecked()) {
-            this.chatMessageRepository.updateCheckedByRoomId(chatRoomId);
+        for (ChatMessage chatMessage : chatMessageList) {
+            chatMessage.updateChecked(true);
+            chatMessageRepository.save(chatMessage);
         }
 
         return  chatMessageList.stream().map(ChatMessageResponseDto::new).collect(Collectors.toList());

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatMessageServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatMessageServiceImpl.java
@@ -72,7 +72,12 @@ public class ChatMessageServiceImpl implements ChatMessageService{
         ChatRoom chatRoomEntity = this.chatRoomRepository.findById(chatRoomId).orElseThrow(
                 () -> new CustomException(ErrorCode.NOT_FOUND, "채팅방이 존재하지 않음"));
         List<ChatMessage> chatMessageList = this.chatMessageRepository.findAllByChatRoomOrderByCreatedDateDesc(chatRoomEntity);
+
+        // 읽음 표시
+        if(!chatMessageList.get(0).isChecked()) {
+            this.chatMessageRepository.updateCheckedByRoomId(chatRoomId);
+        }
+
         return  chatMessageList.stream().map(ChatMessageResponseDto::new).collect(Collectors.toList());
     }
-
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatMessageServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatMessageServiceImpl.java
@@ -5,12 +5,14 @@ import com.fithub.fithubbackend.domain.chat.domain.ChatRoom;
 import com.fithub.fithubbackend.domain.chat.dto.ChatMessageRequestDto;
 import com.fithub.fithubbackend.domain.chat.dto.ChatMessageResponseDto;
 import com.fithub.fithubbackend.domain.chat.repository.ChatMessageRepository;
+import com.fithub.fithubbackend.domain.chat.repository.ChatRepository;
 import com.fithub.fithubbackend.domain.chat.repository.ChatRoomRepository;
 import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +26,9 @@ public class ChatMessageServiceImpl implements ChatMessageService{
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final ChatRepository chatRepository;
+    private final SimpMessagingTemplate simpMessagingTemplate;
+
 
     @Transactional
     @Override
@@ -35,13 +40,22 @@ public class ChatMessageServiceImpl implements ChatMessageService{
 
     @Transactional
     @Override
-    public Long save(ChatMessageRequestDto requestDto, User user) {
+    public Long save(ChatMessageRequestDto requestDto, User sender) {
         ChatMessage message = ChatMessage.builder()
                     .chatRoom(chatRoomRepository.findByRoomId(requestDto.getRoomId()))
                     .message(requestDto.getMessage())
-                    .sender(user)
+                    .sender(sender)
                     .build();
-        return chatMessageRepository.save(message).getMessageId();
+        chatMessageRepository.save(message);
+
+        // 메세지 알림
+        Long roomId = message.getChatRoom().getRoomId();
+        List<User> users = chatRepository.findUsersByRoomId(roomId);
+        users.remove(sender);
+        Long receiverId = users.get(0).getId();
+        simpMessagingTemplate.convertAndSend("/topic/alarm/" + receiverId, "새로운 채팅!");
+
+        return message.getMessageId();
     }
 
     @Transactional
@@ -60,4 +74,5 @@ public class ChatMessageServiceImpl implements ChatMessageService{
         List<ChatMessage> chatMessageList = this.chatMessageRepository.findAllByChatRoomOrderByCreatedDateDesc(chatRoomEntity);
         return  chatMessageList.stream().map(ChatMessageResponseDto::new).collect(Collectors.toList());
     }
+
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomService.java
@@ -19,7 +19,7 @@ public interface ChatRoomService {
     /* ChatRoom 삭제 */
     public void delete(final Long id);
 
-    public boolean hasChatRoom(final Long userId);
+    public boolean hasChatRoom(final Long userId, final Long receiverId);
 
     public long findRoomIdByUserId(final long userId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomService.java
@@ -19,4 +19,7 @@ public interface ChatRoomService {
     /* ChatRoom 삭제 */
     public void delete(final Long id);
 
+    public boolean hasChatRoom(final Long userId);
+
+    public long findRoomIdByUserId(final long userId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomServiceImpl.java
@@ -43,6 +43,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         // modifiedDate 기준으로 정렬
         Comparator<ChatRoomResponseDto> comparator = Comparator.comparing(ChatRoomResponseDto::getLastMessageDate);
         Collections.sort(dtoList, comparator.reversed());
+
         return dtoList;
     }
 

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomServiceImpl.java
@@ -84,8 +84,20 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     }
 
     @Override
-    public boolean hasChatRoom(Long userId) {
-        return this.chatRepository.existsByChatPK_UserId(userId);
+    public boolean hasChatRoom(Long userId, Long receiverId) {
+       List<Long> roomIdsOfUser = chatRepository.findChatsById(userId)
+               .stream()
+               .map(Chat::getChatRoomId)
+               .collect(Collectors.toList());
+
+        List<Long> roomIdsOfReceiver = chatRepository.findChatsById(receiverId)
+                .stream()
+                .map(Chat::getChatRoomId)
+                .collect(Collectors.toList());
+
+        roomIdsOfUser.retainAll(roomIdsOfReceiver);
+
+        return !roomIdsOfUser.isEmpty();
     }
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomServiceImpl.java
@@ -82,4 +82,14 @@ public class ChatRoomServiceImpl implements ChatRoomService {
                 () -> new CustomException(ErrorCode.NOT_FOUND, "채팅룸이 존재하지 않음"));
         this.chatRoomRepository.delete(entity);
     }
+
+    @Override
+    public boolean hasChatRoom(Long userId) {
+        return this.chatRepository.existsByChatPK_UserId(userId);
+    }
+
+    @Override
+    public long findRoomIdByUserId(long userId) {
+        return this.chatRepository.findChatByChatPK_UserId(userId).getChatPK().getChatRoom().getRoomId();
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/domain/Chat.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/domain/Chat.java
@@ -21,4 +21,8 @@ public class Chat {
         this.chatPK = new ChatPK(chatRoom, user);
         this.chatRoomName = chatRoomName;
     }
+
+    public long getChatRoomId() {
+        return this.chatPK.getChatRoom().getRoomId();
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/domain/ChatMessage.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/domain/ChatMessage.java
@@ -35,5 +35,6 @@ public class ChatMessage extends BaseTimeEntity {
         this.sender = sender;
         this.chatRoom = chatRoom;
         this.message = message;
+        this.checked = false;
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/domain/ChatMessage.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/domain/ChatMessage.java
@@ -37,4 +37,8 @@ public class ChatMessage extends BaseTimeEntity {
         this.message = message;
         this.checked = false;
     }
+
+    public void updateChecked(boolean checked) {
+        this.checked = checked;
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/dto/ChatRoomResponseDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/dto/ChatRoomResponseDto.java
@@ -32,8 +32,8 @@ public class ChatRoomResponseDto {
     @Schema(description = "마지막 채팅 내용")
     private String lastMessage;
 
-    @Schema(description = "안읽은 채팅 개수")
-    private int unreadChatCount;
+    @Schema(description = "안읽은 채팅 메세지 존재 여부")
+    private boolean hasUnreadChatMessage;
 
     public ChatRoomResponseDto(Chat entity) {
         this.roomId = entity.getChatPK().getChatRoom().getRoomId();
@@ -44,7 +44,7 @@ public class ChatRoomResponseDto {
         ChatMessage lastChatMessage = entity.getChatPK().getChatRoom().getChatMessageList().get(messageListSize - 1);
         this.lastMessageDate = lastChatMessage.getCreatedDate();
         this.lastMessage = lastChatMessage.getMessage();
-        this.unreadChatCount = lastChatMessage.isChecked()? 0 : 1;
+        this.hasUnreadChatMessage = !lastChatMessage.isChecked();
     }
 
 

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/dto/ChatRoomResponseDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/dto/ChatRoomResponseDto.java
@@ -35,8 +35,6 @@ public class ChatRoomResponseDto {
     @Schema(description = "안읽은 채팅 개수")
     private int unreadChatCount;
 
-
-
     public ChatRoomResponseDto(Chat entity) {
         this.roomId = entity.getChatPK().getChatRoom().getRoomId();
         this.roomName = entity.getChatRoomName();

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/dto/ChatRoomResponseDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/dto/ChatRoomResponseDto.java
@@ -44,8 +44,7 @@ public class ChatRoomResponseDto {
         ChatMessage lastChatMessage = entity.getChatPK().getChatRoom().getChatMessageList().get(messageListSize - 1);
         this.lastMessageDate = lastChatMessage.getCreatedDate();
         this.lastMessage = lastChatMessage.getMessage();
-
-        this.unreadChatCount = 0;
+        this.unreadChatCount = lastChatMessage.isChecked()? 0 : 1;
     }
 
 

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/repository/ChatMessageRepository.java
@@ -11,8 +11,4 @@ import java.util.List;
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
     List<ChatMessage> findAllByChatRoomOrderByCreatedDateDesc(ChatRoom chatRoom);
 
-    @Modifying
-    @Query("UPDATE ChatMessage c SET c.checked = true WHERE c.chatRoom.roomId = :roomId")
-    void updateCheckedByRoomId(Long roomId);
-
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/repository/ChatMessageRepository.java
@@ -14,4 +14,5 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     @Modifying
     @Query("UPDATE ChatMessage c SET c.checked = true WHERE c.chatRoom.roomId = :roomId")
     void updateCheckedByRoomId(Long roomId);
+
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/repository/ChatMessageRepository.java
@@ -2,11 +2,16 @@ package com.fithub.fithubbackend.domain.chat.repository;
 
 import com.fithub.fithubbackend.domain.chat.domain.ChatMessage;
 import com.fithub.fithubbackend.domain.chat.domain.ChatRoom;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
     List<ChatMessage> findAllByChatRoomOrderByCreatedDateDesc(ChatRoom chatRoom);
+
+    @Modifying
+    @Query("UPDATE ChatMessage c SET c.checked = true WHERE c.chatRoom.roomId = :roomId")
+    void updateCheckedByRoomId(Long roomId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/repository/ChatRepository.java
@@ -14,8 +14,6 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
     @Query("SELECT e.chatPK.user FROM Chat e WHERE e.chatPK.chatRoom.roomId = :roomId")
     List<User> findUsersByRoomId(Long roomId);
 
-    boolean existsByChatPK_UserId(Long userId);
-
     Chat findChatByChatPK_UserId(Long userId);
 
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/repository/ChatRepository.java
@@ -1,14 +1,16 @@
 package com.fithub.fithubbackend.domain.chat.repository;
 
 import com.fithub.fithubbackend.domain.chat.domain.Chat;
-import com.fithub.fithubbackend.domain.chat.domain.ChatPK;
+import com.fithub.fithubbackend.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface ChatRepository extends JpaRepository<Chat, Long> {
     @Query("SELECT e FROM Chat e WHERE e.chatPK.user.id = :id")
     List<Chat> findChatsById(Long id);
+
+    @Query("SELECT e.chatPK.user FROM Chat e WHERE e.chatPK.chatRoom.roomId = :roomId")
+    List<User> findUsersByRoomId(Long roomId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/repository/ChatRepository.java
@@ -13,4 +13,9 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
 
     @Query("SELECT e.chatPK.user FROM Chat e WHERE e.chatPK.chatRoom.roomId = :roomId")
     List<User> findUsersByRoomId(Long roomId);
+
+    boolean existsByChatPK_UserId(Long userId);
+
+    Chat findChatByChatPK_UserId(Long userId);
+
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/repository/ChatRepository.java
@@ -8,8 +8,8 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface ChatRepository extends JpaRepository<Chat, Long> {
-    @Query("SELECT e FROM Chat e WHERE e.chatPK.user.id = :id")
-    List<Chat> findChatsById(Long id);
+    @Query("SELECT e FROM Chat e WHERE e.chatPK.user.id = :userId")
+    List<Chat> findChatsById(Long userId);
 
     @Query("SELECT e.chatPK.user FROM Chat e WHERE e.chatPK.chatRoom.roomId = :roomId")
     List<User> findUsersByRoomId(Long roomId);

--- a/src/main/java/com/fithub/fithubbackend/domain/user/api/AuthController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/api/AuthController.java
@@ -1,10 +1,8 @@
 package com.fithub.fithubbackend.domain.user.api;
 
 import com.fithub.fithubbackend.domain.user.application.AuthService;
-import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.domain.user.dto.*;
 import com.fithub.fithubbackend.global.auth.TokenInfoDto;
-import com.fithub.fithubbackend.global.domain.AuthUser;
 import com.fithub.fithubbackend.global.exception.ErrorResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -29,6 +27,7 @@ import java.io.IOException;
 @RequestMapping("/auth")
 public class AuthController {
     private final AuthService authService;
+
 
     @Operation(summary = "회원가입 swagger에서 사용 불가능. postman으로 테스트 가능 (multipart/form-data)", responses = {
             @ApiResponse(responseCode = "200", description = "회원 생성"),

--- a/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/application/AuthServiceImpl.java
@@ -23,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -53,6 +54,8 @@ public class AuthServiceImpl implements AuthService {
     private final HeaderUtil headerUtil;
 
     private final AwsS3Uploader awsS3Uploader;
+
+    private final SimpMessagingTemplate simpMessagingTemplate;
 
     @Value("${default.image.address}")
     private String profileImgUrl;

--- a/src/main/java/com/fithub/fithubbackend/global/config/stomp/StompHandler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/stomp/StompHandler.java
@@ -8,16 +8,15 @@ import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.stereotype.Component;
 
 
+
 @RequiredArgsConstructor
 @Component
 @Slf4j
 public class StompHandler implements ChannelInterceptor {
 
-
-    // ws 송신 사전 작업 필요 시
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
-        return message;
+        return ChannelInterceptor.super.preSend(message, channel);
     }
 }
 


### PR DESCRIPTION
## PR 유형
- 기능 추가
- 기능 수정

## 반영 브랜치
- main -> main

## 변경 사항

#### 새로운 메세지 알림 기능 추가
- 로그인 시, /topic/alarm/{userId} 구독
- 새로운 메세지 전송하면 /queue/alarm/{userId}로 '새로운 채팅!' 발행

#### 채팅방 목록 조회 시, (각 방에 새 메세지 있음/없음) 데이터 추가
- unreadChatCnt 0: 안 읽은 메세지 없음
- unreadChatCnt 1: 안 읽은 메세지 있음

#### 채팅방 생성 -> 채팅하기로 기능 변경 
- 채팅방 없을 시: 채팅방 생성 후 메세지 내용 조회
- 채팅방 있을 시: 바로 메세지 내용 조회

## 테스트 결과 

### 새로운 메세지 알림 기능 추가
![image](https://github.com/team-Fithub/fithub-backend/assets/81075657/d266969a-c343-42df-bfc0-cb5b10615e5b)
경로 'notification'에서 'alarm' 으로 변경해뒀습니다.

### 채팅방 목록 조회 시, (각 방에 새 메세지 있음/없음) 데이터 추가 
![image](https://github.com/team-Fithub/fithub-backend/assets/81075657/f09c0d8d-152e-4eeb-b0bc-81e01c1facb7)

### 채팅방 생성 -> 채팅하기로 기능 변경 (추가 변경 내용 아래 참고)
![image](https://github.com/team-Fithub/fithub-backend/assets/81075657/b970ee1e-187e-4f16-b609-293ac8e4acc8)

## 기능/테스트 추가!

### 기존 채팅방 존재 여부 검사: /chatroom/check
채팅 생성 api 다시 남겨뒀습니다.
![image](https://github.com/team-Fithub/fithub-backend/assets/81075657/3439cd2a-d060-4a89-89b8-fc704a68b667)



