### PR TITLE
fix: 예약 멀티스레드로 접근 시, 제대로 예약일과 트레이닝 예약 가능 여부가 변경되지 않는거 수정

### DIFF
--- a/src/main/java/com/fithub/fithubbackend/domain/Training/api/PaymentController.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/api/PaymentController.java
@@ -42,7 +42,10 @@ public class PaymentController {
     @PostMapping("/order")
     public ResponseEntity<Long> saveOrder(@RequestBody @Valid ReserveReqDto dto, @AuthUser User user) {
         if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
-        return ResponseEntity.ok(paymentService.saveOrder(dto, user));
+        Long orderId = paymentService.saveOrder(dto, user);
+        paymentService.updateAvailableDate(dto.getReservationDateId());
+        paymentService.updateTrainingStatus(dto.getTrainingId());
+        return ResponseEntity.ok(orderId);
     }
 
     @Operation(summary = "결제 금액 검증 api", description = "결제가 진행된 후에 결제한 금액과 트레이닝에 등록된 금액이 다른지 검증", responses = {

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/application/PaymentService.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/application/PaymentService.java
@@ -10,6 +10,8 @@ import java.io.IOException;
 
 public interface PaymentService {
     Long saveOrder(ReserveReqDto dto, User user);
+    void updateAvailableDate(Long availableDateId);
+    void updateTrainingStatus(Long trainingId);
 
     Long validate(PaymentReqDto dto) throws IamportResponseException, IOException;
 

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/AvailableDateRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/AvailableDateRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 public interface AvailableDateRepository extends JpaRepository<AvailableDate, Long> {
     Optional<AvailableDate> findByTrainingIdAndDate(Long trainingId, LocalDate date);
 
-    boolean existsByEnabledTrueAndTrainingIdAndIdNot(Long trainingId, Long id);
+    boolean existsByEnabledTrueAndTrainingId(Long trainingId);
 }

--- a/src/main/java/com/fithub/fithubbackend/domain/Training/repository/AvailableTimeRepository.java
+++ b/src/main/java/com/fithub/fithubbackend/domain/Training/repository/AvailableTimeRepository.java
@@ -1,5 +1,6 @@
 package com.fithub.fithubbackend.domain.Training.repository;
 
+import com.fithub.fithubbackend.domain.Training.domain.AvailableDate;
 import com.fithub.fithubbackend.domain.Training.domain.AvailableTime;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.QueryHint;
@@ -9,7 +10,6 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.QueryHints;
 
 import java.time.LocalTime;
-import java.util.List;
 import java.util.Optional;
 
 public interface AvailableTimeRepository extends JpaRepository<AvailableTime, Long> {
@@ -20,7 +20,6 @@ public interface AvailableTimeRepository extends JpaRepository<AvailableTime, Lo
     @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000")})
     Optional<AvailableTime> findById(@NotNull Long id);
 
-    boolean existsByEnabledTrueAndAvailableDateIdAndIdNot(Long availableDateId, Long id);
-    boolean existsByEnabledTrueAndAvailableDateId(Long availableDateId);
+    boolean existsByEnabledTrueAndAvailableDate(AvailableDate date);
     Optional<AvailableTime> findByEnabledTrueAndAvailableDateIdAndTime(Long availableDateId, LocalTime time);
 }

--- a/src/main/java/com/fithub/fithubbackend/global/component/Scheduler.java
+++ b/src/main/java/com/fithub/fithubbackend/global/component/Scheduler.java
@@ -70,7 +70,7 @@ public class Scheduler {
     }
 
     private void closeDateIfTimeAllClosed(AvailableDate date) {
-        if (!availableTimeRepository.existsByEnabledTrueAndAvailableDateId(date.getId())) {
+        if (!availableTimeRepository.existsByEnabledTrueAndAvailableDate(date)) {
             date.closeDate();
         }
     }


### PR DESCRIPTION
## pr 유형
- 기능 수정

## 변경사항
#### 문제
- 18일에 12시, 13시가 있고 순차적으로 12시 예약, 13시를 예약한다면 정상적으로 18일이 예약 불가능한 날짜가 됨
- 그런데 동시에 접근해서 12시, 13시를 예약한다면 18일의 enabled가 false로 바뀌지 않음

트랜잭션 두 개에서 수정된 각 값에 대한 수정은 이루어짐
[pool-3-thread-2] c.f.f.d.T.a.PaymentServiceImpl           : [closeReservationDateTime - AvailableTime 96] - 95 enabled: true
[pool-3-thread-2] c.f.f.d.T.a.PaymentServiceImpl           : [closeReservationDateTime - AvailableTime 96] - 96 enabled: false
[pool-3-thread-3] c.f.f.d.T.a.PaymentServiceImpl           : [closeReservationDateTime - AvailableTime 95] - 95 enabled: false
[pool-3-thread-3] c.f.f.d.T.a.PaymentServiceImpl           : [closeReservationDateTime - AvailableTime 95] - 96 enabled: true

#### 원인
다른 트랜잭션에서 진행된 수정이어서 읽지 않는 것


#### 해결
트랜잭션 격리 수준을 낮추는 것보다는 예약일 수정과 트레이닝 예약 가능 여부 수정을 새로운 트랜잭션에서 시작하는 게 더 나을 것 같다고 생각.

``` java
@PostMapping("/order")
  public ResponseEntity<Long> saveOrder(@RequestBody @Valid ReserveReqDto dto, @AuthUser User user) {
      if(user == null) throw new CustomException(ErrorCode.AUTHENTICATION_ERROR, "로그인한 사용자만 가능합니다.");
      Long orderId = paymentService.saveOrder(dto, user);
      paymentService.updateAvailableDate(dto.getReservationDateId());
      paymentService.updateTrainingStatus(dto.getTrainingId());
      return ResponseEntity.ok(orderId);
  }
```
위와 같이 원래는 saveOrder에서 한번에 진행하던 것들을 컨트롤러에서 새롭게 메서드를 불러서 트랜잭션 새로 시작하도록 변경

## 테스트
1일, 2일 각각 12시,13시가 있음
한 명은 1일 12시
두 명은 1일 13시
한 명은 2일 12시
동시 예약

``` java
@Test
@Transactional
void saveOrder() throws InterruptedException {
    log.info("saveOrder 시작");
    ReserveReqDto dto = ReserveReqDto.builder()
            .trainingId(21L)
            .reservationDateId(57L)
            .reservationTimeId(95L)
            .build();

    ReserveReqDto dto2 = ReserveReqDto.builder()
            .trainingId(21L)
            .reservationDateId(57L)
            .reservationTimeId(96L)
            .build();

    ReserveReqDto dto3 = ReserveReqDto.builder()
            .trainingId(21L)
            .reservationDateId(58L)
            .reservationTimeId(97L)
            .build();

    User trainer = userRepository.findById(2L).get();
    User user = userRepository.findById(3L).get();
    User trainer2 = userRepository.findById(4L).get();
    User admin = userRepository.findById(1L).get();
    ExecutorService service = Executors.newFixedThreadPool(4);
    CountDownLatch latch = new CountDownLatch(4);

    Assertions.assertThatThrownBy(() -> {
        service.execute(() -> {
            paymentController.saveOrder(dto, user);
            latch.countDown();
        });

        service.execute(() -> {
            paymentController.saveOrder(dto2, trainer);
            latch.countDown();
        });

        service.execute(() -> {
            paymentController.saveOrder(dto2, trainer2);
            latch.countDown();
        });

        service.execute(() -> {
            paymentController.saveOrder(dto3, admin);
            latch.countDown();
        });

        latch.await();
    }).isInstanceOf(CustomException.class);
}
```

update
        available_date 
    set
        date=?,
        deleted=?,
        enabled=?,
        training_id=? 
    where
        id=?

날짜가 제대로 수정
1일 13시 예약을 두 명이서 해서 한 명은 예약 불가능 에러 확인
- Exception in thread "pool-3-thread-2" com.fithub.fithubbackend.global.exception.CustomException: 해당 시간은 이미 예약되었습니다.
