### PR TITLE
update: 채팅 메세지 ws 발행 시, 데이터 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatMessageController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/api/ChatMessageController.java
@@ -37,8 +37,10 @@ public class ChatMessageController {
     public void sendMessage(@Header("Authorization") String accessToken, ChatMessageRequestDto messageRequestDto) {
         Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
         UserAdapter userAdapter = (UserAdapter) authentication.getPrincipal();
-        chatMessageService.save(messageRequestDto, userAdapter.getUser());
-        simpMessagingTemplate.convertAndSend("/topic/chatroom/" + messageRequestDto.getRoomId(), messageRequestDto.getMessage());
+        ChatMessageResponseDto responseDto = chatMessageService.save(messageRequestDto, userAdapter.getUser());
+
+        // messageRequestDto가 아닌 다른 값으로 응답해야함...
+        simpMessagingTemplate.convertAndSend("/topic/chatroom/" + messageRequestDto.getRoomId(), responseDto);
     }
 
     @Operation(summary = "채팅 메세지 조회", responses = {

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatMessageService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatMessageService.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public interface ChatMessageService {
 
-    Long save(final ChatMessageRequestDto requestDto, final User user);
+    ChatMessageResponseDto save(final ChatMessageRequestDto requestDto, final User user);
 
     void delete(final Long chatMessageId);
 

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatMessageServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatMessageServiceImpl.java
@@ -30,7 +30,7 @@ public class ChatMessageServiceImpl implements ChatMessageService{
 
     @Transactional
     @Override
-    public Long save(ChatMessageRequestDto requestDto, User sender) {
+    public ChatMessageResponseDto save(ChatMessageRequestDto requestDto, User sender) {
         ChatMessage message = ChatMessage.builder()
                     .chatRoom(chatRoomRepository.findByRoomId(requestDto.getRoomId()))
                     .message(requestDto.getMessage())
@@ -45,7 +45,7 @@ public class ChatMessageServiceImpl implements ChatMessageService{
         String receiverEmail = users.get(0).getEmail();
         simpMessagingTemplate.convertAndSend("/topic/alarm/" + receiverEmail, "새로운 채팅!");
 
-        return message.getMessageId();
+        return new ChatMessageResponseDto(message, sender.getId());
     }
 
     @Transactional


### PR DESCRIPTION
### PR 타입
- 기능 수정

### 반영 브랜치
main -> main

### 변경 사항
ws으로 채팅 전송 시 발행되는 채팅 응답 데이터 추가 (chatMessageResponseDto 리턴)

### 테스트 결과
![image](https://github.com/team-Fithub/fithub-backend/assets/81075657/c1d8228a-f78b-4f62-a0ff-89d2c80944d3)
