### PR TITLE
update: 관심사 업데이트 dto 필드 수정

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/user/dto/InterestUpdateDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/dto/InterestUpdateDto.java
@@ -14,17 +14,11 @@ import java.util.List;
 public class InterestUpdateDto {
 
     @NotNull
-    @Schema(description = "관심사 삭제 여부")
-    private boolean interestsDeleted;
-
-    @Schema(description = "interestsDeleted = true 일 때만 사용. 삭제되지 않는 관심사. ex) PILATES, HEALTH, PT, CROSSFIT, YOGA")
-    private List<Category> unModifiedInterests;
+    @Schema(description = "관심사 수정 여부")
+    private boolean interestsUpdated;
 
     @NotNull
-    @Schema(description = "관심사 추가 여부")
-    private boolean interestsAdded;
-
-    @Schema(description = "추가된 관심사. ex) PILATES, HEALTH, PT, CROSSFIT, YOGA")
-    private List<Category> addedInterests;
+    @Schema(description = "관심사 리스트")
+    private List<Category> interests;
 
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/user/repository/UserInterestRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/user/repository/UserInterestRepository.java
@@ -2,13 +2,19 @@ package com.fithub.fithubbackend.domain.user.repository;
 
 import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.domain.user.domain.UserInterest;
+import com.fithub.fithubbackend.global.common.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface UserInterestRepository extends JpaRepository<UserInterest, Long> {
     List<UserInterest> findByUser(User user);
-
     List<UserInterest> findByUserId(Long userId);
     void deleteByUser(User user);
+    @Modifying
+    @Query("delete from UserInterest u where u.user = :user and u.interest in :interests")
+    void deleteAllByUserAndInterests(@Param("user") User user, @Param("interests")List<Category> interests);
 }


### PR DESCRIPTION
## PR 유형
- 기능 수정

## 반영 브랜치
- main -> main

## 변경 사항
- 관심사 업데이트 dto 수정
   - 변경 전 : 관심사 추가/삭제 여부, 관심사 추가/삭제된 리스트
   - 변경 후 :  **관심사 수정 여부**, **관심사 리스트**
- 삭제된 관심사를 일괄 delete 처리하기 위해 쿼리 개선
    - 기존 쿼리: 1건씩 데이터 delete
        `userInterestRepository.delete(originalInterest);` 
    - 수정 쿼리: @Query를 통해 쿼리를 직접 작성하여 데이터 일괄 delete
        ```
        @Modifying
        @Query("delete from UserInterest u where u.user = :user and u.interest in :interests")
        void deleteAllByUserAndInterests(@Param("user") User user, @Param("interests")List<Category> interests);
        ```
       ![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/70d87b16-d3a8-4ea0-b913-a32c4c93ca88)



## 참고 사이트
[https://velog.io/@isayaksh/JPA-%EB%8C%80%EB%9F%89%EC%9D%98-%EB%8D%B0%EC%9D%B4%ED%84%B0-%EC%9D%BC%EA%B4%84-DELETE-%EC%BF%BC%EB%A6%AC-%EA%B0%9C%EC%84%A0](url)

