### PR TITLE
update: 채팅 메세지 ws 발행 시, 발신자 이메일 데이터 추가

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatMessageServiceImpl.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/application/ChatMessageServiceImpl.java
@@ -45,7 +45,11 @@ public class ChatMessageServiceImpl implements ChatMessageService{
         String receiverEmail = users.get(0).getEmail();
         simpMessagingTemplate.convertAndSend("/topic/alarm/" + receiverEmail, "새로운 채팅!");
 
-        return new ChatMessageResponseDto(message, sender.getId());
+        // ws 발행 위한 발신자 email 데이터 추가
+        ChatMessageResponseDto responseDto = new ChatMessageResponseDto(message, sender.getId());
+        responseDto.setSenderEmail(sender.getEmail());
+
+        return responseDto;
     }
 
     @Transactional

--- a/src/main/java/com/fithub/fithubbackend/domain/chat/dto/ChatMessageResponseDto.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/chat/dto/ChatMessageResponseDto.java
@@ -5,9 +5,11 @@ import com.fithub.fithubbackend.domain.chat.domain.ChatMessage;
 import com.fithub.fithubbackend.global.domain.Document;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 @Getter
+@Setter
 public class ChatMessageResponseDto {
 
     @Schema(description = "메세지 id")
@@ -18,6 +20,9 @@ public class ChatMessageResponseDto {
 
     @Schema(description = "발신자 구분")
     private boolean isMe;
+
+    @Schema(description = "발신자 이메일")
+    private String senderEmail;
 
     @Schema(description = "발신자 닉네임")
     private String senderNickname;


### PR DESCRIPTION
### PR 타입
- 기능 수정

### 반영 브랜치
main -> main

### 변경 사항
ws으로 채팅 전송 시 발행되는 채팅 응답 데이터 추가 (chatMessageResponseDto 리턴 + **email 데이터 추가**)

### 테스트 결과
![image](https://github.com/team-Fithub/fithub-backend/assets/81075657/77434728-fa1c-4643-8d86-84ca7f7182aa)

