### PR TITLE
feat: 게시글 좋아요 및 댓글 알림 기능 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/UserPostLikesServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/UserPostLikesServiceImpl.java
@@ -10,6 +10,7 @@ import com.fithub.fithubbackend.global.exception.ErrorCode;
 import com.fithub.fithubbackend.global.notify.NotificationType;
 import com.fithub.fithubbackend.global.notify.dto.NotifyRequestDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -23,6 +24,7 @@ public class UserPostLikesServiceImpl implements UserPostLikesService {
 
     private final LikesRepository likesRepository;
     private final PostService postService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     @Transactional
@@ -36,7 +38,8 @@ public class UserPostLikesServiceImpl implements UserPostLikesService {
         post.addLikes(new Likes(user, post));
 
         if (user != post.getUser())
-            createLikesNotifyRequest(post, user);
+            eventPublisher.publishEvent(createLikesNotifyRequest(post, user));
+
     }
 
     private NotifyRequestDto createLikesNotifyRequest(Post post, User user) {

--- a/src/main/java/com/fithub/fithubbackend/domain/board/application/UserPostLikesServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/board/application/UserPostLikesServiceImpl.java
@@ -7,6 +7,8 @@ import com.fithub.fithubbackend.domain.board.repository.LikesRepository;
 import com.fithub.fithubbackend.domain.user.domain.User;
 import com.fithub.fithubbackend.global.exception.CustomException;
 import com.fithub.fithubbackend.global.exception.ErrorCode;
+import com.fithub.fithubbackend.global.notify.NotificationType;
+import com.fithub.fithubbackend.global.notify.dto.NotifyRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -22,7 +24,6 @@ public class UserPostLikesServiceImpl implements UserPostLikesService {
     private final LikesRepository likesRepository;
     private final PostService postService;
 
-    // TODO 게시글 좋아요 시, 게시글 작성자에게 알림 전송
     @Override
     @Transactional
     public void addLikes(User user, long postId) {
@@ -33,6 +34,18 @@ public class UserPostLikesServiceImpl implements UserPostLikesService {
             throw new CustomException(ErrorCode.DUPLICATE, "이미 좋아요한 게시글입니다.");
 
         post.addLikes(new Likes(user, post));
+
+        if (user != post.getUser())
+            createLikesNotifyRequest(post, user);
+    }
+
+    private NotifyRequestDto createLikesNotifyRequest(Post post, User user) {
+        return NotifyRequestDto.builder()
+                .receiver(post.getUser())
+                .content(user.getNickname() + "님이 회원님의 게시글을 좋아합니다.")
+                .urlId(post.getId())
+                .type(NotificationType.LIKE_POST)
+                .build();
     }
 
     @Override


### PR DESCRIPTION
## PR 유형
- 기능 추가

## 반영 브랜치
- main -> main

## 변경 사항

### 게시글 좋아요 알림
- 게시글 좋아요 시,  게시글 작성자에게 알림 전송 
  ![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/44af1d08-66cf-4b70-9330-768ba7e6e079)
- 자신의 게시글에 좋아요 누를 시, **알림 전송 X** 

<hr>

### 게시글 댓글 알림
- 게시글 댓글 남길 시, 게시글 작성자 또는 부모 댓글 작성자에게 알림 전송

NO | 게시글 작성자 | 댓글 작성자 | 부모 댓글 작성자 | 결과 
-- | -- | -- | -- | -- | 
1 | A | A | A | 알림 전송 X 
2 | A | A | B | 부모 댓글 작성자에게 알림 전송
3 | B | A | A | 게시글 작성자에게 알림 전송
4 | B | A | B | 게시글 작성자에게 알림 전송
5 | B | A | C | 게시글 작성자, 부모 댓글 작성자에게 알림 전송
6 | B | A | null |  게시글 작성자에게 알림 전송

- 게시글 작성자에게 알림 전송 시 `comment.getUser().getNickname()님이 회원님의 게시글에 댓글을 남겼습니다.` 문구 전송
 ![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/7b4cb658-cc19-4542-970d-a6ddbe8930f3)

- 부모 댓글 작성자에게 알림 전송 시 `comment.getUser().getNickname()님이 회원님의 댓글에 답글을 남겼습니다.` 문구 전송
 ![image](https://github.com/team-Fithub/fithub-backend/assets/106025529/c63e6ad7-0876-46f5-a58e-7f7f88d6019b)


