### PR TITLE
update: 채팅방 api 반환값 수정, 메세지 조회 반환값 데이터 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatMessageController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatMessageController.java
@@ -1,7 +1,6 @@
 package com.fithub.fithubbackend.domain.chat.api;
 
 import com.fithub.fithubbackend.domain.chat.application.ChatMessageService;
-import com.fithub.fithubbackend.domain.chat.application.ChatRoomService;
 import com.fithub.fithubbackend.domain.chat.dto.ChatMessageRequestDto;
 import com.fithub.fithubbackend.domain.chat.dto.ChatMessageResponseDto;
 import com.fithub.fithubbackend.domain.user.domain.User;

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatMessageController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatMessageController.java
@@ -48,7 +48,7 @@ public class ChatMessageController {
     @GetMapping("/chatroom/message")
     public ResponseEntity<List<ChatMessageResponseDto>> getChatList(@AuthUser User user, @RequestParam("chatRoomId") Long chatRoomId) {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
-        List<ChatMessageResponseDto> chatMessageResponseDtoList = chatMessageService.findAllByChatRoomId(chatRoomId);
+        List<ChatMessageResponseDto> chatMessageResponseDtoList = chatMessageService.findAllByChatRoomId(chatRoomId, user.getId());
         return ResponseEntity.ok(chatMessageResponseDtoList);
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatRoomController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatRoomController.java
@@ -53,7 +53,7 @@ public class ChatRoomController {
             @Parameter(name = "receiverId", description = "수신자 아이디"),
     })
     @GetMapping("/check")
-    public ResponseEntity<Boolean> hasChatRoom(@AuthUser User user, @RequestParam("receiverId") Long receiverId) {
+    public ResponseEntity<Long> hasChatRoom(@AuthUser User user, @RequestParam("receiverId") Long receiverId) {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         return ResponseEntity.ok(chatRoomService.hasChatRoom(user.getId(), receiverId));
     }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatRoomController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatRoomController.java
@@ -41,10 +41,9 @@ public class ChatRoomController {
             @Parameter(name = "receiverId", description = "수신자 아이디"),
     })
     @PostMapping("/create")
-    public ResponseEntity<Void> createChat(@AuthUser User user, @RequestParam("receiverId") Long receiverId) {
+    public ResponseEntity<Long> createChat(@AuthUser User user, @RequestParam("receiverId") Long receiverId) {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
-        chatRoomService.save(user, receiverId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(chatRoomService.save(user, receiverId));
     }
 
     @Operation(summary = "기존 채팅방 존재 유무 확인", responses = {

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatMessageService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatMessageService.java
@@ -7,12 +7,11 @@ import com.fithub.fithubbackend.domain.user.domain.User;
 import java.util.List;
 
 public interface ChatMessageService {
-    ChatMessageResponseDto findById(final Long chatMessageId);
 
     Long save(final ChatMessageRequestDto requestDto, final User user);
 
     void delete(final Long chatMessageId);
 
-    List<ChatMessageResponseDto> findAllByChatRoomId(final Long chatRoomId);
+    List<ChatMessageResponseDto> findAllByChatRoomId(final Long chatRoomId, final Long userId);
 
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatMessageServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatMessageServiceImpl.java
@@ -28,15 +28,6 @@ public class ChatMessageServiceImpl implements ChatMessageService{
     private final ChatRepository chatRepository;
     private final SimpMessagingTemplate simpMessagingTemplate;
 
-
-    @Transactional
-    @Override
-    public ChatMessageResponseDto findById(Long chatMessageId) {
-        ChatMessage chatMessageEntity = this.chatMessageRepository.findById(chatMessageId).orElseThrow(
-                () -> new CustomException(ErrorCode.NOT_FOUND, "채팅 메세지가 존재하지 않음"));
-        return new ChatMessageResponseDto(chatMessageEntity);
-    }
-
     @Transactional
     @Override
     public Long save(ChatMessageRequestDto requestDto, User sender) {
@@ -67,16 +58,18 @@ public class ChatMessageServiceImpl implements ChatMessageService{
 
     @Transactional
     @Override
-    public List<ChatMessageResponseDto> findAllByChatRoomId(Long chatRoomId) {
+    public List<ChatMessageResponseDto> findAllByChatRoomId(Long chatRoomId, Long userId) {
         ChatRoom chatRoomEntity = this.chatRoomRepository.findById(chatRoomId).orElseThrow(
                 () -> new CustomException(ErrorCode.NOT_FOUND, "채팅방이 존재하지 않음"));
-        List<ChatMessage> chatMessageList = this.chatMessageRepository.findAllByChatRoomOrderByCreatedDateDesc(chatRoomEntity);
+        List<ChatMessage> chatMessageList = this.chatMessageRepository.findAllByChatRoomOrderByCreatedDate(chatRoomEntity);
 
         for (ChatMessage chatMessage : chatMessageList) {
             chatMessage.updateChecked(true);
             chatMessageRepository.save(chatMessage);
         }
 
-        return  chatMessageList.stream().map(ChatMessageResponseDto::new).collect(Collectors.toList());
+        return chatMessageList.stream()
+                .map(entity -> new ChatMessageResponseDto(entity, userId))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomService.java
@@ -19,7 +19,7 @@ public interface ChatRoomService {
     /* ChatRoom 삭제 */
     public void delete(final Long id);
 
-    public boolean hasChatRoom(final Long userId, final Long receiverId);
+    public Long hasChatRoom(final Long userId, final Long receiverId);
 
     public long findRoomIdByUserId(final long userId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomServiceImpl.java
@@ -84,7 +84,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     }
 
     @Override
-    public boolean hasChatRoom(Long userId, Long receiverId) {
+    public Long hasChatRoom(Long userId, Long receiverId) {
        List<Long> roomIdsOfUser = chatRepository.findChatsById(userId)
                .stream()
                .map(Chat::getChatRoomId)
@@ -97,7 +97,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
         roomIdsOfUser.retainAll(roomIdsOfReceiver);
 
-        return !roomIdsOfUser.isEmpty();
+        return roomIdsOfUser.isEmpty() ? null : roomIdsOfUser.get(0);
     }
 
     @Override

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/dto/ChatMessageResponseDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/dto/ChatMessageResponseDto.java
@@ -13,8 +13,11 @@ public class ChatMessageResponseDto {
     @Schema(description = "메세지 id")
     private Long messageId;
 
-    @Schema(description = "발신자 id")
-    private Long senderId;
+//    @Schema(description = "발신자 id")
+//    private Long senderId;
+
+    @Schema(description = "발신자 구분")
+    private boolean isMe;
 
     @Schema(description = "발신자 닉네임")
     private String senderNickname;
@@ -30,9 +33,9 @@ public class ChatMessageResponseDto {
     private LocalDateTime createdDate;
 
 
-    public ChatMessageResponseDto(ChatMessage entity) {
+    public ChatMessageResponseDto(ChatMessage entity, long userId) {
         this.messageId = entity.getMessageId();
-        this.senderId = entity.getSender().getId();
+        this.isMe = entity.getSender().getId() == userId? true : false;
         this.senderNickname = entity.getSender().getNickname();
         this.senderProfileImg = entity.getSender().getProfileImg();
         this.message = entity.getMessage();

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/repository/ChatMessageRepository.java
@@ -9,6 +9,6 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
-    List<ChatMessage> findAllByChatRoomOrderByCreatedDateDesc(ChatRoom chatRoom);
+    List<ChatMessage> findAllByChatRoomOrderByCreatedDate(ChatRoom chatRoom);
 
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/repository/ChatMessageRepository.java
@@ -3,8 +3,6 @@ package com.fithub.fithubbackend.domain.chat.repository;
 import com.fithub.fithubbackend.domain.chat.domain.ChatMessage;
 import com.fithub.fithubbackend.domain.chat.domain.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 


### PR DESCRIPTION
## PR 유형
- 수정

## 반영 브랜치
- main-> main

## 변경 사항
- 채팅방 존재 여부 체크 기능: 채팅방 id 리턴으로 변경
- 채팅방 생성 기능: 채팅방 id 리턴으로 변경
- 메세지 응답 dto isMe 데이터 추가
- 메세지 조회 시 정렬 날짜 기준 오름차순

## 테스트 결과
![image](https://github.com/team-Fithub/fithub-backend/assets/81075657/c64ef4e5-a818-45ee-990f-2da2112f1fdf)
![image](https://github.com/team-Fithub/fithub-backend/assets/81075657/2dfe9716-75af-4520-a8ec-452ce64bfcdb)
![image](https://github.com/team-Fithub/fithub-backend/assets/81075657/9c5bc994-523a-4836-87ee-601a5abe14b1)



