### PR TITLE
Fix: ec2에서 웹소켓 연결 에러 수정, 알림 구독 사용자id -> email로 변경

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatMessageServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatMessageServiceImpl.java
@@ -51,8 +51,8 @@ public class ChatMessageServiceImpl implements ChatMessageService{
         Long roomId = message.getChatRoom().getRoomId();
         List<User> users = chatRepository.findUsersByRoomId(roomId);
         users.remove(sender);
-        Long receiverId = users.get(0).getId();
-        simpMessagingTemplate.convertAndSend("/topic/alarm/" + receiverId, "새로운 채팅!");
+        String receiverEmail = users.get(0).getEmail();
+        simpMessagingTemplate.convertAndSend("/topic/alarm/" + receiverEmail, "새로운 채팅!");
 
         return message.getMessageId();
     }

--- a/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fithub/fithubbackend/global/auth/JwtAuthenticationFilter.java
@@ -38,7 +38,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     };
 
     private static final String[] SHOULD_NOT_FILTER_GET_URI_LIST = new String[] {
-            "/training/**", "/auth/oauth/login", "/posts/**", "/ws", "/search/trainers/**"
+            "/training/**", "/auth/oauth/login", "/posts/**", "/ws/**", "/search/trainers/**"
     };
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/SecurityConfig.java
@@ -24,7 +24,6 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
-import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -98,11 +97,11 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration corsConfiguration = new CorsConfiguration();
-        corsConfiguration.addAllowedOriginPattern("*");
         corsConfiguration.setAllowCredentials(true);
-        corsConfiguration.setAllowedHeaders(List.of("*"));
-        corsConfiguration.setAllowedMethods(List.of("*"));
-        corsConfiguration.setExposedHeaders(List.of("Authorization"));
+        corsConfiguration.addAllowedOriginPattern("*");
+        corsConfiguration.addAllowedHeader("*");
+        corsConfiguration.addAllowedMethod("*");
+        corsConfiguration.addExposedHeader("Authorization");
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", corsConfiguration);

--- a/src/main/java/com/fithub/fithubbackend/global/config/stomp/StompConfig.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/stomp/StompConfig.java
@@ -19,13 +19,13 @@ public class StompConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws").setAllowedOrigins("*");
+        registry.addEndpoint("/ws/stomp").setAllowedOriginPatterns("*");
     }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
-        config.enableSimpleBroker("/topic");
-        config.setApplicationDestinationPrefixes("/queue");
+        config.enableSimpleBroker("/topic", "/queue");
+        config.setApplicationDestinationPrefixes("/app");
     }
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/global/config/stomp/StompHandler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/config/stomp/StompHandler.java
@@ -1,12 +1,13 @@
 package com.fithub.fithubbackend.global.config.stomp;
 
+import com.fithub.fithubbackend.global.auth.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.stereotype.Component;
-
 
 
 @RequiredArgsConstructor
@@ -14,10 +15,21 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class StompHandler implements ChannelInterceptor {
 
+    private final JwtTokenProvider jwtTokenProvider;
+
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
-        return ChannelInterceptor.super.preSend(message, channel);
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+//        String token = accessor.getFirstNativeHeader("Authorization");
+        log.info("[StompHandler] - accessor command: {}", accessor.getCommand());
+//        if (accessor.getCommand() == StompCommand.CONNECT) {
+//            if (StringUtils.hasText(token) && token.startsWith("Bearer")) {
+//                token = token.substring(7);
+//            }
+//            if (!jwtTokenProvider.validateToken(token)) {
+//                throw new CustomException(ErrorCode.AUTHENTICATION_ERROR);
+//            }
+//        }
+        return message;
     }
 }
-
-

--- a/src/main/java/com/fithub/fithubbackend/global/notify/service/NotifyServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/global/notify/service/NotifyServiceImpl.java
@@ -26,7 +26,7 @@ public class NotifyServiceImpl implements NotifyService {
     @Override
     public void notifyByRequest(NotifyRequestDto dto) {
         notifyRepository.save(createNotify(dto.getReceiver(), dto.getContent(), dto.getUrl(), dto.getType()));
-        messagingTemplate.convertAndSend("/topic/alarm/" + dto.getReceiver().getId(), dto.getContent());
+        messagingTemplate.convertAndSend("/topic/alarm/" + dto.getReceiver().getEmail(), dto.getContent());
     }
 
     private Notify createNotify(User receiver, String content, String url, NotificationType type) {


### PR DESCRIPTION
## pr 유형
- 수정

## 변경사항
- 서버에 배포하면 웹소켓 연결 안 되는 문제
  -  설정에서 setAllowedOrigins -> setAllowedOriginPatterns으로 수정. 현재 cors설정에서 allowCredentials=true라 해당 설정이 아닌 originPatterns를 사용해야됨
  - /ws -> /ws/stomp 변경
 - 웹소켓 설정에서 /topic, /queue 둘 다 구독 용도라는 걸 알게되고 수정, 클라이언트가 보낼 때는 /app을 사용하도록 수정
 - Stomphandler에서 jwt 검사로 인증된 사용자만 가능하도록 코드 추가 (현재는 주석, 프론트 코드 된 것 같으면 수정)
 - 로그인 시, 프론트에서 가지고 있는 정보는 이메일이라 알림 구독을 사용자 id가 아닌 이메일로 수정