### PR TITLE
feat: 채팅방 삭제 기능 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatRoomController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatRoomController.java
@@ -57,6 +57,13 @@ public class ChatRoomController {
         return ResponseEntity.ok(chatRoomService.hasChatRoom(user.getId(), receiverId));
     }
 
+
+    @GetMapping("/check/receiver/left")
+    public ResponseEntity<Boolean> isReceiverLeft(@AuthUser User user, @RequestParam Long roomId) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        return ResponseEntity.ok(chatRoomService.isReceiverLeft(user.getId(), roomId));
+    }
+
     @DeleteMapping
     public ResponseEntity<String> deleteUserChatRoom(@AuthUser User user, @RequestParam Long roomId) {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatRoomController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatRoomController.java
@@ -57,4 +57,10 @@ public class ChatRoomController {
         return ResponseEntity.ok(chatRoomService.hasChatRoom(user.getId(), receiverId));
     }
 
+    @DeleteMapping
+    public ResponseEntity<String> deleteUserChatRoom(@AuthUser User user, @RequestParam Long roomId) {
+        if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
+        chatRoomService.deleteChatRoom(user.getId(), roomId);
+        return ResponseEntity.ok().body("완료");
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatRoomController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatRoomController.java
@@ -57,13 +57,22 @@ public class ChatRoomController {
         return ResponseEntity.ok(chatRoomService.hasChatRoom(user.getId(), receiverId));
     }
 
-
+    @Operation(summary = "채팅방 목록 -> 채팅방 클릭 시, 상대방이 나갔는지 확인", responses = {
+            @ApiResponse(responseCode = "200", description = "확인 성공, false면 상대방이 있는 것(채팅 가능)"),
+    }, parameters = {
+            @Parameter(name = "roomId", description = "채팅방 id"),
+    })
     @GetMapping("/check/receiver/left")
     public ResponseEntity<Boolean> isReceiverLeft(@AuthUser User user, @RequestParam Long roomId) {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
         return ResponseEntity.ok(chatRoomService.isReceiverLeft(user.getId(), roomId));
     }
 
+    @Operation(summary = "채팅방 삭제(나가기)", responses = {
+            @ApiResponse(responseCode = "200", description = "삭제 또는 수정 성공"),
+    }, parameters = {
+            @Parameter(name = "roomId", description = "채팅방 id"),
+    })
     @DeleteMapping
     public ResponseEntity<String> deleteUserChatRoom(@AuthUser User user, @RequestParam Long roomId) {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatRoomController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatRoomController.java
@@ -58,14 +58,14 @@ public class ChatRoomController {
     }
 
     @Operation(summary = "채팅방 목록 -> 채팅방 클릭 시, 상대방이 나갔는지 확인", responses = {
-            @ApiResponse(responseCode = "200", description = "확인 성공, false면 상대방이 있는 것(채팅 가능)"),
+            @ApiResponse(responseCode = "200", description = "확인 성공, true면 상대방이 있는 것(채팅 가능)"),
     }, parameters = {
             @Parameter(name = "roomId", description = "채팅방 id"),
     })
-    @GetMapping("/check/receiver/left")
-    public ResponseEntity<Boolean> isReceiverLeft(@AuthUser User user, @RequestParam Long roomId) {
+    @GetMapping("/check/receiver/exist")
+    public ResponseEntity<Boolean> isReceiverExists(@AuthUser User user, @RequestParam Long roomId) {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
-        return ResponseEntity.ok(chatRoomService.isReceiverLeft(user.getId(), roomId));
+        return ResponseEntity.ok(chatRoomService.isReceiverExists(user.getId(), roomId));
     }
 
     @Operation(summary = "채팅방 삭제(나가기)", responses = {

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomService.java
@@ -18,5 +18,5 @@ public interface ChatRoomService {
 
     Long hasChatRoom(final Long userId, final Long receiverId);
 
-    Boolean isReceiverLeft(Long userId, Long roomId);
+    Boolean isReceiverExists(Long userId, Long roomId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomService.java
@@ -7,19 +7,14 @@ import java.util.List;
 
 public interface ChatRoomService {
 
-    /* ChatRoom 조회 */
-    public ChatRoomResponseDto findById(final Long id);
-
     /* ChatRoom 목록 조회 - 최신순 */
-    public List<ChatRoomResponseDto> findChatRoomDesc(User user);
+    List<ChatRoomResponseDto> findChatRoomDesc(User user);
 
     /* ChatRoom 생성 */
     Long save(final User user, final Long receiverId);
 
     /* ChatRoom 삭제 */
-    public void delete(final Long id);
+    void deleteChatRoom(Long userId, Long roomId);
 
-    public Long hasChatRoom(final Long userId, final Long receiverId);
-
-    public long findRoomIdByUserId(final long userId);
+    Long hasChatRoom(final Long userId, final Long receiverId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomService.java
@@ -17,4 +17,6 @@ public interface ChatRoomService {
     void deleteChatRoom(Long userId, Long roomId);
 
     Long hasChatRoom(final Long userId, final Long receiverId);
+
+    Boolean isReceiverLeft(Long userId, Long roomId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomServiceImpl.java
@@ -113,9 +113,9 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     }
 
     @Override
-    public Boolean isReceiverLeft(Long userId, Long roomId) {
+    public Boolean isReceiverExists(Long userId, Long roomId) {
         Chat receiverChat = chatRepository.findByChatPK_ChatRoomRoomIdAndChatPK_UserIdNot(roomId, userId).orElseThrow(
                 () -> new CustomException(ErrorCode.NOT_FOUND, "해당 채팅방의 다른 사용자를 찾을 수 없습니다."));
-        return receiverChat.isDeleted();
+        return !receiverChat.isDeleted();
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomServiceImpl.java
@@ -26,15 +26,9 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
     @Transactional
     @Override
-    public ChatRoomResponseDto findById(final Long id) {
-        return null;
-    }
-
-    @Transactional
-    @Override
     public List<ChatRoomResponseDto> findChatRoomDesc(User user) {
         // Chat 테이블: 현재 유저의 채팅방 id와 채팅방 이름 가져옴
-        List<Chat> chatList = this.chatRepository.findByChatPK_UserId(user.getId());
+        List<Chat> chatList = this.chatRepository.findByChatPK_UserIdAndDeletedFalse(user.getId());
 
         List<ChatRoomResponseDto> dtoList = chatList.stream()
                 .map(ChatRoomResponseDto::new)
@@ -78,19 +72,37 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     @Transactional
     @Override
     public void deleteChatRoom(Long userId, Long roomId) {
-        ChatRoom chatRoom = this.chatRoomRepository.findById(roomId).orElseThrow(
-                () -> new CustomException(ErrorCode.NOT_FOUND, "채팅룸이 존재하지 않음"));
-        List<Chat> chatList = chatRepository.findByChatPK_ChatRoom(chatRoom);
+        List<Chat> chatList = chatRepository.findByChatPK_ChatRoomRoomId(roomId);
+
+        boolean needToAllDelete = chatList.stream().anyMatch(Chat::isDeleted);
+        if (needToAllDelete) {
+            deleteAllAssociatedChat(chatList);
+        } else {
+            deleteOnlyUsersChat(chatList, userId);
+        }
+    }
+
+    private void deleteAllAssociatedChat(List<Chat> chatList) {
+        chatRepository.deleteAll(chatList);
+        chatRoomRepository.delete(chatList.get(0).getChatPK().getChatRoom());
+    }
+
+    private void deleteOnlyUsersChat(List<Chat> chatList, Long userId) {
+        Chat userChat = chatList.stream()
+                .filter(chat -> chat.getChatPK().getUser().getId().equals(userId))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "사용자의 채팅이 존재하지 않음"));
+        userChat.deleteChat();
     }
 
     @Override
     public Long hasChatRoom(Long userId, Long receiverId) {
-       List<Long> roomIdsOfUser = chatRepository.findByChatPK_UserId(userId)
+       List<Long> roomIdsOfUser = chatRepository.findByChatPK_UserIdAndDeletedFalse(userId)
                .stream()
                .map(Chat::getChatRoomId)
                .collect(Collectors.toList());
 
-        List<Long> roomIdsOfReceiver = chatRepository.findByChatPK_UserId(receiverId)
+        List<Long> roomIdsOfReceiver = chatRepository.findByChatPK_UserIdAndDeletedFalse(receiverId)
                 .stream()
                 .map(Chat::getChatRoomId)
                 .collect(Collectors.toList());
@@ -98,10 +110,5 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         roomIdsOfUser.retainAll(roomIdsOfReceiver);
 
         return roomIdsOfUser.isEmpty() ? null : roomIdsOfUser.get(0);
-    }
-
-    @Override
-    public long findRoomIdByUserId(long userId) {
-        return this.chatRepository.findChatByChatPK_UserId(userId).getChatPK().getChatRoom().getRoomId();
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatRoomServiceImpl.java
@@ -111,4 +111,11 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
         return roomIdsOfUser.isEmpty() ? null : roomIdsOfUser.get(0);
     }
+
+    @Override
+    public Boolean isReceiverLeft(Long userId, Long roomId) {
+        Chat receiverChat = chatRepository.findByChatPK_ChatRoomRoomIdAndChatPK_UserIdNot(roomId, userId).orElseThrow(
+                () -> new CustomException(ErrorCode.NOT_FOUND, "해당 채팅방의 다른 사용자를 찾을 수 없습니다."));
+        return receiverChat.isDeleted();
+    }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/domain/Chat.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/domain/Chat.java
@@ -1,6 +1,7 @@
 package com.fithub.fithubbackend.domain.chat.domain;
 
 import com.fithub.fithubbackend.domain.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -16,13 +17,21 @@ public class Chat {
 
     private String chatRoomName;
 
+    @Schema(description = "해당 채팅방에서 나갔는지, 안 나갔는지")
+    private boolean deleted;
+
     @Builder
     public Chat(ChatRoom chatRoom, String chatRoomName, User user) {
         this.chatPK = new ChatPK(chatRoom, user);
         this.chatRoomName = chatRoomName;
+        deleted = false;
     }
 
     public long getChatRoomId() {
         return this.chatPK.getChatRoom().getRoomId();
+    }
+
+    public void deleteChat() {
+        this.deleted = true;
     }
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/domain/ChatPK.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/domain/ChatPK.java
@@ -1,8 +1,10 @@
 package com.fithub.fithubbackend.domain.chat.domain;
 
 import com.fithub.fithubbackend.domain.user.domain.User;
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.persistence.*;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.*;
 
 import java.io.Serializable;

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/repository/ChatRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatRepository extends JpaRepository<Chat, Long> {
     List<Chat> findByChatPK_UserIdAndDeletedFalse(Long userId);
@@ -15,5 +16,7 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
     List<User> findUsersByRoomId(@Param("roomId") Long roomId);
 
     List<Chat> findByChatPK_ChatRoomRoomId(Long roomId);
+
+    Optional<Chat> findByChatPK_ChatRoomRoomIdAndChatPK_UserIdNot(Long roomId, Long userId);
 
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/repository/ChatRepository.java
@@ -1,7 +1,6 @@
 package com.fithub.fithubbackend.domain.chat.repository;
 
 import com.fithub.fithubbackend.domain.chat.domain.Chat;
-import com.fithub.fithubbackend.domain.chat.domain.ChatRoom;
 import com.fithub.fithubbackend.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,13 +9,11 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface ChatRepository extends JpaRepository<Chat, Long> {
-    List<Chat> findByChatPK_UserId(Long userId);
+    List<Chat> findByChatPK_UserIdAndDeletedFalse(Long userId);
 
     @Query("SELECT e.chatPK.user FROM Chat e WHERE e.chatPK.chatRoom.roomId = :roomId")
     List<User> findUsersByRoomId(@Param("roomId") Long roomId);
 
-    Chat findChatByChatPK_UserId(Long userId);
-
-    List<Chat> findByChatPK_ChatRoom(ChatRoom chatRoom);
+    List<Chat> findByChatPK_ChatRoomRoomId(Long roomId);
 
 }


### PR DESCRIPTION
## pr 유형
- 기능 추가

## 변경 사항
- 채팅방 나가기 (삭제) 기능 추가
1:1 채팅이므로 사용자 한 명이 나가면 다른 사용자는 그걸 알 수 있어야 됨 -> chat에 deleted 추가
deleted인 chat은 가져오지 않도록 수정해서 내가 그 채팅방을 나간 사용자면 chatRoomList에서 볼 수 없음

채팅방에서 모든 사용자가 나가야 채팅방 아예 삭제. 한 명의 사용자만 나갔으면 접근은 가능하도록