### PR TITLE
feat: 트레이너 탈퇴 기능 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/ReserveInfoRepository.java
@@ -2,6 +2,7 @@ package com.fithub.fithubbackend.domain.Training.repository;
 
 import com.fithub.fithubbackend.domain.Training.domain.ReserveInfo;
 import com.fithub.fithubbackend.domain.Training.enums.ReserveStatus;
+import com.fithub.fithubbackend.domain.trainer.domain.Trainer;
 import com.fithub.fithubbackend.domain.user.domain.User;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.data.domain.Page;
@@ -19,6 +20,7 @@ public interface ReserveInfoRepository extends JpaRepository<ReserveInfo, Long> 
     List<ReserveInfo> findByTrainingIdAndStatus(Long trainingId, ReserveStatus status);
     boolean existsByTrainingIdAndStatusNotIn(Long trainingId, List<@NotNull ReserveStatus> status);
     boolean existsByUserAndStatusNotIn(User user, List<@NotNull ReserveStatus> status);
+    boolean existsByTrainerAndStatusNotIn(Trainer trainer, List<@NotNull ReserveStatus> status);
     boolean existsByTrainingId(Long trainingId);
 
     List<ReserveInfo> findByReserveDateTimeAndStatus(LocalDateTime now, ReserveStatus status);

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/TrainingRepository.java
@@ -19,7 +19,7 @@ public interface TrainingRepository extends JpaRepository<Training, Long> {
     List<Training> findByDeletedFalseAndClosedFalseAndStartDateLessThanEqualAndEndDateGreaterThanEqual(LocalDate startDate, LocalDate endDate);
     List<Training> findByTrainerId(Long trainerId);
     boolean existsByDeletedFalseAndClosedFalseAndTrainerId(Long trainerId);
-
+    boolean existsByTrainerIdAndEndDateAfter(Long trainerId, LocalDate now);
     @Query(value = "SELECT * FROM training AS t WHERE t.deleted = false AND t.closed = false AND MBRContains(ST_LINESTRINGFROMTEXT(:pointFormat), t.point)", nativeQuery = true)
     List<Training> findByPoint(@Param("pointFormat")String pointFormat, Pageable pageable);
 

--- a/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/Trainer.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/trainer/domain/Trainer.java
@@ -81,4 +81,12 @@ public class Trainer extends BaseTimeEntity {
     public void grantPermission() {
         this.user.getRoles().add("ROLE_TRAINER");
     }
+
+    public void clearUpTrainer(String profileUrl) {
+        this.name = "탈퇴 회원";
+        this.email = "";
+        this.point = null;
+        this.profileUrl = profileUrl;
+        this.address = null;
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/api/UserController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/api/UserController.java
@@ -74,6 +74,7 @@ public class UserController {
     @Operation(summary = "회원 탈퇴", responses = {
             @ApiResponse(responseCode = "200", description = "탈퇴 성공"),
             @ApiResponse(responseCode = "400", description = "예약 또는 진행 중인 트레이닝이 존재해 탈퇴 작업 불가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "409", description = "모집 중인 트레이닝이 존재해 탈퇴 작업 불가능", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
     }, parameters = {
             @Parameter(name="CloseAccountReasonDto", description = "탈퇴 사유 dto. reason 이 other(기타)가 아니라면 customReason 를 안 보내거나 null 로 보내주기.")
     })

--- a/src/main/java/com/fithub/fithubbackend/global/exception/ErrorCode.java
+++ b/src/main/java/com/fithub/fithubbackend/global/exception/ErrorCode.java
@@ -36,7 +36,8 @@ public enum ErrorCode {
     PERMISSION_DENIED(HttpStatus.FORBIDDEN, "해당 작업을 수행할 권한이 없습니다."),
 
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-    POINT_PARSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "좌표 변환 중 에러가 발생했습니다. 좌표를 다시 설정해주세요");
+    POINT_PARSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "좌표 변환 중 에러가 발생했습니다. 좌표를 다시 설정해주세요"),
+    CONFLICT_TRAINING(HttpStatus.CONFLICT, "모집 중인 트레이닝이 존재해 트레이너 탈퇴 작업이 불가능합니다.");
     private final HttpStatus httpStatus;
     private final String message;
 }


### PR DESCRIPTION
## PR 유형
- 기능 추가

## 반영 브랜치
- main -> main

## 변경 사항

### 트레이너 탈퇴 기능 추가
- `탈퇴 회원` 으로 표시되도록 트레이너 이름 수정
- 이메일을 빈 문자열로 변경
- 트레이너의 현재 재직 중인 회사 주소와 위도 경도 `null `로 변경
- 트레이너 프로필 이미지를 **기본 이미지**로 변경
- 예약되거나 진행 중인 트레이닝이 있을 경우 탈퇴 보류 (`400` error 발생)
- 모집 중인 트레이닝이 있을 경우 탈퇴 보류 (`409` error 발생)

## 테스트 결과 

### 트레이너 회원 탈퇴

> PUT /users

**Request body**
- closureReasonType: 탈퇴 사유 (**INSUFFICIENT_FACILITIES(원하는 시설 부족), 
   UNSATISFACTORY_SERVICE(고객 응대에 대한 불만족), LOW_USAGE(낮은 사용 빈도), OTHER(기타)** 중 택 1)
- customReason: closureReasonType 이 "OTHER" 일 경우 값 전달. 회원이 직접 탈퇴 사유 입력.

<hr>

![트레이너 탈퇴](https://github.com/team-Fithub/fithub-backend/assets/106025529/6927a17c-e042-4731-9892-beaf9f440827)
- **예약 또는 진행 중인 트레이닝**이 있을 경우 탈퇴 보류 (**400 error** 발생)

![409](https://github.com/team-Fithub/fithub-backend/assets/106025529/5a9dddd9-5ef8-4a98-8d4f-09c95e5562ce)
- **모집 중인 트레이닝**이 있을 경우 탈퇴 보류 (**409 error** 발생)